### PR TITLE
Remove DSE pages, add Scylla Cloud Page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ autoclass_content = 'both'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'cloud.rst', 'core_graph.rst', 'geo_types.rst', 'graph.rst', 'graph_fluent.rst']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,9 @@ Contents
 :doc:`dates_and_times`
     Some discussion on the driver's approach to working with timestamp, date, time types
 
+:doc:`scylla_cloud`	
+    Connect to Scylla Cloud
+
 :doc:`CHANGELOG`
     Log of changes to the driver, organized by version.
 
@@ -75,6 +78,7 @@ Contents
    user_defined_types
    object_mapper
    dates_and_times
+   scylla_cloud
    faq
 
 Getting Help

--- a/docs/scylla_cloud.rst
+++ b/docs/scylla_cloud.rst
@@ -1,0 +1,5 @@
+Scylla Cloud
+------------
+
+To connect to a `Scylla Cloud <https://www.scylladb.com/product/scylla-cloud/>`_ cluster, go to the Cluster Connect page, Python example.
+For best performance, make sure to use the Scylla Driver.


### PR DESCRIPTION
The PR 
- exclude DSE only pages
- Create a new page for Scylla Cloud

It does not fix all the links to the excluded pages.