### PR TITLE
metadata pagination: last page wasn't always handled

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1982,6 +1982,8 @@ class _SchemaParser(object):
                         elif not next_success:
                             raise next_result
                         if not next_result.paging_state:
+                            if next_result.parsed_rows:
+                                yield next_result.parsed_rows
                             break
                         yield next_result.parsed_rows
 


### PR DESCRIPTION
Seem like there was a bug in metadata pagination
that it was breaking on the notice no next page
while no yeilding the parsed rows of that last page

in most cases since the defaut of rows per page is 1000 that was enough, but in the case there were more keyspaces then that limit, some of the keyspaces were missed and it was failing the SCT test.

Fix: #174