### PR TITLE
fix(tests/integration/standard):  Removing "@unittest.skip('Failing with scylla')"

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,5 +19,5 @@ jobs:
 
     - name: Test with pytest
       run: |
-        ./ci/run_integration_test.sh tests/integration/standard/test_authentication.py tests/integration/standard/test_cluster.py tests/integration/standard/test_concurrent.py tests/integration/standard/test_connection.py tests/integration/standard/test_control_connection.py tests/integration/standard/test_custom_payload.py tests/integration/standard/test_custom_protocol_handler.py tests/integration/standard/test_cython_protocol_handlers.py
+        ./ci/run_integration_test.sh tests/integration/standard -m "not cassandra"
         # can't run this, cause only 2 cpus on github actions: tests/integration/standard/test_shard_aware.py

--- a/ci/run_integration_test.sh
+++ b/ci/run_integration_test.sh
@@ -7,7 +7,7 @@ source .test-venv/bin/activate
 pip install -U pip wheel setuptools
 
 # install driver wheel
-pip install --ignore-installed -r test-requirements.txt pytest
+pip install --ignore-installed -r test-requirements.txt
 pip install .
 
 # download awscli

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 geomet>=0.1,<0.3
 six >=1.9
 futures <=2.2.0
+pytest
 # Futures is not required for Python 3, but it works up through 2.2.0 (after which it introduced breaking syntax).
 # This is left here to make sure install -r works with any runtime. When installing via setup.py, futures is omitted
 # for Python 3, in favor of the standard library implementation.

--- a/tests/integration/standard/test_authentication_misconfiguration.py
+++ b/tests/integration/standard/test_authentication_misconfiguration.py
@@ -14,10 +14,12 @@
 
 import unittest
 
+import pytest
+
 from tests.integration import USE_CASS_EXTERNAL, use_cluster, TestCluster
 
 
-@unittest.skip('Failing with scylla')
+@pytest.mark.cassandra
 class MisconfiguredAuthenticationTests(unittest.TestCase):
     """ One node (not the contact point) has password auth. The rest of the nodes have no auth """
     # TODO: 	Fix ccm to apply following options to scylla.yaml

--- a/tests/integration/standard/test_client_warnings.py
+++ b/tests/integration/standard/test_client_warnings.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pytest
 
 try:
     import unittest2 as unittest
@@ -27,7 +27,7 @@ def setup_module():
     use_singledc()
 
 
-@unittest.skip('Failing with scylla')
+@pytest.mark.cassandra
 class ClientWarningTests(unittest.TestCase):
 
     @classmethod

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 
 try:
     import unittest2 as unittest
@@ -276,7 +277,7 @@ class ClusterTests(unittest.TestCase):
 
         cluster.shutdown()
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     def test_invalid_protocol_negotation(self):
         """
         Test for protocol negotiation when explicit versions are set
@@ -1128,7 +1129,6 @@ class ClusterTests(unittest.TestCase):
             else:
                 raise Exception("session.execute didn't time out in {0} tries".format(max_retry_count))
 
-    @unittest.skip('Failing with scylla')
     def test_replicas_are_queried(self):
         """
         Test that replicas are queried first for TokenAwarePolicy. A table with RF 1
@@ -1497,7 +1497,6 @@ class BetaProtocolTest(unittest.TestCase):
         except Exception as e:
             self.fail("Unexpected error encountered {0}".format(e.message))
 
-    @unittest.skip('Failing with scylla')
     @protocolv5
     def test_valid_protocol_version_beta_options_connect(self):
         """
@@ -1552,7 +1551,7 @@ class DeprecationWarningTest(unittest.TestCase):
             self.assertIn("Cluster.set_meta_refresh_enabled is deprecated and will be removed in 4.0.",
                           str(w[0].message))
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     def test_deprecation_warning_default_consistency_level(self):
         """
         Tests the deprecation warning has been added when enabling

--- a/tests/integration/standard/test_custom_payload.py
+++ b/tests/integration/standard/test_custom_payload.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pytest
 
 try:
     import unittest2 as unittest
@@ -31,6 +31,7 @@ def setup_module():
 #These test rely on the custom payload being returned but by default C*
 #ignores all the payloads.
 @local
+@pytest.mark.cassandra
 class CustomPayloadTests(unittest.TestCase):
 
     def setUp(self):
@@ -45,7 +46,6 @@ class CustomPayloadTests(unittest.TestCase):
 
         self.cluster.shutdown()
 
