### PR TITLE
docs: update url

### DIFF
--- a/docs/_utils/deploy.sh
+++ b/docs/_utils/deploy.sh
@@ -2,12 +2,11 @@
 
 # Copy contents
 mkdir gh-pages
-cp -r ./docs/_build/dirhtml/* gh-pages
+cp -r ./docs/_build/dirhtml/. gh-pages
 ./docs/_utils/redirect.sh > gh-pages/index.html
 
 # Create gh-pages branch
 cd gh-pages
-touch .nojekyll
 git init
 git config --local user.email "action@scylladb.com"
 git config --local user.name "GitHub Action"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ html_use_index = False
 htmlhelp_basename = 'CassandraDriverdoc'
 
 # URL which points to the root of the HTML documentation. 
-html_baseurl = 'https://scylladb.github.io/python-driver'
+html_baseurl = 'https://python-driver.docs.scylladb.com'
 
 # Dictionary of values to pass into the template engine’s context for all pages
 html_context = {'html_baseurl': html_baseurl}


### PR DESCRIPTION
Once this commit is merged, the docs will be published under the new domain name https://python-driver.docs.scylladb.com