### PR TITLE
Fix race condition in use keyspace

### DIFF
--- a/.github/workflows/integration-tests-python2.yml
+++ b/.github/workflows/integration-tests-python2.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
      - master
+  push:
+    branches:
+      - master
 
 jobs:
   tests:

--- a/.github/workflows/integration-tests-python2.yml
+++ b/.github/workflows/integration-tests-python2.yml
@@ -21,5 +21,5 @@ jobs:
 
     - name: Test with pytest
       run: |
-        ./ci/run_integration_test.sh tests/integration/standard/test_authentication.py tests/integration/standard/test_cluster.py tests/integration/standard/test_concurrent.py tests/integration/standard/test_connection.py tests/integration/standard/test_control_connection.py tests/integration/standard/test_custom_payload.py tests/integration/standard/test_custom_protocol_handler.py tests/integration/standard/test_cython_protocol_handlers.py tests/integration/standard/test_scylla_cloud.py
+        ./ci/run_integration_test.sh tests/integration/standard/test_authentication.py tests/integration/standard/test_cluster.py tests/integration/standard/test_concurrent.py tests/integration/standard/test_connection.py tests/integration/standard/test_control_connection.py tests/integration/standard/test_custom_payload.py tests/integration/standard/test_custom_protocol_handler.py tests/integration/standard/test_cython_protocol_handlers.py tests/integration/standard/test_scylla_cloud.py tests/integration/standard/test_use_keyspace.py
         # can't run this, cause only 2 cpus on github actions: tests/integration/standard/test_shard_aware.py

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches:
      - master
-
+  push:
+    branches:
+      - master
 
 jobs:
   tests:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,5 +21,5 @@ jobs:
 
     - name: Test with pytest
       run: |
-        ./ci/run_integration_test.sh tests/integration/standard/test_authentication.py tests/integration/standard/test_cluster.py tests/integration/standard/test_concurrent.py tests/integration/standard/test_connection.py tests/integration/standard/test_control_connection.py tests/integration/standard/test_custom_payload.py tests/integration/standard/test_custom_protocol_handler.py tests/integration/standard/test_cython_protocol_handlers.py tests/integration/standard/test_scylla_cloud.py
+        ./ci/run_integration_test.sh tests/integration/standard/test_authentication.py tests/integration/standard/test_cluster.py tests/integration/standard/test_concurrent.py tests/integration/standard/test_connection.py tests/integration/standard/test_control_connection.py tests/integration/standard/test_custom_payload.py tests/integration/standard/test_custom_protocol_handler.py tests/integration/standard/test_cython_protocol_handlers.py tests/integration/standard/test_scylla_cloud.py tests/integration/standard/test_use_keyspace.py
         # can't run this, cause only 2 cpus on github actions: tests/integration/standard/test_shard_aware.py

--- a/.github/workflows/test-python2.yaml
+++ b/.github/workflows/test-python2.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Test on python2
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build source/wheel distribution for python2
     if: "(!contains(github.event.pull_request.labels.*.name, 'disable-test-build'))|| github.event_name == 'push' && endsWith(github.event.ref, 'scylla')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -41,7 +41,7 @@ jobs:
 
   upload_pypi:
     needs: [build, test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && endsWith(github.event.ref, 'scylla')
     # alternatively, to publish when a GitHub Release is created, use the following rule:

--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -739,6 +739,9 @@ class HostConnection(object):
                         conn.shard_id,
                         self.host
                     )
+                if self._keyspace:
+                    conn.set_keyspace_blocking(self._keyspace)
+
                 self._connections[conn.shard_id] = conn
             if old_conn is not None:
                 remaining = old_conn.in_flight - len(old_conn.orphaned_request_ids)
@@ -763,13 +766,6 @@ class HostConnection(object):
                             old_conn.close()
                         else:
                             self._trash.add(old_conn)
-            if self._keyspace:
-                with self._lock:
-                    if self.is_shutdown:
-                        conn.close()
-                    old_conn = self._connections.get(conn.shard_id)
-                    if old_conn:
-                        old_conn.set_keyspace_blocking(self._keyspace)
             num_missing_or_needing_replacement = self.num_missing_or_needing_replacement
             log.debug(
                 "Connected to %s/%i shards on host %s (%i missing or needs replacement)",

--- a/tests/integration/standard/test_use_keyspace.py
+++ b/tests/integration/standard/test_use_keyspace.py
@@ -1,0 +1,71 @@
+import os
+import time
+import random
+from subprocess import run
+import logging
+
+try:
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+except ImportError:
+    from futures import ThreadPoolExecutor, as_completed  # noqa
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest  # noqa
+
+from mock import patch
+
+from cassandra.connection import Connection
+from cassandra.cluster import Cluster
+from cassandra.policies import TokenAwarePolicy, RoundRobinPolicy, ConstantReconnectionPolicy
+from cassandra import OperationTimedOut, ConsistencyLevel
+
+from tests.integration import use_cluster, get_node, PROTOCOL_VERSION
+
+LOGGER = logging.getLogger(__name__)
+
+def setup_module():
+    os.environ['SCYLLA_EXT_OPTS'] = "--smp 2 --memory 2048M"
+    use_cluster('shared_aware', [3], start=True)
+
+
+
+class TestUseKeyspace(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.cluster = Cluster(contact_points=["127.0.0.1"], protocol_version=PROTOCOL_VERSION,
+                              load_balancing_policy=TokenAwarePolicy(RoundRobinPolicy()),
+                              reconnection_policy=ConstantReconnectionPolicy(1))
+        cls.session = cls.cluster.connect()
+        LOGGER.info(cls.cluster.is_shard_aware())
+        LOGGER.info(cls.cluster.shard_aware_stats())
+    @classmethod
+    def teardown_class(cls):
+        cls.cluster.shutdown()
+    
+    def test_set_keyspace_slow_connection(self):
+        # Test that "USE keyspace" gets propagated
+        # to all connections.
+        #
+        # Reproduces an issue #187 where some pending
+        # connections for shards would not 
+        # receive "USE keyspace".
+        #
+        # Simulate that scenario by adding an artifical
+        # delay before sending "USE keyspace" on
+        # connections.
+
+        original_set_keyspace_blocking = Connection.set_keyspace_blocking
+        def patched_set_keyspace_blocking(*args, **kwargs):
+            time.sleep(1)
+            return original_set_keyspace_blocking(*args, **kwargs)
+
+        with patch.object(Connection, "set_keyspace_blocking", patched_set_keyspace_blocking):
+            self.session.execute("CREATE KEYSPACE test_set_keyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+            self.session.execute("CREATE TABLE test_set_keyspace.set_keyspace_slow_connection(pk int, PRIMARY KEY(pk))")
+
+            session2 = self.cluster.connect()
+            session2.execute("USE test_set_keyspace")
+            for i in range(200):
+                session2.execute(f"SELECT * FROM set_keyspace_slow_connection WHERE pk = 1")


### PR DESCRIPTION
This PR fixes a race condition in "USE keyspace" handling that was causing some connections to be used before the command was applied - which resulted in exceptions being thrown.