### PR TITLE
fix pool shutdown and disable failing tests due to #121

### DIFF
--- a/tests/integration/standard/test_control_connection.py
+++ b/tests/integration/standard/test_control_connection.py
@@ -103,6 +103,8 @@ class ControlConnectionTests(unittest.TestCase):
         new_host = self.cluster.get_control_connection_host()
         self.assertNotEqual(host, new_host)
 
+    # TODO: enable after https://github.com/scylladb/python-driver/issues/121 is fixed
+    @unittest.skip('Fails on scylla due to the broadcast_rpc_port is None')
     @notdse
     @greaterthanorequalcass40
     def test_control_connection_port_discovery(self):

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -53,6 +53,8 @@ def setup_module():
 
 
 class HostMetaDataTests(BasicExistingKeyspaceUnitTestCase):
+    # TODO: enable after https://github.com/scylladb/python-driver/issues/121 is fixed
+    @unittest.skip('Fails on scylla due to the broadcast_rpc_port is None')
     @local
     def test_host_addresses(self):
         """

--- a/tests/integration/standard/test_single_interface.py
+++ b/tests/integration/standard/test_single_interface.py
@@ -49,6 +49,8 @@ class SingleInterfaceTest(unittest.TestCase):
         if self.cluster is not None:
             self.cluster.shutdown()
 
+    # TODO: enable after https://github.com/scylladb/python-driver/issues/121 is fixed
+    @unittest.skip('Fails on scylla due to the broadcast_rpc_port is None')
     def test_single_interface(self):
         """
         Test that we can connect to a multiple hosts bound to a single interface.


### PR DESCRIPTION
There is a bug that can cause HostConnectionPool.shutdown to get into deadlock.
You can see it by running `tests/integration/standard/test_query.py`, usually you see it on `test_too_many_statements` test.

This PR is mainly to address this problem, but also contains patches to disable tests and code reorganizing patches. 
