### PR TITLE
Formal cibuildwheel python3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,8 +166,8 @@ jobs:
       if: type != pull_request AND (branch = master OR (tag =~ /^.*-scylla$/))
 
 install:
-  # - python3 -m pip install cibuildwheel==1.3.0
-  - python3 -m pip install git+https://github.com/joerick/cibuildwheel.git@python3.9
+  - python3 -m pip install cibuildwheel==1.6.0
+
 
 script:
   # build the wheels, put them into './wheelhouse'


### PR DESCRIPTION
Now that they merged PR for python3.9 support
and that branch is deleted, we should move back to
formal version

Ref: https://github.com/joerick/cibuildwheel/pull/382