### PR TITLE
Fixed warnings 3.24.1-scylla

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
     - master
-    tags:
-    - '**'
     paths:
     - 'docs/**'
 

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -342,7 +342,7 @@ class Metadata(object):
         """
         Find a host in the metadata for a specific endpoint. If a string inet address and port are passed,
         iterate all hosts to match the :attr:`~.pool.Host.broadcast_rpc_address` and
-        :attr:`~.pool.Host.broadcast_rpc_port`attributes.
+        :attr:`~.pool.Host.broadcast_rpc_port`attributes`.
         """
         if not isinstance(endpoint_or_address, EndPoint):
             return self._get_host_by_address(endpoint_or_address, port)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ autoclass_content = 'both'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'cloud.rst', 'core_graph.rst', 'geo_types.rst', 'graph.rst', 'graph_fluent.rst']
+exclude_patterns = ['_build', 'cloud.rst', 'core_graph.rst', 'classic_graph.rst', 'geo_types.rst', 'graph.rst', 'graph_fluent.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -75,7 +75,7 @@ html_theme = 'sphinx_scylladb_theme'
 # documentation.
 html_theme_options = {
     'header_links': [
-    ('Scylla Python Driver', 'https://scylladb.github.io/python-driver/'),
+    ('Scylla Python Driver', 'https://python-driver.docs.scylladb.com/'),
     ('Scylla Cloud', 'https://docs.scylladb.com/scylla-cloud/'),
     ('Scylla University', 'https://university.scylladb.com/'),
     ('ScyllaDB Home', 'https://www.scylladb.com/')],

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -10,7 +10,7 @@ geomet = "0.1.2"
 six = "1.15.0"
 futures = "2.2.0"
 eventlet = "0.25.2"
-gevent = "20.6.2"
+gevent = "20.12.1"
 scales = "1.0.9"
 [tool.poetry.dev-dependencies]
 sphinx-autobuild = "0.7.1"


### PR DESCRIPTION
Related issue https://github.com/scylladb/python-driver/issues/88

The file ``classic_graph.rst`` is now excluded from being parsed. Other documents talking about graphs (core-graph, graph_fluent, graph) were already excluded deliberately since they are [not relevant to scylla](https://github.com/scylladb/python-driver/pull/77#pullrequestreview-537660834). 

## How to test this PR

Within the ``docs folder``:

1. Run ``make pristine``
2. Run ``make preview``.
3. Sphinx should run without warnings.