### PR TITLE
Improve cluster port handling

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1151,6 +1151,9 @@ class Cluster(object):
                 raise ValueError("Only numeric values are supported for port (%s)" % port)
             port = int(port)
 
+        if port < 1 or port > 65535:
+            raise ValueError("Invalid port number (%s) (1-65535)" % port)
+
         if connection_class is not None:
             self.connection_class = connection_class
 

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1144,6 +1144,13 @@ class Cluster(object):
 
         Any of the mutable Cluster attributes may be set as keyword arguments to the constructor.
         """
+
+        # Handle port passed as string
+        if isinstance(port, str):
+            if not port.isdigit():
+                raise ValueError("Only numeric values are supported for port (%s)" % port)
+            port = int(port)
+
         if connection_class is not None:
             self.connection_class = connection_class
 

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -121,6 +121,16 @@ class ClusterTest(unittest.TestCase):
         for n in (0, mn, 128):
             self.assertRaises(ValueError, c.set_max_requests_per_connection, d, n)
 
+    def test_port_str(self):
+        """Check port passed as tring is converted and checked properly"""
+        cluster = Cluster(contact_points=['127.0.0.1'], port='1111')
+        for cp in cluster.endpoints_resolved:
+            if cp.address in ('::1', '127.0.0.1'):
+                self.assertEqual(cp.port, 1111)
+
+        with self.assertRaises(ValueError):
+            cluster = Cluster(contact_points=['127.0.0.1'], port='string')
+
 
 class SchedulerTest(unittest.TestCase):
     # TODO: this suite could be expanded; for now just adding a test covering a ticket

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -132,6 +132,12 @@ class ClusterTest(unittest.TestCase):
             cluster = Cluster(contact_points=['127.0.0.1'], port='string')
 
 
+    def test_port_range(self):
+        for invalid_port in [0, 65536, -1]:
+            with self.assertRaises(ValueError):
+                cluster = Cluster(contact_points=['127.0.0.1'], port=invalid_port)
+
+
 class SchedulerTest(unittest.TestCase):
     # TODO: this suite could be expanded; for now just adding a test covering a ticket
 


### PR DESCRIPTION
With Scylla pytests we accidentally passed port number represented as str to the driver (as it was read from config). This works in establishing connections but fails later as endpoints are kept in a dict where the port part of the key is expected to be an integer.

This patch converts str port to string and does basic value checks.

Please run Python 2 tests before merging.