### PR TITLE
doc: fix sphinx warnings

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -408,7 +408,7 @@ class ExecutionProfile(object):
 class GraphExecutionProfile(ExecutionProfile):
     graph_options = None
     """
-    :class:`.GraphOptions` to use with this execution
+    :class:`cassandra.graph.GraphOptions` to use with this execution
 
     Default options for graph queries, initialized as follows by default::
 

--- a/cassandra/datastax/graph/fluent/_predicates.py
+++ b/cassandra/datastax/graph/fluent/_predicates.py
@@ -194,8 +194,8 @@ class Geo(object):
         Search any instance of geometry inside the Distance targeted.
         :param value: A Distance to look for.
         :param units: The units for ``value``. See GeoUnit enum. (Can also
-            provide an integer to use as a multiplier to convert ``value`` to
-            degrees.)
+        provide an integer to use as a multiplier to convert ``value`` to
+        degrees.)
         """
         return GeoP.inside(
             value=Distance(x=value.x, y=value.y, radius=value.radius * units)

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -3287,10 +3287,10 @@ def group_keys_by_replica(session, keyspace, table, keys):
     :class:`~.NO_VALID_REPLICA`
 
     Example usage::
-        result = group_keys_by_replica(
-                     session, "system", "peers",
-                     (("127.0.0.1", ), ("127.0.0.2", ))
-                 )
+        
+        >>> result = group_keys_by_replica(
+        ...     session, "system", "peers",
+        ...     (("127.0.0.1", ), ("127.0.0.2", )))
     """
     cluster = session.cluster
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ autoclass_content = 'both'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'cloud.rst', 'core_graph.rst', 'geo_types.rst']
+exclude_patterns = ['_build', 'cloud.rst', 'core_graph.rst', 'geo_types.rst', 'graph.rst', 'graph_fluent.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ autoclass_content = 'both'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'cloud.rst', 'core_graph.rst', 'geo_types.rst', 'graph.rst', 'graph_fluent.rst']
+exclude_patterns = ['_build', 'cloud.rst', 'core_graph.rst', 'geo_types.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,7 +38,7 @@ the `graph` requirements::
 
     pip install scylla-driver[graph]
 
-See :doc:`graph_fluent` for more details about this API.
+See :doc:`graph_fluent <graph_fluent>` for more details about this API.
 
 (*Optional*) Compression Support
 --------------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,8 +38,6 @@ the `graph` requirements::
 
     pip install scylla-driver[graph]
 
-See :doc:`graph_fluent <graph_fluent>` for more details about this API.
-
 (*Optional*) Compression Support
 --------------------------------
 Compression can optionally be used for communication between the driver and


### PR DESCRIPTION
Fixes the warning raised by sphinx when running ``make preview``.

> /home/dgarcia/python-driver/cassandra/cluster.py:docstring of cassandra.cluster.GraphExecutionProfile.graph_options:1: WARNING: more than one target found for cross-reference 'GraphOptions': cassandra.datastax.graph.GraphOptions, cassandra.graph.GraphOptions

Some python docstings were not indented as expected by Sphinx.

> /home/dgarcia/python-driver/docs/installation.rst:41: WARNING: unknown document: graph_fluent

The file was being excluded in the conf.py file.
