### PR TITLE
pool: fix cluster shutdown RuntimeError on short lived sessions

### DIFF
--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -527,7 +527,7 @@ class HostConnection(object):
                 return
 
         conn = self._session.cluster.connection_factory(self.host.endpoint)
-        if conn.shard_id not in self._connections.keys():
+        if not self.is_shutdown and conn.shard_id not in self._connections.keys():
             log.debug(
                 "New connection created to shard_id=%i on host %s",
                 conn.shard_id,


### PR DESCRIPTION
when a program has a short life span, initial asynchronous opening
of connections to shards could take longer than the program
execution

if cluster.shutdown() is called while we are still trying to
connect to all shards we could get DEBUG tracebacks like:

    cluster.shutdown()
  File "cassandra/cluster.py", line 1761, in cassandra.cluster.Cluster.shutdown
  File "cassandra/cluster.py", line 3149, in cassandra.cluster.Session.shutdown
  File "cassandra/pool.py", line 507, in cassandra.pool.HostConnection.shutdown
RuntimeError: dictionary changed size during iteration

this fixes the issue by making sure we only append new connections
when not shutting down