### PR TITLE
ResultSet: handle empty non-final pages on ResultSet iteration

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5133,6 +5133,7 @@ class ResultSet(object):
         if not self.response_future._continuous_paging_session:
             self.fetch_next_page()
             self._page_iter = iter(self._current_rows)
+            return self.next()
 
         return next(self._page_iter)
 


### PR DESCRIPTION
This commit provides a fix to the situation when iterating on a
ResultSet, the driver aborts the iteration if the server returns
an empty page even if there are next pages available.

Python driver is affected by the same problem as JAVA-2934
This fix is similar to https://github.com/datastax/java-driver/pull/1544