-    @unittest.skip('Failing with scylla')
     def test_custom_query_basic(self):
         """
         Test to validate that custom payloads work with simple queries
@@ -68,7 +68,6 @@ class CustomPayloadTests(unittest.TestCase):
         # Validate that various types of custom payloads are sent and received okay
         self.validate_various_custom_payloads(statement=statement)
 
-    @unittest.skip('Failing with scylla')
     def test_custom_query_batching(self):
         """
         Test to validate that custom payloads work with batch queries
@@ -93,7 +92,6 @@ class CustomPayloadTests(unittest.TestCase):
         # Validate that various types of custom payloads are sent and received okay
         self.validate_various_custom_payloads(statement=batch)
 
-    @unittest.skip('Failing with scylla')
     def test_custom_query_prepared(self):
         """
         Test to validate that custom payloads work with prepared queries

--- a/tests/integration/standard/test_custom_protocol_handler.py
+++ b/tests/integration/standard/test_custom_protocol_handler.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 
 try:
     import unittest2 as unittest
@@ -25,7 +26,7 @@ from cassandra import ProtocolVersion, ConsistencyLevel
 
 from tests.integration import use_singledc, drop_keyspace_shutdown_cluster, \
     greaterthanorequalcass30, execute_with_long_wait_retry, greaterthanorequaldse51, greaterthanorequalcass3_10, \
-    greaterthanorequalcass31, TestCluster
+    greaterthanorequalcass31, TestCluster, protocolv5
 from tests.integration.datatype_utils import update_datatypes, PRIMITIVE_DATATYPES
 from tests.integration.standard.utils import create_table_with_all_types, get_all_primitive_params
 from six import binary_type
@@ -124,8 +125,8 @@ class CustomProtocolHandlerTest(unittest.TestCase):
         self.assertEqual(len(CustomResultMessageTracked.checked_rev_row_set), len(PRIMITIVE_DATATYPES)-1)
         cluster.shutdown()
 
-    @unittest.skip('Failing with scylla')
     @greaterthanorequalcass31
+    @protocolv5
     def test_protocol_divergence_v5_fail_by_continuous_paging(self):
         """
         Test to validate that V5 and DSE_V1 diverge. ContinuousPagingOptions is not supported by V5
@@ -171,8 +172,8 @@ class CustomProtocolHandlerTest(unittest.TestCase):
         self._protocol_divergence_fail_by_flag_uses_int(ProtocolVersion.V4, uses_int_query_flag=False,
                                                         int_flag=True)
 
-    @unittest.skip('Failing with scylla')
     @greaterthanorequalcass3_10
+    @protocolv5
     def test_protocol_v5_uses_flag_int(self):
         """
         Test to validate that the _PAGE_SIZE_FLAG is treated correctly using write_uint for V5
@@ -198,8 +199,8 @@ class CustomProtocolHandlerTest(unittest.TestCase):
         self._protocol_divergence_fail_by_flag_uses_int(ProtocolVersion.DSE_V1, uses_int_query_flag=True,
                                                         int_flag=True)
 
-    @unittest.skip('Failing with scylla')
     @greaterthanorequalcass3_10
+    @protocolv5
     def test_protocol_divergence_v5_fail_by_flag_uses_int(self):
         """
         Test to validate that the _PAGE_SIZE_FLAG is treated correctly using write_uint for V5

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 
 try:
     import unittest2 as unittest
@@ -245,7 +246,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         self.check_create_statement(tablemeta, create_statement)
 
-    @unittest.skip('Failing with scylla')
     def test_compound_primary_keys(self):
         create_statement = self.make_create_statement(["a"], ["b"], ["c"])
         create_statement += " WITH CLUSTERING ORDER BY (b ASC)"
@@ -258,7 +258,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         self.check_create_statement(tablemeta, create_statement)
 
-    @unittest.skip('Failing with scylla')
     def test_compound_primary_keys_protected(self):
         create_statement = self.make_create_statement(["Aa"], ["Bb"], ["Cc"])
         create_statement += ' WITH CLUSTERING ORDER BY ("Bb" ASC)'
@@ -271,7 +270,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         self.check_create_statement(tablemeta, create_statement)
 
-    @unittest.skip('Failing with scylla')
     def test_compound_primary_keys_more_columns(self):
         create_statement = self.make_create_statement(["a"], ["b", "c"], ["d", "e", "f"])
         create_statement += " WITH CLUSTERING ORDER BY (b ASC, c ASC)"
