### PR TITLE
shard aware: Move ShardInfo class into a Cython

### DIFF
--- a/cassandra/c_shard_info.pyx
+++ b/cassandra/c_shard_info.pyx
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cimport libc.stdlib
 from libc.stdint cimport INT64_MIN, UINT32_MAX, uint64_t, int64_t
 
 cdef extern from *:
@@ -42,7 +41,7 @@ cdef class ShardingInfo():
         sharding_ignore_msb = message.options.get('SCYLLA_SHARDING_IGNORE_MSB', [''])[0] or None
 
         if not (shard_id or shards_count or partitioner == "org.apache.cassandra.dht.Murmur3Partitioner" or
-            sharding_algorithm ==  "biased-token-round-robin" or sharding_ignore_msb):
+            sharding_algorithm == "biased-token-round-robin" or sharding_ignore_msb):
             return 0, None
 
         return int(shard_id), ShardingInfo(shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb)
@@ -53,12 +52,3 @@ cdef class ShardingInfo():
         biased_token <<= self.sharding_ignore_msb;
         cdef int shardId = (<__uint128_t>biased_token * self.shards_count) >> 64;
         return shardId
-
-        # cdef long token = token_input + INT64_MIN
-        # token = token << self.sharding_ignore_msb
-        # cdef long tokLo = token & UINT32_MAX
-        # cdef long tokHi = (token >> 32) & UINT32_MAX
-        # cdef long mul1 = tokLo * self.shards_count
-        # cdef long mul2 = tokHi * self.shards_count
-        # cdef long sum = (mul1 >> 32) + mul2
-        # return libc.stdlib.abs(<int>(sum >> 32))

--- a/cassandra/c_shard_info.pyx
+++ b/cassandra/c_shard_info.pyx
@@ -1,0 +1,64 @@
+# Copyright 2020 ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cimport libc.stdlib
+from libc.stdint cimport INT64_MIN, UINT32_MAX, uint64_t, int64_t
+
+cdef extern from *:
+    ctypedef unsigned int __uint128_t
+
+cdef class ShardingInfo():
+    cdef readonly int shards_count
+    cdef readonly str partitioner
+    cdef readonly str sharding_algorithm
+    cdef readonly int sharding_ignore_msb
+
+    cdef object __weakref__
+
+    def __init__(self, shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb):
+        self.shards_count = int(shards_count)
+        self.partitioner = partitioner
+        self.sharding_algorithm = sharding_algorithm
+        self.sharding_ignore_msb = int(sharding_ignore_msb)
+
+
+    @staticmethod
+    def parse_sharding_info(message):
+        shard_id = message.options.get('SCYLLA_SHARD', [''])[0] or None
+        shards_count = message.options.get('SCYLLA_NR_SHARDS', [''])[0] or None
+        partitioner = message.options.get('SCYLLA_PARTITIONER', [''])[0] or None
+        sharding_algorithm = message.options.get('SCYLLA_SHARDING_ALGORITHM', [''])[0] or None
+        sharding_ignore_msb = message.options.get('SCYLLA_SHARDING_IGNORE_MSB', [''])[0] or None
+
+        if not (shard_id or shards_count or partitioner == "org.apache.cassandra.dht.Murmur3Partitioner" or
+            sharding_algorithm ==  "biased-token-round-robin" or sharding_ignore_msb):
+            return 0, None
+
+        return int(shard_id), ShardingInfo(shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb)
+
+    
+    def shard_id_from_token(self, int64_t token_input):
+        cdef uint64_t biased_token = token_input + (<uint64_t>1 << 63);
+        biased_token <<= self.sharding_ignore_msb;
+        cdef int shardId = (<__uint128_t>biased_token * self.shards_count) >> 64;
+        return shardId
+
+        # cdef long token = token_input + INT64_MIN
+        # token = token << self.sharding_ignore_msb
+        # cdef long tokLo = token & UINT32_MAX
+        # cdef long tokHi = (token >> 32) & UINT32_MAX
+        # cdef long mul1 = tokLo * self.shards_count
+        # cdef long mul2 = tokHi * self.shards_count
+        # cdef long sum = (mul1 >> 32) + mul2
+        # return libc.stdlib.abs(<int>(sum >> 32))

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -43,8 +43,7 @@ from cassandra.protocol import (ReadyMessage, AuthenticateMessage, OptionsMessag
                                 AuthSuccessMessage, ProtocolException,
                                 RegisterMessage, ReviseRequestMessage)
 from cassandra.util import OrderedDict
-from cassandra.murmur3 import INT64_MIN
-
+from cassandra.shard_info import ShardingInfo
 
 log = logging.getLogger(__name__)
 
@@ -599,44 +598,6 @@ if six.PY3:
         return i
 else:
     int_from_buf_item = ord
