### PR TITLE
fix(gitflow): temporary disable macos pypy until 7.3.7 is released

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -42,8 +42,10 @@ jobs:
           - os: macos-latest
             platform: all
 
-          - os: macos-latest
-            platform: PyPy
+          #- os: macos-latest
+          #  platform: PyPy
+          # It is disabled due to the https://foss.heptapod.net/pypy/pypy/-/issues/3314
+          # Re-enable when PyPy 7.3.7 is released https://downloads.python.org/pypy/versions.json
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
There is an pypy issue on MacOs, https://foss.heptapod.net/pypy/pypy/-/issues/3314 wich does not allow it to be built.
This issue is fixed on master and py3.7, but 7.3.7 is not released yet.
So only way is to disable it and wait till pypy 7.3.7 is released.
