### PR TITLE
tests: fix test_bad_contact_point

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3921,6 +3921,8 @@ class ControlConnection(object):
             tokens = row.get("tokens", None)
             if partitioner and tokens and self._token_meta_enabled:
                 token_map[host] = tokens
+            self._cluster.metadata.update_host(host, old_endpoint=endpoint)
+
         for old_host_id, old_host in self._cluster.metadata.all_hosts_items():
             if old_host_id not in found_host_ids:
                 should_rebuild_token_map = True

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -41,6 +41,7 @@ from tests.integration import (get_cluster, use_singledc, PROTOCOL_VERSION, exec
                                greaterthanorequaldse67, lessthancass40,
                                TestCluster, DSE_VERSION)
 
+from tests.util import wait_until
 
 log = logging.getLogger(__name__)
 
@@ -124,7 +125,12 @@ class MetaDataRemovalTest(unittest.TestCase):
 
         @test_category metadata
         """
-        self.assertEqual(len(self.cluster.metadata.all_hosts()), 3)
+        # wait until we have only 3 hosts
+        wait_until(condition=lambda: len(self.cluster.metadata.all_hosts()) == 3, delay=0.5, max_attempts=5)
+
+        # verify the un-existing host was filtered
+        for host in self.cluster.metadata.all_hosts():
+            self.assertNotEquals(host.endpoint.address, '126.0.0.186')
 
 
 class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):


### PR DESCRIPTION
since recent changes to metadata, on first round we remove all
host that we creating with unkown host_ids, so this test is failing
cause it's expects all the corrent  hosts to be available in the,
metadata, they would be available, but not right away.

changed the test to check that the unwanted host isn't appering
and stop assuming anything about the number of host exacted to be available
in metadata