### PR TITLE
Add support script to help merge new tags from upstreams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - CIBW_BEFORE_TEST="pip install -r {project}/test-requirements.txt pytest"
     - CIBW_BEFORE_BUILD_LINUX="rm -rf ~/.pyxbld && yum install -y redhat-rpm-config gcc libffi-devel python-devel libev libev-devel openssl openssl-devel"
     - CASS_DRIVER_BUILD_CONCURRENCY=2
+    - TWINE_USERNAME=__token__
 
 jobs:
   allow_failures:
@@ -43,7 +44,7 @@ jobs:
       env:
         - CIBW_BUILD="pp*"
         - CIBW_TEST_COMMAND_LINUX="" # TODO: enable tests
-      if: type != pull_request AND (branch = master OR tag IS present)
+      if: type != pull_request AND (branch = master OR (tag =~ /^.*-scylla$/))
 
     # perform a linux S390X build
     - name: IBM-Z (s390x)
@@ -52,7 +53,7 @@ jobs:
       env:
         - CIBW_TEST_COMMAND_LINUX="" # TODO: enable tests
         - CIBW_BUILD="cp37* cp38*"
-      if: type != pull_request AND (branch = master OR tag IS present)
+      if: type != pull_request AND (branch = master OR (tag =~ /^.*-scylla$/))
 
     # perform a linux arm64 build
     - name: ARM64 (aarch64)
@@ -61,7 +62,7 @@ jobs:
       env:
         - CIBW_TEST_COMMAND_LINUX="" # TODO: enable tests
         - CIBW_BUILD="cp37* cp38*"
-      if: type != pull_request AND (branch = master OR tag IS present)
+      if: type != pull_request AND (branch = master OR (tag =~ /^.*-scylla$/))
 
     # perform a linux PPC64LE build
     - name: PowerPC (ppc64le)
@@ -70,7 +71,7 @@ jobs:
       env:
         - CIBW_TEST_COMMAND_LINUX="" # TODO: enable tests
         - CIBW_BUILD="cp37* cp38*"
-      if: type != pull_request AND (branch = master OR tag IS present)
+      if: type != pull_request AND (branch = master OR (tag =~ /^.*-scylla$/))
 
     # and a mac build
     - name: CPython MacOS
@@ -91,7 +92,7 @@ jobs:
       before_install:
         - brew install libev
       language: shell
-      if: type != pull_request AND (branch = master OR tag IS present)
+      if: type != pull_request AND (branch = master OR (tag =~ /^.*-scylla$/))
 
     # and a windows build
     - name: CPython Windows 64
@@ -113,7 +114,7 @@ jobs:
         - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
         # make sure it's on PATH as 'python3'
         - ln -s /c/Python38/python.exe /c/Python38/python3.exe
-      if: type != pull_request AND (branch = master OR tag IS present)
+      if: type != pull_request AND (branch = master OR (tag =~ /^.*-scylla$/))
 
     - name: PyPy Windows
       os: windows
@@ -128,7 +129,7 @@ jobs:
         - ln -s /c/Python38/python.exe /c/Python38/python3.exe
         - choco install openssl
         - cmd.exe //c "RefreshEnv.cmd"
-      if: type != pull_request AND (branch = master OR tag IS present)
+      if: type != pull_request AND (branch = master OR (tag =~ /^.*-scylla$/))
 
 install:
   - python3 -m pip install cibuildwheel==1.3.0
@@ -138,10 +139,10 @@ script:
   - python3 -m cibuildwheel --output-dir wheelhouse
 
 
-after_success:
-  # if the release was tagged, upload them to PyPI
+after_script:
+  # if the release was tagged with scylla tags, upload them to PyPI
   - |
-    if [[ $TRAVIS_TAG ]]; then
+    if [[ $TRAVIS_TAG =~ .*-scylla ]]; then
       python3 -m pip install twine
       python3 -m twine upload wheelhouse/*.whl
     fi

--- a/scripts/merge_next_tag_from_upstream.sh
+++ b/scripts/merge_next_tag_from_upstream.sh
@@ -1,0 +1,63 @@
+#! /bin/bash -e
+
+# This script is helper for mergeing the next tag form upstream
+# while re-tagging it so our Travis setup would pick it including our merge code
+# otherwise if we just push the tags out of the upstream, they won't include the code from this fork
+
+# this script assumes remotes for scylladb/python-driver and for datastax/python-driver are configured
+
+upstream_repo_url=https://github.com/datastax/python-driver
+
+upstream_repo=$(git remote -v | grep ${upstream_repo_url} | awk '{print $1}' | head -n1)
+scylla_repo=$(git remote -v | grep scylladb/python-driver | awk '{print $1}' | head -n1)
+
+git fetch ${upstream_repo}
+git fetch ${scylla_repo}
+
+scylla_tags=$(git ls-remote  --refs --tags --sort=v:refname ${scylla_repo} | awk '{print $2}')
+upsteam_tags=$(git ls-remote  --refs --tags --sort=v:refname ${upstream_repo} | awk '{print $2}')
+
+first_new_tag=$(diff -u <(echo "${scylla_tags}") <(echo "${upsteam_tags}") | grep '^\+' | grep -v '++\s' | sed -E 's/^\+//' | head -n1)
+
+
+header="Merge branch '${first_new_tag}' of ${upstream_repo_url}"
+commit_count=$(git log HEAD..${first_new_tag}  --oneline --pretty=tformat:'%h' | wc -l)
+desc="* '${first_new_tag}' of {upstream_repo_url}: (${commit_count} commits)"
+top20_commits=$(git log HEAD..${first_new_tag}  --oneline --pretty=tformat:'  %h: %s' | head -n20)
+
+echo "
+Preview of the merge:
+
+$header
+
+$desc
+$top20_commits
+  ..."
+
+
+read -p "Continue with merge (y/n)?" choice
+case "$choice" in
+  y|Y )
+      echo "Merging..."
+      git pull https://github.com/datastax/python-driver ${first_new_tag} --log=20 --no-ff
+
+      new_scyla_tag=$(echo ${first_new_tag} | sed 's|refs/tags/||')-scylla
+
+      tag_msg="
+   when done merging, use those to push a new tag:
+
+      git merge --continue
+      git tag ${new_scyla_tag}
+      git push --tags ${scylla_repo} master
+
+   re-triggering a build of a tag in Travis:
+
+      git push --delete ${scylla_repo} ${new_scyla_tag}
+      # then push it again
+      git push --tags ${scylla_repo} master
+
+      "
+      echo "$tag_msg" ;;
+
+  * ) echo "Aborted...";;
+esac


### PR DESCRIPTION
Since all tags we are merging in won't include our own code
we need a system in place to make sure we re-tag each formal version
from now on

Each tag like `3.21.0` would be tagged after the merge with `3.21.0-scylla`
and our Travis setup would only build `*-scylla` tags

Travis is limited not more then 3 tags in a push,
otherwise it won't trigger a build, so we'll do those merges/pushes
one tag at a time