@@ -309,7 +307,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         self.check_create_statement(tablemeta, create_statement)
 
-    @unittest.skip('Failing with scylla')
     def test_compound_primary_keys_compact(self):
         create_statement = self.make_create_statement(["a"], ["b"], ["c"])
         create_statement += " WITH CLUSTERING ORDER BY (b ASC)"
@@ -344,7 +341,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         c_column = tablemeta.columns['c']
         self.assertTrue(c_column.is_reversed)
 
-    @unittest.skip('Failing with scylla')
     def test_compound_primary_keys_more_columns_compact(self):
         create_statement = self.make_create_statement(["a"], ["b", "c"], ["d"])
         create_statement += " WITH CLUSTERING ORDER BY (b ASC, c ASC)"
@@ -409,7 +405,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         tablemeta = self.get_table_metadata()
         self.check_create_statement(tablemeta, create_statement)
 
-    @unittest.skip('Failing with scylla')
     def test_compound_primary_keys_more_columns_ordering(self):
         create_statement = self.make_create_statement(["a"], ["b", "c"], ["d", "e", "f"])
         create_statement += " WITH CLUSTERING ORDER BY (b DESC, c ASC)"
@@ -442,7 +437,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         tablemeta = self.get_table_metadata()
         self.check_create_statement(tablemeta, create_statement)
 
