### PR TITLE
build: support for python 3.11 wheel

### DIFF
--- a/.github/workflows/build-experimental.yml
+++ b/.github/workflows/build-experimental.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.3.0
+          python -m pip install cibuildwheel==2.11.2
 
       - name: Build wheels
         run: |

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build_wheels:
     name: Build wheels ${{ matrix.os }} (${{ matrix.platform }})
-    if: contains(github.event.pull_request.labels.*.name, 'test-build') || github.event_name == 'push' && endsWith(github.event.ref, 'scylla')
+    if: "(!contains(github.event.pull_request.labels.*.name, 'disable-test-build')) || github.event_name == 'push' && endsWith(github.event.ref, 'scylla')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -121,7 +121,7 @@ jobs:
 
   build_sdist:
     name: Build source distribution
-    if: contains(github.event.pull_request.labels.*.name, 'test-build') || github.event_name == 'push' && endsWith(github.event.ref, 'scylla')
+    if: "(!contains(github.event.pull_request.labels.*.name, 'disable-test-build'))|| github.event_name == 'push' && endsWith(github.event.ref, 'scylla')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.3.0
+          python -m pip install cibuildwheel==2.11.2
 
       - name: Install OpenSSL for Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-20.04
-    if: contains(github.event.pull_request.labels.*.name, 'integration-tests')
+    if: "!contains(github.event.pull_request.labels.*.name, 'disable-integration-tests')"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/tests/unit/io/test_asyncioreactor.py
+++ b/tests/unit/io/test_asyncioreactor.py
@@ -3,7 +3,7 @@ try:
     from cassandra.io.asyncioreactor import AsyncioConnection
     import asynctest
     ASYNCIO_AVAILABLE = True
-except (ImportError, SyntaxError):
+except (ImportError, SyntaxError, AttributeError):
     AsyncioConnection = None
     ASYNCIO_AVAILABLE = False
 

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -1295,7 +1295,7 @@ class HostFilterPolicyInitTest(unittest.TestCase):
         ))
 
     def test_immutable_predicate(self):
-        expected_message_regex = "can't set attribute"
+        expected_message_regex = "can't set attribute|object has no setter"
         hfp = HostFilterPolicy(child_policy=Mock(name='child_policy'),
                                predicate=Mock(name='predicate'))
         with self.assertRaisesRegexp(AttributeError, expected_message_regex):


### PR DESCRIPTION
update to `cibuildwheel==2.11.2` to start producing python 3.11 wheels