### PR TITLE
shard aware: shard aware unique port (advanced shard aware) 

### DIFF
--- a/cassandra/c_shard_info.pyx
+++ b/cassandra/c_shard_info.pyx
@@ -22,15 +22,19 @@ cdef class ShardingInfo():
     cdef readonly str partitioner
     cdef readonly str sharding_algorithm
     cdef readonly int sharding_ignore_msb
+    cdef readonly int shard_aware_port
+    cdef readonly int shard_aware_port_ssl
 
     cdef object __weakref__
 
-    def __init__(self, shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb):
+    def __init__(self, shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb, shard_aware_port,
+                 shard_aware_port_ssl):
         self.shards_count = int(shards_count)
         self.partitioner = partitioner
         self.sharding_algorithm = sharding_algorithm
         self.sharding_ignore_msb = int(sharding_ignore_msb)
-
+        self.shard_aware_port = int(shard_aware_port) if shard_aware_port else 0
+        self.shard_aware_port_ssl = int(shard_aware_port_ssl) if shard_aware_port_ssl else 0
 
     @staticmethod
     def parse_sharding_info(message):
@@ -39,12 +43,15 @@ cdef class ShardingInfo():
         partitioner = message.options.get('SCYLLA_PARTITIONER', [''])[0] or None
         sharding_algorithm = message.options.get('SCYLLA_SHARDING_ALGORITHM', [''])[0] or None
         sharding_ignore_msb = message.options.get('SCYLLA_SHARDING_IGNORE_MSB', [''])[0] or None
+        shard_aware_port = message.options.get('SCYLLA_SHARD_AWARE_PORT', [''])[0] or None
+        shard_aware_port_ssl = message.options.get('SCYLLA_SHARD_AWARE_PORT_SSL', [''])[0] or None
 
         if not (shard_id or shards_count or partitioner == "org.apache.cassandra.dht.Murmur3Partitioner" or
             sharding_algorithm == "biased-token-round-robin" or sharding_ignore_msb):
             return 0, None
 