-    @unittest.skip('Failing with scylla')
     def test_counter(self):
         create_statement = (
             "CREATE TABLE {keyspace}.{table} ("
@@ -476,7 +470,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         tablemeta = self.get_table_metadata()
         self.check_create_statement(tablemeta, create_statement)
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     def test_indexes(self):
         create_statement = self.make_create_statement(["a"], ["b", "c"], ["d", "e", "f"])
         create_statement += " WITH CLUSTERING ORDER BY (b ASC, c ASC)"
@@ -501,7 +495,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.assertIn('CREATE INDEX d_index', statement)
         self.assertIn('CREATE INDEX e_index', statement)
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     @greaterthancass21
     def test_collection_indexes(self):
 
@@ -532,7 +526,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
             tablemeta = self.get_table_metadata()
             self.assertIn('(full(b))', tablemeta.export_as_string())
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     def test_compression_disabled(self):
         create_statement = self.make_create_statement(["a"], ["b"], ["c"])
         create_statement += " WITH compression = {}"
@@ -541,7 +535,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         expected = "compression = {}" if CASSANDRA_VERSION < Version("3.0") else "compression = {'enabled': 'false'}"
         self.assertIn(expected, tablemeta.export_as_string())
 
-    @unittest.skip('Failing with scylla')
     def test_non_size_tiered_compaction(self):
         """
         test options for non-size-tiered compaction strategy
@@ -568,7 +561,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
             self.assertNotIn("min_threshold", cql)
             self.assertNotIn("max_threshold", cql)
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     def test_refresh_schema_metadata(self):
         """
         test for synchronously refreshing all cluster metadata
@@ -653,7 +646,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         cluster2.shutdown()
 
-    @unittest.skip('Failing with scylla')
     def test_refresh_keyspace_metadata(self):
         """
         test for synchronously refreshing keyspace metadata
@@ -682,7 +674,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         cluster2.shutdown()
 
-    @unittest.skip('Failing with scylla')
     def test_refresh_table_metadata(self):
         """
         test for synchronously refreshing table metadata
@@ -715,7 +706,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         cluster2.shutdown()
 
-    @unittest.skip('Failing with scylla')
     @greaterthanorequalcass30
     def test_refresh_metadata_for_mv(self):
         """
@@ -777,7 +767,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         finally:
             cluster3.shutdown()
 
-    @unittest.skip('Failing with scylla')
     def test_refresh_user_type_metadata(self):
         """
         test for synchronously refreshing UDT metadata in keyspace
@@ -845,7 +834,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
             self.assertEqual(cluster.metadata.keyspaces[self.keyspace_name].user_types, {})
             cluster.shutdown()
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     def test_refresh_user_function_metadata(self):
         """
         test for synchronously refreshing UDF metadata in keyspace
@@ -882,7 +871,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         cluster2.shutdown()
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     def test_refresh_user_aggregate_metadata(self):
         """
         test for synchronously refreshing UDA metadata in keyspace
@@ -925,7 +914,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         cluster2.shutdown()
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     @greaterthanorequalcass30
     def test_multiple_indices(self):
         """
@@ -959,7 +948,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.assertEqual(index_2.index_options["target"], "keys(b)")
         self.assertEqual(index_2.keyspace_name, "schemametadatatests")
 
-    @unittest.skip('Failing with scylla')
     @greaterthanorequalcass30
     def test_table_extensions(self):
         s = self.session
@@ -1179,7 +1167,7 @@ CREATE TABLE export_udts.users (
 
         cluster.shutdown()
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     @greaterthancass21
     def test_case_sensitivity(self):
         """
@@ -1249,7 +1237,7 @@ CREATE TABLE export_udts.users (
         self.assertRaises(AlreadyExists, session.execute, ddl % (ksname, cfname))
         cluster.shutdown()
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     @local
     def test_replicas(self):
         """
@@ -1323,7 +1311,6 @@ class KeyspaceAlterMetadata(unittest.TestCase):
         self.session.execute('DROP KEYSPACE %s' % name)
         self.cluster.shutdown()
 
-    @unittest.skip('Failing with scylla')
     def test_keyspace_alter(self):
         """
         Table info is preserved upon keyspace alter:
@@ -1518,6 +1505,7 @@ class FunctionTest(unittest.TestCase):
             super(FunctionTest.VerifiedAggregate, self).__init__(test_case, Aggregate, test_case.keyspace_aggregate_meta, **kwargs)
 
 
+@pytest.mark.cassandra
 class FunctionMetadata(FunctionTest):
 
     def make_function_kwargs(self, called_on_null=True):
@@ -1533,7 +1521,6 @@ class FunctionMetadata(FunctionTest):
                 'monotonic': False,
                 'monotonic_on': []}
 
-    @unittest.skip('Failing with scylla')
     def test_functions_after_udt(self):
         """
         Test to to ensure functions come after UDTs in in keyspace dump
@@ -1569,7 +1556,6 @@ class FunctionMetadata(FunctionTest):
             self.assertNotIn(-1, (type_idx, func_idx), "TYPE or FUNCTION not found in keyspace_cql: " + keyspace_cql)
             self.assertGreater(func_idx, type_idx)
 
-    @unittest.skip('Failing with scylla')
     def test_function_same_name_diff_types(self):
         """
         Test to verify to that functions with different signatures are differentiated in metadata
@@ -1599,7 +1585,6 @@ class FunctionMetadata(FunctionTest):
                 self.assertEqual(len(functions), 2)
                 self.assertNotEqual(functions[0].argument_types, functions[1].argument_types)
 
-    @unittest.skip('Failing with scylla')
     def test_function_no_parameters(self):
         """
         Test to verify CQL output for functions with zero parameters
@@ -1621,7 +1606,6 @@ class FunctionMetadata(FunctionTest):
             fn_meta = self.keyspace_function_meta[vf.signature]
             self.assertRegexpMatches(fn_meta.as_cql_query(), "CREATE FUNCTION.*%s\(\) .*" % kwargs['name'])
 
-    @unittest.skip('Failing with scylla')
     def test_functions_follow_keyspace_alter(self):
         """
         Test to verify to that functions maintain equality after a keyspace is altered
@@ -1649,7 +1633,6 @@ class FunctionMetadata(FunctionTest):
             finally:
                 self.session.execute('ALTER KEYSPACE %s WITH durable_writes = true' % self.keyspace_name)
 
-    @unittest.skip('Failing with scylla')
     def test_function_cql_called_on_null(self):
         """
         Test to verify to that that called on null argument is honored on function creation.
@@ -1677,7 +1660,7 @@ class FunctionMetadata(FunctionTest):
             self.assertRegexpMatches(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) RETURNS NULL ON NULL INPUT RETURNS .*")
 
 
-@unittest.skip('Failing with scylla')
+@pytest.mark.cassandra
 class AggregateMetadata(FunctionTest):
 
     @classmethod
@@ -1990,7 +1973,7 @@ class BadMetaTest(unittest.TestCase):
             self.assertIs(m._exc_info[0], self.BadMetaException)
             self.assertIn("/*\nWarning:", m.export_as_string())
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     @greaterthancass21
     def test_bad_user_function(self):
         self.session.execute("""CREATE FUNCTION IF NOT EXISTS %s (key int, val int)
@@ -2009,7 +1992,7 @@ class BadMetaTest(unittest.TestCase):
                 self.assertIs(m._exc_info[0], self.BadMetaException)
                 self.assertIn("/*\nWarning:", m.export_as_string())
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     @greaterthancass21
     def test_bad_user_aggregate(self):
         self.session.execute("""CREATE FUNCTION IF NOT EXISTS sum_int (key int, val int)
@@ -2031,7 +2014,7 @@ class BadMetaTest(unittest.TestCase):
 
 class DynamicCompositeTypeTest(BasicSharedKeyspaceUnitTestCase):
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     def test_dct_alias(self):
         """
         Tests to make sure DCT's have correct string formatting

--- a/tests/integration/standard/test_prepared_statements.py
+++ b/tests/integration/standard/test_prepared_statements.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pytest
 
 from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
 
@@ -452,7 +452,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
 
         self.assertIsNot(wildcard_prepared.result_metadata, original_result_metadata)
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.xfail
     def test_prepared_id_is_update(self):
         """
         Tests that checks the query id from the prepared statement
@@ -477,7 +477,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         self.assertNotEqual(id_before, id_after)
         self.assertEqual(len(prepared_statement.result_metadata), 4)
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.xfail
     def test_prepared_id_is_updated_across_pages(self):
         """
         Test that checks that the query id from the prepared statement
@@ -508,7 +508,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         self.assertNotEqual(id_before, id_after)
         self.assertEqual(len(prepared_statement.result_metadata), 4)
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.xfail
     def test_prepare_id_is_updated_across_session(self):
         """
         Test that checks that the query id from the prepared statement
@@ -549,7 +549,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         with self.assertRaises(InvalidRequest):
             self.session.execute(prepared_statement.bind((1, )))
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.xfail
     def test_id_is_not_updated_conditional_v4(self):
         """
         Test that verifies that the result_metadata and the
@@ -564,7 +564,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         self.addCleanup(cluster.shutdown)
         self._test_updated_conditional(session, 9)
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.xfail
     @requirecassandra
     def test_id_is_not_updated_conditional_v5(self):
         """

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+
+import pytest
+
 from cassandra.concurrent import execute_concurrent
 from cassandra import DriverException
 
@@ -472,7 +475,6 @@ class ForcedHostIndexPolicy(RoundRobinPolicy):
 
 class PreparedStatementMetdataTest(unittest.TestCase):
 
-    @unittest.skip('Failing with scylla')
     def test_prepared_metadata_generation(self):
         """
         Test to validate that result metadata is appropriately populated across protocol version
@@ -957,7 +959,7 @@ class LightweightTransactionTests(unittest.TestCase):
         # Make sure test passed
         self.assertTrue(received_timeout)
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.cassandra
     def test_was_applied_batch_stmt(self):
         """
         Test to ensure `:attr:cassandra.cluster.ResultSet.was_applied` works as expected
@@ -1395,7 +1397,7 @@ class BaseKeyspaceTests():
         cls.cluster.shutdown()
 
 
-@unittest.skip('Failing with scylla')
+@pytest.mark.cassandra
 class QueryKeyspaceTests(BaseKeyspaceTests):
 
     def test_setting_keyspace(self):
@@ -1464,7 +1466,6 @@ class QueryKeyspaceTests(BaseKeyspaceTests):
         self._check_set_keyspace_in_statement(session)
 
 
-@unittest.skip('Failing with scylla')
 @greaterthanorequalcass40
 class SimpleWithKeyspaceTests(QueryKeyspaceTests, unittest.TestCase):
     @unittest.skip
@@ -1493,7 +1494,6 @@ class SimpleWithKeyspaceTests(QueryKeyspaceTests, unittest.TestCase):
         self.assertEqual(results[0], (1, 1))
 
 
-@unittest.skip('Failing with scylla')
 @greaterthanorequalcass40
 class BatchWithKeyspaceTests(QueryKeyspaceTests, unittest.TestCase):
     def _check_set_keyspace_in_statement(self, session):
@@ -1520,7 +1520,6 @@ class BatchWithKeyspaceTests(QueryKeyspaceTests, unittest.TestCase):
         self.assertEqual(set(range(10)), values, msg=results)
 
 
-@unittest.skip('Failing with scylla')
 @greaterthanorequalcass40
 class PreparedWithKeyspaceTests(BaseKeyspaceTests, unittest.TestCase):
 

--- a/tests/integration/standard/test_shard_aware.py
+++ b/tests/integration/standard/test_shard_aware.py
@@ -16,6 +16,8 @@ import time
 import random
 from subprocess import run
 
+import pytest
+
 try:
     from concurrent.futures import ThreadPoolExecutor, as_completed
 except ImportError:
@@ -164,6 +166,7 @@ class TestShardAwareIntegration(unittest.TestCase):
             for result in as_completed(futures):
                 print(result)
 
+    @pytest.mark.cassandra
     def test_closing_connections(self):
         """
         Verify that reconnection is working as expected, when connection are being closed.

--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 
 try:
     import unittest2 as unittest
@@ -734,7 +735,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         s.execute(u"SELECT * FROM system.local WHERE key = 'ef\u2052ef'")
         s.execute(u"SELECT * FROM system.local WHERE key = %s", (u"fe\u2051fe",))
 
-    @unittest.skip('Failing with scylla')
+    @pytest.mark.xfail
     def test_can_read_composite_type(self):
         """
         Test to ensure that CompositeTypes can be used in a query

--- a/tests/integration/standard/test_udts.py
+++ b/tests/integration/standard/test_udts.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 
 try:
     import unittest2 as unittest
@@ -51,7 +52,6 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         super(UDTTests, self).setUp()
         self.session.set_keyspace(self.keyspace_name)
 
-    @unittest.skip('Failing with scylla')
     @greaterthanorequalcass36
     def test_non_frozen_udts(self):
         """
@@ -75,7 +75,6 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         table_sql = self.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].as_cql_query()
         self.assertNotIn("<frozen>", table_sql)
 
-    @unittest.skip('Failing with scylla')
     def test_can_insert_unprepared_registered_udts(self):
         """
         Test the insertion of unprepared, registered UDTs
@@ -120,7 +119,6 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         c.shutdown()
 
-    @unittest.skip('Failing with scylla')
     def test_can_register_udt_before_connecting(self):
         """
         Test the registration of UDTs before session creation
@@ -179,7 +177,6 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         c.shutdown()
 
-    @unittest.skip('Failing with scylla')
     def test_can_insert_prepared_unregistered_udts(self):
         """
         Test the insertion of prepared, unregistered UDTs
@@ -224,7 +221,6 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         c.shutdown()
 
-    @unittest.skip('Failing with scylla')
     def test_can_insert_prepared_registered_udts(self):
         """
         Test the insertion of prepared, registered UDTs
@@ -394,7 +390,6 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
         )
 
