### PR TITLE
docs: add license notice on every page

### DIFF
--- a/docs/_templates/notice.html
+++ b/docs/_templates/notice.html
@@ -1,6 +1,6 @@
 <div class="notice">
 <p>
 ScyllaDB Python Driver is available under the <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache v2 License</a>.
-ScyllaDB Python Driver is a fork from <a href="https://github.com/datastax/python-driver">DataStax Python Driver</a>.
+ScyllaDB Python Driver is a fork of <a href="https://github.com/datastax/python-driver">DataStax Python Driver</a>.
 See Copyright <a href="https://python-driver.docs.scylladb.com/stable/#copyright">here</a>.</p>
 </div>

--- a/docs/_templates/notice.html
+++ b/docs/_templates/notice.html
@@ -1,4 +1,6 @@
 <div class="notice">
-<p>© 2013-2017 DataStax</p>
-<p>© 2016, The Apache Software Foundation. Apache®, Apache Cassandra®, Cassandra®, the Apache feather logo and the Apache Cassandra® Eye logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries. No endorsement by The Apache Software Foundation is implied by the use of these marks.</p>
+<p>
+ScyllaDB Python Driver is available under the <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache v2 License</a>.
+ScyllaDB Python Driver is a fork from <a href="https://github.com/datastax/python-driver">DataStax Python Driver</a>.
+See Copyright <a href="https://python-driver.docs.scylladb.com/stable/#copyright">here</a>.</p>
 </div>

--- a/docs/_templates/notice.html
+++ b/docs/_templates/notice.html
@@ -1,0 +1,4 @@
+<div class="notice">
+<p>© 2013-2017 DataStax</p>
+<p>© 2016, The Apache Software Foundation. Apache®, Apache Cassandra®, Cassandra®, the Apache feather logo and the Apache Cassandra® Eye logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries. No endorsement by The Apache Software Foundation is implied by the use of these marks.</p>
+</div>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,6 +93,7 @@ Reporting Issues
 
 Please report any bugs and make any feature requests on the `Github project issues <https://github.com/scylladb/python-driver/issues>`_
 
+
 Copyright
 ---------
 
@@ -100,3 +101,4 @@ Copyright
 
 © 2016, The Apache Software Foundation.
 Apache®, Apache Cassandra®, Cassandra®, the Apache feather logo and the Apache Cassandra® Eye logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries. No endorsement by The Apache Software Foundation is implied by the use of these marks.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,4 +101,3 @@ Copyright
 
 © 2016, The Apache Software Foundation.
 Apache®, Apache Cassandra®, Cassandra®, the Apache feather logo and the Apache Cassandra® Eye logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries. No endorsement by The Apache Software Foundation is implied by the use of these marks.
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,14 +92,3 @@ Reporting Issues
 ----------------
 
 Please report any bugs and make any feature requests on the `Github project issues <https://github.com/scylladb/python-driver/issues>`_
-
-
-Copyright
----------
-
-© 2013-2017 DataStax
-
-© 2016, The Apache Software Foundation.
-Apache®, Apache Cassandra®, Cassandra®, the Apache feather logo and the Apache Cassandra® Eye logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries. No endorsement by The Apache Software Foundation is implied by the use of these marks.
-
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,3 +92,11 @@ Reporting Issues
 ----------------
 
 Please report any bugs and make any feature requests on the `Github project issues <https://github.com/scylladb/python-driver/issues>`_
+
+Copyright
+---------
+
+© 2013-2017 DataStax
+
+© 2016, The Apache Software Foundation.
+Apache®, Apache Cassandra®, Cassandra®, the Apache feather logo and the Apache Cassandra® Eye logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries. No endorsement by The Apache Software Foundation is implied by the use of these marks.


### PR DESCRIPTION
Related issue: https://github.com/scylladb/sphinx-scylladb-theme/pull/611

## How to test this PR

1. Build the docs with `make preview`. 
1. Open http://127.0.0.1:5500
1. You should see the copyright notice after the prev / next navigation buttons on every page:

![image](https://user-images.githubusercontent.com/9107969/204584278-513deb43-b065-4334-8703-59dbabfe17f1.png)

