### PR TITLE
docs: added multiversion_regex_builder

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -72,3 +72,7 @@ multiversion: setup
 	$(POETRY) run sphinx-multiversion $(SOURCEDIR) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+.PHONY: multiversionpreview
+multiversionpreview: multiversion
+	$(POETRY) run python3 -m http.server 5500 --directory $(BUILDDIR)/dirhtml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.abspath('..'))
 import cassandra
 import recommonmark
 from recommonmark.transform import AutoStructify
+from sphinx_scylladb_theme.utils import multiversion_regex_builder
 
 
 # -- General configuration -----------------------------------------------------
@@ -112,9 +113,11 @@ redirects_file = "_utils/redirections.yaml"
 
 # -- Options for multiversion --------------------------------------------------
 # Whitelist pattern for tags (set to None to ignore all tags)
-smv_tag_whitelist = r'\b(3.22.0-scylla|3.21.0-scylla|3.22.3-scylla|3.24.0-scylla)\b'
+TAGS = ['3.21.0-scylla', '3.22.0-scylla', '3.22.3-scylla', '3.24.0-scylla']
+smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
-smv_branch_whitelist = "None"
+BRANCHES = []
+smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"
 # Pattern for released versions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,7 +113,7 @@ redirects_file = "_utils/redirections.yaml"
 
 # -- Options for multiversion --------------------------------------------------
 # Whitelist pattern for tags (set to None to ignore all tags)
-TAGS = ['3.21.0-scylla', '3.22.0-scylla', '3.22.3-scylla', '3.24.0-scylla']
+TAGS = ['3.21.0-scylla', '3.22.0-scylla', '3.22.3-scylla', '3.24.0-scylla', '3.24.1-scylla']
 smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
 BRANCHES = []


### PR DESCRIPTION
The new built-in function `multiversion_regex_builder(versions)` enables maintainers to define versions in an array instead of defining complex regex expressions.

**Before:** 

`smv_tag_whitelist = r'\b(3.22.0-scylla|3.21.0-scylla|3.22.3-scylla|3.24.0-scylla)\b'`

**Now:** 

`TAGS = ['3.21.0-scylla', '3.22.0-scylla', '3.22.3-scylla', '3.24.0-scylla']`

It also adds a new command ``make multiversionpreview`` that launches a webserver to quickly preview the multiversion build.


## Testing this PR

1. Run ``make multiversionpreview``.
2. Open http://0.0.0.0:5500 in a new browser tab.
3. You should see folders for every version listed in ``TAGS`` (conf.py).
