### PR TITLE
Removed  pipx

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,7 @@
 # You can set these variables from the command line.
+POETRY        = $(HOME)/.poetry/bin/poetry
 SPHINXOPTS    =
-SPHINXBUILD   = poetry run sphinx-build
+SPHINXBUILD   = $(POETRY) run sphinx-build
 PAPER         =
 BUILDDIR      = _build
 SOURCEDIR     = .
@@ -29,7 +30,7 @@ clean:
 
 .PHONY: preview
 preview: setup
-	poetry run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --port 5500
+	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --port 5500
 
 .PHONY: dirhtml
 dirhtml: setup
@@ -67,6 +68,7 @@ linkcheck: setup
 
 .PHONY: multiversion
 multiversion: setup
-	poetry run sphinx-multiversion $(SOURCEDIR) $(BUILDDIR)/dirhtml
+	@mkdir -p $(HOME)/.cache/pypoetry/virtualenvs
+	$(POETRY) run sphinx-multiversion $(SOURCEDIR) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."

--- a/docs/_utils/setup.sh
+++ b/docs/_utils/setup.sh
@@ -6,11 +6,5 @@ if pwd | egrep -q '\s'; then
 fi
 
 which python3 || { echo "Failed to find python3. Try installing Python for your operative system: https://www.python.org/downloads/" && exit 1; }
-# install pipx
-which pipx || python3 -m pip install --user pipx
-python3 -m pipx ensurepath
-
-# install poetry
-which poetry || pipx install poetry
-poetry --version || { echo "Failed to find or install poetry. Try installing it manually: https://python-poetry.org/docs/#installation" && exit 1; }
+which poetry || curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/1.1.3/get-poetry.py | python3 - && source ${HOME}/.poetry/env
 poetry install


### PR DESCRIPTION
Fixes the error in GH action where pipx is registered but not in this version of python.

If you get an error involving poetry when testing the PR locally,  uninstall it first with ```pipx uninstall poetry```. Then, you should be able to run ``make preview``.

Reference: https://github.com/scylladb/mermaid/commit/ac65ec45e918a4a4df7f31e22cb314a103b76aef