-    @unittest.skip('Failing with scylla')
     def test_can_insert_nested_registered_udts(self):
         """
         Test for ensuring nested registered udts are properly inserted
@@ -422,7 +417,6 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
             # insert udts and verify inserts with reads
             self.nested_udt_verification_helper(s, max_nesting_depth, udts)
 
-    @unittest.skip('Failing with scylla')
     def test_can_insert_nested_unregistered_udts(self):
         """
         Test for ensuring nested unregistered udts are properly inserted
@@ -459,7 +453,6 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
                 result = s.execute("SELECT v_{0} FROM mytable WHERE k=0".format(i))[0]
                 self.assertEqual(udt, result["v_{0}".format(i)])
 
-    @unittest.skip('Failing with scylla')
     def test_can_insert_nested_registered_udts_with_different_namedtuples(self):
         """
         Test for ensuring nested udts are inserted correctly when the
@@ -489,7 +482,6 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
             # insert udts and verify inserts with reads
             self.nested_udt_verification_helper(s, max_nesting_depth, udts)
 
-    @unittest.skip('Failing with scylla')
     def test_raise_error_on_nonexisting_udts(self):
         """
         Test for ensuring that an error is raised for operating on a nonexisting udt or an invalid keyspace
@@ -555,7 +547,6 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         c.shutdown()
 
-    @unittest.skip('Failing with scylla')
     def test_can_insert_udt_all_collection_datatypes(self):
         """
         Test for inserting various types of COLLECTION_TYPES into UDT's
@@ -672,7 +663,6 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         c.shutdown()
 
-    @unittest.skip('Failing with scylla')
     def test_non_alphanum_identifiers(self):
         """
         PYTHON-413


### PR DESCRIPTION
* Use `pytest.mark.cassandra` to not run test doesn't work on Scylla
* Fix the github action that runs tests/integration/standard tests
* Remove skip mark from tests are passed
* Remove skip from the test that needs at least protocol 5
