### PR TITLE
Redirect to tag

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,4 +28,4 @@ jobs:
       run : ./docs/_utils/deploy.sh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        LATEST_VERSION: 3.22.2-scylla
+        LATEST_VERSION: 3.22.0-scylla

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,3 +28,4 @@ jobs:
       run : ./docs/_utils/deploy.sh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LATEST_VERSION: 3.22.2-scylla

--- a/docs/_utils/deploy.sh
+++ b/docs/_utils/deploy.sh
@@ -3,8 +3,8 @@
 # Clone repo
 git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" --branch gh-pages --single-branch gh-pages
 cp -r docs/_build/dirhtml/* gh-pages
-# Redirect index to master
-cp docs/_utils/redirect.html gh-pages/index.html
+# Redirect index to latest version
+./docs/_utils/redirect.sh > gh-pages/index.html
 # Deploy
 cd gh-pages
 touch .nojekyll

--- a/docs/_utils/redirect.html
+++ b/docs/_utils/redirect.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>Redirecting to Driver</title>
-    <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; URL=./master/index.html">
-    <link rel="canonical" href="./master/index.html">
-  </head>
-</html>

--- a/docs/_utils/redirect.sh
+++ b/docs/_utils/redirect.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+latest=${LATEST_VERSION:='master'}
+
+cat <<- _EOF_
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to Driver</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; URL=./${LATEST_VERSION}/index.html">
+    <link rel="canonical" href="./${LATEST_VERSION}/index.html">
+  </head>
+</html>
+_EOF_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -231,7 +231,7 @@ man_pages = [
 # Whitelist pattern for tags (set to None to ignore all tags)
 smv_tag_whitelist = r'\b(3.22.0-scylla|3.21.0-scylla)\b'
 # Whitelist pattern for branches (set to None to ignore all branches)
-smv_branch_whitelist = r"^master$"
+smv_branch_whitelist = r"None"
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"
 # Pattern for released versions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -231,7 +231,7 @@ man_pages = [
 # Whitelist pattern for tags (set to None to ignore all tags)
 smv_tag_whitelist = r'\b(3.22.0-scylla|3.21.0-scylla)\b'
 # Whitelist pattern for branches (set to None to ignore all branches)
-smv_branch_whitelist = r"None"
+smv_branch_whitelist = "None"
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"
 # Pattern for released versions


### PR DESCRIPTION
Before accepting this PR, please merge #67 

@lauranovich requested to redirect the docs by default to the latest tagged version instead of showing the contents of the master branch. The latest version is now configurable through new a variable named ``LATEST_VERSION``, which is defined in ``.github/workflows/pages.yml`` under the ``Deploy`` section.

**Preview:** https://dgarcia360.github.io/python-driver/

After applying the same solution to the java driver, I'll add some notes on how to apply the changes to other projects in the [theme repo base example](https://github.com/scylladb/sphinx-scylladb-theme).