-
-class ShardingInfo(object):
-
-    def __init__(self, shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb):
-        self.shards_count = int(shards_count)
-        self.partitioner = partitioner
-        self.sharding_algorithm = sharding_algorithm
-        self.sharding_ignore_msb = int(sharding_ignore_msb)
-
-    @staticmethod
-    def parse_sharding_info(message):
-        shard_id = message.options.get('SCYLLA_SHARD', [''])[0] or None
-        shards_count = message.options.get('SCYLLA_NR_SHARDS', [''])[0] or None
-        partitioner = message.options.get('SCYLLA_PARTITIONER', [''])[0] or None
-        sharding_algorithm = message.options.get('SCYLLA_SHARDING_ALGORITHM', [''])[0] or None
-        sharding_ignore_msb = message.options.get('SCYLLA_SHARDING_IGNORE_MSB', [''])[0] or None
-        log.debug("Parsing sharding info from message options %s", message.options)
-
-        if not (shard_id or shards_count or partitioner == "org.apache.cassandra.dht.Murmur3Partitioner" or
-            sharding_algorithm ==  "biased-token-round-robin" or sharding_ignore_msb):
-            return 0, None
-
-        return int(shard_id), ShardingInfo(shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb)
-
-    def shard_id_from_token(self, t):
-        """
-        Convert a Murmur3 token to shard_id based on the number of shards on the host
-        """
-        token = t.value
-        token += INT64_MIN
-        token <<= self.sharding_ignore_msb
-        tokLo = token & 0xffffffff
-        tokHi = (token >> 32) & 0xffffffff
-        mul1 = tokLo * self.shards_count
-        mul2 = tokHi * self.shards_count
-        _sum = (mul1 >> 32) + mul2
-        output = _sum >> 32
-        return output
 
 
 class Connection(object):

--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -389,7 +389,7 @@ class HostConnection(object):
         shard_id = None
         if self.host.sharding_info and routing_key:
             t = self._session.cluster.metadata.token_map.token_class.from_key(routing_key)
-            shard_id = self.host.sharding_info.shard_id_from_token(t)
+            shard_id = self.host.sharding_info.shard_id_from_token(t.value)
 
         conn = self._connections.get(shard_id)
 

--- a/cassandra/shard_info.py
+++ b/cassandra/shard_info.py
@@ -1,0 +1,62 @@
+# Copyright 2020 ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from cassandra.murmur3 import INT64_MIN
+
+log = logging.getLogger(__name__)
+
+
+class _ShardingInfo(object):
+
+    def __init__(self, shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb):
+        self.shards_count = int(shards_count)
+        self.partitioner = partitioner
+        self.sharding_algorithm = sharding_algorithm
+        self.sharding_ignore_msb = int(sharding_ignore_msb)
+
+    @staticmethod
+    def parse_sharding_info(message):
+        shard_id = message.options.get('SCYLLA_SHARD', [''])[0] or None
+        shards_count = message.options.get('SCYLLA_NR_SHARDS', [''])[0] or None
+        partitioner = message.options.get('SCYLLA_PARTITIONER', [''])[0] or None
+        sharding_algorithm = message.options.get('SCYLLA_SHARDING_ALGORITHM', [''])[0] or None
+        sharding_ignore_msb = message.options.get('SCYLLA_SHARDING_IGNORE_MSB', [''])[0] or None
+        log.debug("Parsing sharding info from message options %s", message.options)
+
+        if not (shard_id or shards_count or partitioner == "org.apache.cassandra.dht.Murmur3Partitioner" or
+            sharding_algorithm == "biased-token-round-robin" or sharding_ignore_msb):
+            return 0, None
+
+        return int(shard_id), _ShardingInfo(shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb)
+
+    def shard_id_from_token(self, token):
+        """
+        Convert a Murmur3 token to shard_id based on the number of shards on the host
+        """
+        token += INT64_MIN
+        token <<= self.sharding_ignore_msb
+        tokLo = token & 0xffffffff
+        tokHi = (token >> 32) & 0xffffffff
+        mul1 = tokLo * self.shards_count
+        mul2 = tokHi * self.shards_count
+        _sum = (mul1 >> 32) + mul2
+        output = _sum >> 32
+        return output
+
+
+try:
+    from .c_shard_info import ShardingInfo
+except ImportError:
+    ShardingInfo = _ShardingInfo

--- a/setup.py
+++ b/setup.py
@@ -307,7 +307,7 @@ On OSX, via homebrew:
             try:
                 from Cython.Build import cythonize
                 cython_candidates = ['cluster', 'concurrent', 'connection', 'cqltypes', 'metadata',
-                                     'pool', 'protocol', 'query', 'util']
+                                     'pool', 'protocol', 'query', 'util', 'shard_info']
                 compile_args = [] if is_windows else ['-Wno-unused-function']
                 self.extensions.extend(cythonize(
                     [Extension('cassandra.%s' % m, ['cassandra/%s.py' % m],

--- a/tests/unit/test_shard_aware.py
+++ b/tests/unit/test_shard_aware.py
@@ -38,8 +38,8 @@ class TestShardAware(unittest.TestCase):
         shard_id, shard_info = ShardingInfo.parse_sharding_info(OptionsHolder())
 
         self.assertEqual(shard_id, 1)
-        self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"a")), 4)
-        self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"b")), 6)
-        self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"c")), 6)
-        self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"e")), 4)
-        self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"100000")), 2)
+        self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"a").value), 4)
+        self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"b").value), 6)
+        self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"c").value), 6)
+        self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"e").value), 4)
+        self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"100000").value), 2)


### PR DESCRIPTION
since the computation was quite naive to begin with and in pure python
we could do much better with a calculation purely in C.