### PR TITLE
bump packaging version to 3.24.5 to match git tag

### DIFF
--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -22,7 +22,7 @@ class NullHandler(logging.Handler):
 
 logging.getLogger('cassandra').addHandler(NullHandler())
 
-__version_info__ = (3, 24, 1)
+__version_info__ = (3, 24, 5)
 __version__ = '.'.join(map(str, __version_info__))
 
 


### PR DESCRIPTION
Dunno if you intentionally left it out, but here is the version bump needed to release to PyPi if I'm not mistaken @fruch