### PR TITLE
Update entrypoint and host_id only when `SniEndPointFactory` used

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3834,9 +3834,14 @@ class ControlConnection(object):
                 datacenter = local_row.get("data_center")
                 rack = local_row.get("rack")
                 self._update_location_info(host, datacenter, rack)
-                new_endpoint = self._cluster.endpoint_factory.create(local_row)
-                if new_endpoint.address:
-                    host.endpoint = new_endpoint
+
+                # support the use case of connecting only with public address
+                if isinstance(self._cluster.endpoint_factory, SniEndPointFactory):
+                    new_endpoint = self._cluster.endpoint_factory.create(local_row)
+
+                    if new_endpoint.address:
+                        host.endpoint = new_endpoint
+
                 host.host_id = local_row.get("host_id")
 
                 found_host_ids.add(host.host_id)


### PR DESCRIPTION
Since there are use cases when the user uses external address (i.e. not the node broadcast address), and not using `AddressTranslator`)

the assumption of the user is that it would be able to connect and use the control connection without creating any more connection to other nodes.

when we chnage the logic to work based on host_id, we decided to remove the initial control connection host, since it didn't had a correct host_name, which break this use case.

so for now we'll leave the removal only for case we are sure it's the expect thing to happen, i.e. when `SniEndPointFactory` is used.

Fix: #184

- [ ] add unit test to cover both cases (integration test would be a bit harder to implement) 