### PR TITLE
deafult to disable_shardaware_port=False when using scylla_cloud

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1163,7 +1163,9 @@ class Cluster(object):
             if contact_points is not _NOT_SET or ssl_context or ssl_options:
                 raise ValueError("contact_points, ssl_context, and ssl_options "
                                  "cannot be specified with a scylla cloud configuration")
-
+            if shard_aware_options and not shard_aware_options.disable_shardaware_port:
+                raise ValueError("shard_aware_options.disable_shardaware_port=False "
+                                 "cannot be specified with a scylla cloud configuration")
             uses_twisted = TwistedConnection and issubclass(self.connection_class, TwistedConnection)
             uses_eventlet = EventletConnection and issubclass(self.connection_class, EventletConnection)
 
@@ -1174,6 +1176,7 @@ class Cluster(object):
             contact_points = scylla_cloud_config.contact_points
             ssl_options = scylla_cloud_config.ssl_options
             auth_provider = scylla_cloud_config.auth_provider
+            shard_aware_options = ShardAwareOptions(shard_aware_options, disable_shardaware_port=True)
 
         if cloud is not None:
             self.cloud = cloud


### PR DESCRIPTION
Since we are going to work via a loadbalancer, shardaware base on port can't work for us.

also if some would try to enable it via configuration, we'll fail like this:

```
Traceback (most recent call last):
  File "../python-driver/cloud_config.py", line 59, in <module>
    thread1()
  File "../python-driver/cloud_config.py", line 39, in thread1
    cluster = Cluster(scylla_cloud='../config_data.yaml', connect_timeout=60, control_connection_timeout=30,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "../python-driver/cassandra/cluster.py", line 1167, in __init__
    raise ValueError("shard_aware_options.disable_shardaware_port=False "
ValueError: shard_aware_options.disable_shardaware_port=False cannot be specified with a scylla cloud configuration
```

Fixes: scylladb/scylla-operator#1104