### PR TITLE
Fix typo in "python-driver: add support for in_memory table attribute"

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -2378,7 +2378,7 @@ class SchemaParserV3(SchemaParserV22):
         ((cf_success, cf_result), (col_success, col_result),
          (indexes_sucess, indexes_result), (triggers_success, triggers_result),
          (view_success, view_result),
-         (scylla_sucess, scylla_result)) = (
+         (scylla_success, scylla_result)) = (
              self.connection.wait_for_responses(
                  cf_query, col_query, indexes_query, triggers_query,
                  view_query, scylla_query, timeout=self.timeout, fail_on_error=False)


### PR DESCRIPTION
there was a samll typo in a37223d194c704fac83c3debc52c03ddbb72dea2
"python-driver: add support for in_memory table attribute"
that was failing metadata refreshes