-        return int(shard_id), ShardingInfo(shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb)
+        return int(shard_id), ShardingInfo(shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb,
+                                           shard_aware_port, shard_aware_port_ssl)
 
     
     def shard_id_from_token(self, int64_t token_input):

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -553,6 +553,20 @@ Selected using ``Session.execute_graph(execution_profile=EXEC_PROFILE_GRAPH_ANAL
 """
 
 
+class ShardAwareOptions:
+    disable = None
+    disable_shardaware_port = False
+
+    def __init__(self, opts=None, disable=None, disable_shardaware_port=None):
+        self.disable = disable
+        self.disable_shardaware_port = disable_shardaware_port
+        if opts:
+            if isinstance(opts, ShardAwareOptions):
+                self.__dict__.update(opts.__dict__)
+            elif isinstance(opts, dict):
+                self.__dict__.update(opts)
+
+
 class _ConfigMode(object):
     UNCOMMITTED = 0
     LEGACY = 1
@@ -1003,6 +1017,12 @@ class Cluster(object):
     load the configuration and certificates.
     """
 
+    shard_aware_options = None
+    """
+    Can be set with :class:`ShardAwareOptions` or with a dict, to disable the automatic shardaware,
+    or to disable the shardaware port (advanced shardaware)
+    """
+
     @property
     def schema_metadata_enabled(self):
         """
@@ -1104,7 +1124,8 @@ class Cluster(object):
                  monitor_reporting_enabled=True,
                  monitor_reporting_interval=30,
                  client_id=None,
-                 cloud=None):
+                 cloud=None,
+                 shard_aware_options=None):
         """
         ``executor_threads`` defines the number of threads in a pool for handling asynchronous tasks such as
         extablishing connection pools or refreshing metadata.
@@ -1304,6 +1325,7 @@ class Cluster(object):
         self.reprepare_on_up = reprepare_on_up
         self.monitor_reporting_enabled = monitor_reporting_enabled
         self.monitor_reporting_interval = monitor_reporting_interval
+        self.shard_aware_options = ShardAwareOptions(opts=shard_aware_options)
 
         self._listeners = set()
         self._listener_lock = Lock()

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -134,8 +134,8 @@ class Metadata(object):
 
     def refresh(self, connection, timeout, target_type=None, change_type=None, **kwargs):
 
-        server_version = self.get_host(connection.endpoint).release_version
-        dse_version = self.get_host(connection.endpoint).dse_version
+        server_version = self.get_host(connection.original_endpoint).release_version
+        dse_version = self.get_host(connection.original_endpoint).dse_version
         parser = get_schema_parser(connection, server_version, dse_version, timeout)
 
         if not target_type:

--- a/cassandra/shard_info.py
+++ b/cassandra/shard_info.py
@@ -20,11 +20,13 @@ log = logging.getLogger(__name__)
 
 class _ShardingInfo(object):
 
-    def __init__(self, shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb):
+    def __init__(self, shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb, shard_aware_port, shard_aware_port_ssl):
         self.shards_count = int(shards_count)
         self.partitioner = partitioner
         self.sharding_algorithm = sharding_algorithm
         self.sharding_ignore_msb = int(sharding_ignore_msb)
+        self.shard_aware_port = int(shard_aware_port) if shard_aware_port else None
+        self.shard_aware_port_ssl = int(shard_aware_port_ssl) if shard_aware_port_ssl else None
 
     @staticmethod
     def parse_sharding_info(message):
@@ -33,13 +35,16 @@ class _ShardingInfo(object):
         partitioner = message.options.get('SCYLLA_PARTITIONER', [''])[0] or None
         sharding_algorithm = message.options.get('SCYLLA_SHARDING_ALGORITHM', [''])[0] or None
         sharding_ignore_msb = message.options.get('SCYLLA_SHARDING_IGNORE_MSB', [''])[0] or None
+        shard_aware_port = message.options.get('SCYLLA_SHARD_AWARE_PORT', [''])[0] or None
+        shard_aware_port_ssl = message.options.get('SCYLLA_SHARD_AWARE_PORT_SSL', [''])[0] or None
         log.debug("Parsing sharding info from message options %s", message.options)
 
         if not (shard_id or shards_count or partitioner == "org.apache.cassandra.dht.Murmur3Partitioner" or
             sharding_algorithm == "biased-token-round-robin" or sharding_ignore_msb):
             return 0, None
 
-        return int(shard_id), _ShardingInfo(shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb)
+        return int(shard_id), _ShardingInfo(shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb,
+                                            shard_aware_port, shard_aware_port_ssl)
 
     def shard_id_from_token(self, token):
         """

--- a/docs/scylla_specific.rst
+++ b/docs/scylla_specific.rst
@@ -26,6 +26,25 @@ https://github.com/scylladb/scylla/blob/master/docs/design-notes/protocols.md#cq
 New Cluster Helpers
 -------------------
 
+* ``shard_aware_options``
+
+  Setting it to ``dict(disable=True)`` would disable the shard aware functionally, for cases favoring once connection per host (example, lots of processes connecting from one client host, generating a big load of connections
+
+  Other option is to configure scylla by setting ``enable_shard_aware_drivers: false`` on scylla.yaml.
+
+.. code:: python
+
+    from cassandra.cluster import Cluster
+
+    cluster = Cluster(shard_aware_options=dict(disable=True))
+    session = cluster.connect()
+
+    assert not cluster.is_shard_aware(), "Shard aware should be disabled"
+
+    # or just disable the shard aware port logic
+    cluster = Cluster(shard_aware_options=dict(disable_shardaware_port=True))
+    session = cluster.connect()
+
 * ``cluster.is_shard_aware()``
 
   New method available on ``Cluster`` allowing to check whether the remote cluster supports shard awareness (bool)

--- a/docs/scylla_specific.rst
+++ b/docs/scylla_specific.rst
@@ -8,9 +8,12 @@ Shard Awareness
 As a result, latency is significantly reduced because there is no need to pass data between the shards.
 
 Details on the scylla cql protocol extensions
-https://github.com/scylladb/scylla/blob/master/docs/design-notes/protocol-extensions.md
+https://github.com/scylladb/scylla/blob/master/docs/design-notes/protocol-extensions.md#intranode-sharding
 
 For using it you only need to enable ``TokenAwarePolicy`` on the ``Cluster``
+
+See the configuration of ``native_shard_aware_transport_port`` and ``native_shard_aware_transport_port_ssl`` on scylla.yaml:
+https://github.com/scylladb/scylla/blob/master/docs/design-notes/protocols.md#cql-client-protocol
 
 .. code:: python
 

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -1514,7 +1514,7 @@ class DontPrepareOnIgnoredHostsTest(unittest.TestCase):
         # the length of mock_calls will vary, but all should use the unignored
         # address
         for c in cluster.connection_factory.mock_calls:
-            self.assertEqual(call(DefaultEndPoint(unignored_address)), c)
+            self.assertEqual(unignored_address, c.args[0].address)
         cluster.shutdown()
 
 

--- a/tests/unit/io/utils.py
+++ b/tests/unit/io/utils.py
@@ -28,7 +28,7 @@ from functools import wraps
 from itertools import cycle
 import six
 from six import binary_type, BytesIO
-from mock import Mock
+from mock import Mock, MagicMock
 
 import errno
 import logging
@@ -214,7 +214,7 @@ class ReactorTestMixin(object):
 
     def make_connection(self):
         c = self.connection_class(DefaultEndPoint('1.2.3.4'), cql_version='3.0.1', connect_timeout=5)
-        mocket = Mock()
+        mocket = MagicMock()
         mocket.send.side_effect = lambda x: len(x)
         self.set_socket(c, mocket)
         return c

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -155,6 +155,7 @@ class SessionTest(unittest.TestCase):
         """
         c = Cluster(protocol_version=4)
         s = Session(c, [Host("127.0.0.1", SimpleConvictionPolicy)])
+        c.connection_class.initialize_reactor()
 
         # default is None
         default_profile = c.profile_manager.default
@@ -183,7 +184,7 @@ class SessionTest(unittest.TestCase):
         """
         c = Cluster(protocol_version=4)
         s = Session(c, [Host("127.0.0.1", SimpleConvictionPolicy)])
-
+        c.connection_class.initialize_reactor()
         # default is None
         self.assertIsNone(s.default_serial_consistency_level)
 

--- a/tests/unit/test_control_connection.py
+++ b/tests/unit/test_control_connection.py
@@ -84,6 +84,7 @@ class MockCluster(object):
         self.executor = Mock(spec=ThreadPoolExecutor)
         self.profile_manager.profiles[EXEC_PROFILE_DEFAULT] = ExecutionProfile(RoundRobinPolicy())
         self.endpoint_factory = DefaultEndPointFactory().configure(self)
+        self.ssl_options = None
 
     def add_host(self, endpoint, datacenter, rack, signal=False, refresh_nodes=True):
         host = Host(endpoint, SimpleConvictionPolicy, datacenter, rack)
@@ -98,6 +99,9 @@ class MockCluster(object):
 
     def on_down(self, host, is_host_addition):
         self.down_host = host
+
+    def get_control_connection_host(self):
+        return self.added_hosts[0] if  self.added_hosts else None
 
 
 def _node_meta_results(local_results, peer_results):
@@ -121,6 +125,7 @@ class MockConnection(object):
 
     def __init__(self):
         self.endpoint = DefaultEndPoint("192.168.1.0")
+        self.original_endpoint = self.endpoint
         self.local_results = [
             ["schema_version", "cluster_name", "data_center", "rack", "partitioner", "release_version", "tokens"],
             [["a", "foocluster", "dc1", "rack1", "Murmur3Partitioner", "2.2.0", ["0", "100", "200"]]]

--- a/tests/unit/test_control_connection.py
+++ b/tests/unit/test_control_connection.py
@@ -100,9 +100,6 @@ class MockCluster(object):
     def on_down(self, host, is_host_addition):
         self.down_host = host
 
-    def get_control_connection_host(self):
-        return self.added_hosts[0] if  self.added_hosts else None
-
 
 def _node_meta_results(local_results, peer_results):
     """

--- a/tests/unit/test_host_connection_pool.py
+++ b/tests/unit/test_host_connection_pool.py
@@ -26,7 +26,7 @@ except ImportError:
 from mock import Mock, NonCallableMagicMock, MagicMock
 from threading import Thread, Event, Lock
 
-from cassandra.cluster import Session
+from cassandra.cluster import Session, ShardAwareOptions
 from cassandra.connection import Connection
 from cassandra.pool import HostConnection, HostConnectionPool
 from cassandra.pool import Host, NoConnectionsAvailable
@@ -160,6 +160,7 @@ class _PoolTests(unittest.TestCase):
         conn = NonCallableMagicMock(spec=Connection, in_flight=0, is_defunct=False, is_closed=False,
                                     max_request_id=100, signaled_error=False)
         session.cluster.connection_factory.return_value = conn
+        session.cluster.shard_aware_options = ShardAwareOptions()
 
         pool = self.PoolImpl(host, HostDistance.LOCAL, session)
         session.cluster.connection_factory.assert_called_once_with(host.endpoint, owning_pool=pool)

--- a/tests/unit/test_host_connection_pool.py
+++ b/tests/unit/test_host_connection_pool.py
@@ -301,7 +301,8 @@ class HostConnectionTests(_PoolTests):
                 connection.shard_id = self.connection_counter
                 self.connection_counter += 1
                 connection.sharding_info = _ShardingInfo(shard_id=1, shards_count=14,
-                                                         partitioner="", sharding_algorithm="", sharding_ignore_msb=0)
+                                                         partitioner="", sharding_algorithm="", sharding_ignore_msb=0,
+                                                         shard_aware_port="", shard_aware_port_ssl="")
 
                 return connection
 

