### PR TITLE
shard aware: adding new apis for shard aware

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1727,6 +1727,15 @@ class Cluster(object):
         holders.append(self.control_connection)
         return holders
 
+    def is_shard_aware(self):
+        return bool(self.get_connection_holders()[:-1][0].host.sharding_info)
+
+    def shard_aware_stats(self):
+        if self.is_shard_aware():
+            return {str(pool.host.endpoint): {'shards_count': pool.host.sharding_info.shards_count,
+                                              'connected': len(pool._connections.keys())}
+                    for pool in self.get_connection_holders()[:-1]}
+
     def shutdown(self):
         """
         Closes all sessions and connection associated with this Cluster.

--- a/tests/integration/standard/test_shard_aware.py
+++ b/tests/integration/standard/test_shard_aware.py
@@ -45,6 +45,9 @@ class TestShardAwareIntegration(unittest.TestCase):
                               reconnection_policy=ConstantReconnectionPolicy(1))
         cls.session = cls.cluster.connect()
 
+        print(cls.cluster.is_shard_aware())
+        print(cls.cluster.shard_aware_stats())
+
     @classmethod
     def teardown_class(cls):
         cls.cluster.shutdown()


### PR DESCRIPTION
**is_shard_aware** - for checking if share aware is active or not
**shard_aware_stats** - for getting stats of connection

```
>>> cluster.shard_aware_stats()
{'127.0.0.1:9042': {'shards_count': 4, 'connected': 4}, '127.0.0.3:9042': {'shards_count': 4, 'connected': 4}, '127.0.0.2:9042': {'shards_count': 4, 'connected': 4}}
```