### PR TITLE
Added sphinx_scylladb_theme

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+name: "CI Docs"
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  release:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Setup dependencies
+      run: | 
+        sudo apt-get install libev4 libev-dev
+        sudo apt-get install build-essential python-dev
+        cd docs
+        ./_utils/setup.sh
+    - name: Build docs
+      run: |
+        cd docs
+        make dirhtml
+    - name: Deploy
+      run : ./docs/_utils/deploy.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+sphinx==1.8.0
+sphinx_scylladb_theme
+sphinx-autobuild==0.7.1

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,3 +2,5 @@
 sphinx==1.8.0
 sphinx_scylladb_theme
 sphinx-autobuild==0.7.1
+gevent>=1.0
+eventlet

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,7 @@ PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest preview
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -128,3 +128,10 @@ doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+preview:
+	./_utils/setup.sh
+	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+	./_utils/preview.sh
+

--- a/docs/_utils/deploy.sh
+++ b/docs/_utils/deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" --branch gh-pages --single-branch gh-pages
+cp -r docs/_build/dirhtml/* gh-pages/
+cd gh-pages
+git config --local user.email "action@scylladb.com"
+git config --local user.name "GitHub Action"
+git add .
+git commit -m "Publish docs" || true
+git push origin gh-pages --force

--- a/docs/_utils/preview
+++ b/docs/_utils/preview
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+python3 _utils/preview.py

--- a/docs/_utils/preview.py
+++ b/docs/_utils/preview.py
@@ -1,0 +1,5 @@
+from livereload import Server, shell
+server = Server()
+server.watch('*.rst', shell('make dirhtml'))
+server.watch('*.md', shell('make dirhtml'))
+server.serve(host='localhost', root='_build/dirhtml')

--- a/docs/_utils/preview.sh
+++ b/docs/_utils/preview.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+python3 _utils/preview.py

--- a/docs/_utils/setup.sh
+++ b/docs/_utils/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+python -m pip install --upgrade pip
+pip install -r docs-requirements.txt
+cd ..
+CASS_DRIVER_NO_CYTHON=1 python setup.py develop
+CASS_DRIVER_NO_CYTHON=1 python setup.py build_ext --inplace --force

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,10 +101,6 @@ html_theme = 'sphinx_scylladb_theme'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-#
 html_theme_options = {
     'header_links': [
     ('Scylla Cloud', 'https://docs.scylladb.com/scylla-cloud/'),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ import cassandra
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx_scylladb_theme']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -96,15 +96,25 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'custom'
+html_theme = 'sphinx_scylladb_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# Theme options are theme-specific and customize the look and feel of a theme
+# further.  For a list of options available for each theme, see the
+# documentation.
+#
+html_theme_options = {
+    'header_links': [
+    ('Scylla Cloud', 'https://docs.scylladb.com/scylla-cloud/'),
+    ('Scylla University', 'https://university.scylladb.com/'),
+    ('ScyllaDB Home', 'https://www.scylladb.com/')],
+    'github_issues_repository': 'scylladb/python-driver'
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = ['./themes']
+# html_theme_path = ['./themes']
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -125,7 +135,7 @@ html_theme_path = ['./themes']
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+# html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -136,14 +146,7 @@ html_static_path = []
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-	'**': [
-	    'about.html',
-	    'navigation.html',
-	    'relations.html',
-	    'searchbox.html'
-	]
-}
+html_sidebars = {'**': ['side-nav.html']}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,4 +1,4 @@
--r requirements.txt
+-r ../requirements.txt
 sphinx==1.8.0
 sphinx_scylladb_theme
 sphinx-autobuild==0.7.1


### PR DESCRIPTION
Added `sphinx_scylladb_theme` with minimum changes.

Instructions to preview the docs:

1. Create a virtualenv.
``pip install --user virtualenv``
``python3 -m virtualenv venv``
``source venv/bin/activate``
2. Build and preview docs
``cd docs``
``make preview``

Fixed on 31/05 : ~~Note: The project does not come with a ``make preview`` command (livereload).~~ 