--- a/tests/unit/test_shard_aware.py
+++ b/tests/unit/test_shard_aware.py
@@ -17,8 +17,15 @@ try:
 except ImportError:
     import unittest  # noqa
 
-from cassandra.connection import ShardingInfo
+import logging
+from unittest.mock import MagicMock
+from futures.thread import ThreadPoolExecutor
+
+from cassandra.pool import HostConnection, HostDistance
+from cassandra.connection import ShardingInfo, DefaultEndPoint
 from cassandra.metadata import Murmur3Token
+
+LOGGER = logging.getLogger(__name__)
 
 
 class TestShardAware(unittest.TestCase):
@@ -43,3 +50,64 @@ class TestShardAware(unittest.TestCase):
         self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"c").value), 6)
         self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"e").value), 4)
         self.assertEqual(shard_info.shard_id_from_token(Murmur3Token.from_key(b"100000").value), 2)
+
+    def test_advanced_shard_aware_port(self):
+        """
+        Test that on given a `shard_aware_port` on the OPTIONS message (ShardInfo class)
+        the next connections would be open using this port
+        """
+        class MockSession(MagicMock):
+            is_shutdown = False
+            keyspace = "ks1"
+
+            def __init__(self, is_ssl=False, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.cluster = MagicMock()
+                if is_ssl:
+                    self.cluster.ssl_options = {'some_ssl_options': True}
+                else:
+                    self.cluster.ssl_options = None
+                self.cluster.executor = ThreadPoolExecutor(max_workers=2)
+                self.cluster.signal_connection_failure = lambda *args, **kwargs: False
+                self.cluster.connection_factory = self.mock_connection_factory
+                self.connection_counter = -1
+                self.futures = []
+
+            def submit(self, fn, *args, **kwargs):
+                logging.info("Scheduling %s with args: %s, kwargs: %s", fn, args, kwargs)
+                if not self.is_shutdown:
+                    f = self.cluster.executor.submit(fn, *args, **kwargs)
+                    self.futures += [f]
+                    return f
+
+            def mock_connection_factory(self, *args, **kwargs):
+                connection = MagicMock()
+                connection.is_shutdown = False
+                connection.is_defunct = False
+                connection.is_closed = False
+                connection.orphaned_threshold_reached = False
+                connection.endpoint = args[0]
+                connection.shard_id = kwargs.get('shard_id', 0)
+                connection.sharding_info = ShardingInfo(shard_id=1, shards_count=4,
+                                                         partitioner="", sharding_algorithm="", sharding_ignore_msb=0,
+                                                         shard_aware_port=19042, shard_aware_port_ssl=19045)
+
+                return connection
+
+        host = MagicMock()
+        host.endpoint = DefaultEndPoint("1.2.3.4")
+
+        for port, is_ssl in [(19042, False), (19045, True)]:
+            session = MockSession(is_ssl=is_ssl)
+            pool = HostConnection(host=host, host_distance=HostDistance.REMOTE, session=session)
+            for f in session.futures:
+                f.result()
+            assert len(pool._connections) == 4
+            for shard_id, connection in pool._connections.items():
+                assert connection.shard_id == shard_id
+                if shard_id == 0:
+                    assert connection.endpoint == DefaultEndPoint("1.2.3.4")
+                else:
+                    assert connection.endpoint == DefaultEndPoint("1.2.3.4", port=port)
+
+        session.cluster.executor.shutdown(wait=True)


### PR DESCRIPTION
shard aware port in now advertised OPTIONS messge,
and we need to replace the connection with the new
host/port

* fixing tests to match the advenced shard awareness

now that we could have two host listed (one with 9042 port, and one
with 19042), we need to make the test a bit less prune to failure cause
of that change

It's implemented in the end in scylla-core in the following commit:
https://github.com/scylladb/scylla/commit/1c11d8f4c40067c95f8ddea42b0d41e40d40fe97
as a separate port scylla is listening on