### PR TITLE
scylla/cloud.py: support using ip address in server

### DIFF
--- a/cassandra/scylla/cloud.py
+++ b/cassandra/scylla/cloud.py
@@ -83,13 +83,12 @@ class CloudConfiguration:
         if username and password:
             self.auth_provider = PlainTextAuthProvider(username, password)
 
-
     @property
     def contact_points(self):
         _contact_points = []
         for data_center in self.data_centers.values():
-            address, _, _ = self.get_server(data_center)
-            _contact_points.append(self.endpoint_factory.create_from_sni(address))
+            _, _, node_domain = self.get_server(data_center)
+            _contact_points.append(self.endpoint_factory.create_from_sni(node_domain))
         return _contact_points
 
     def get_server(self, data_center):

--- a/cassandra/scylla/cloud.py
+++ b/cassandra/scylla/cloud.py
@@ -68,7 +68,7 @@ class CloudConfiguration:
         self.data_centers = cloud_config['datacenters']
         self.auth_info = cloud_config['authInfos'][self.current_context['authInfoName']]
         self.ssl_options = {}
-        self.skip_tls_verify = self.auth_info.get('insecureSkipTLSVerify', False)
+        self.skip_tls_verify = self.auth_info.get('insecureSkipTlsVerify', False)
         self.ssl_context = self.create_pyopenssl_context() if pyopenssl else self.create_ssl_context()
 
         proxy_address, port, node_domain = self.get_server(self.data_centers[self.current_context['datacenterName']])

--- a/cassandra/scylla/cloud.py
+++ b/cassandra/scylla/cloud.py
@@ -94,7 +94,7 @@ class CloudConfiguration:
     def get_server(self, data_center):
         address = data_center.get('server')
         address = address.split(":")
-        port = nth(address, 1, default=443)
+        port = nth(address, 1, default=9142)
         address = nth(address, 0)
         node_domain = data_center.get('nodeDomain')
         assert address and port and node_domain, "server or nodeDomain are missing"


### PR DESCRIPTION
Align with https://github.com/scylladb/gocql/pull/106, so:
When host information was missing, driver used resolved IP address as TLS.ServerName.
Instead it should connect to Server specified in ConnectionConfig and use NodeDomain as SNI.

Depends: https://github.com/scylladb/scylla-ccm/pull/412
Ref: https://github.com/scylladb/gocql/pull/106