### PR TITLE
Fix wait_for_schema_agreement deadlock

### DIFF
--- a/tests/unit/test_control_connection.py
+++ b/tests/unit/test_control_connection.py
@@ -512,13 +512,13 @@ class ControlConnectionTest(unittest.TestCase):
             }
             self.cluster.scheduler.reset_mock()
             self.control_connection._handle_schema_change(event)
-            self.cluster.scheduler.schedule_unique.assert_called_once_with(ANY, self.control_connection.refresh_schema, **event)
+            self.cluster.scheduler.schedule_unique.assert_called_once_with(ANY, self.control_connection._refresh_schema_async, ANY, **event)
 
             self.cluster.scheduler.reset_mock()
             event['target_type'] = SchemaTargetType.KEYSPACE
             del event['table']
             self.control_connection._handle_schema_change(event)
-            self.cluster.scheduler.schedule_unique.assert_called_once_with(ANY, self.control_connection.refresh_schema, **event)
+            self.cluster.scheduler.schedule_unique.assert_called_once_with(ANY, self.control_connection._refresh_schema_async, ANY, **event)
 
     def test_refresh_disabled(self):
         cluster = MockCluster()
@@ -566,7 +566,7 @@ class ControlConnectionTest(unittest.TestCase):
         cc_no_topo_refresh._handle_status_change(status_event)
         cc_no_topo_refresh._handle_schema_change(schema_event)
         cluster.scheduler.schedule_unique.assert_has_calls([call(ANY, cc_no_topo_refresh.refresh_node_list_and_token_map),
-                                                            call(0.0, cc_no_topo_refresh.refresh_schema,
+                                                            call(0.0, cc_no_topo_refresh._refresh_schema_async, ANY,
                                                                  **schema_event)])
 
     def test_refresh_nodes_and_tokens_add_host_detects_port(self):


### PR DESCRIPTION
Fixes #168 
Fix works by creating a new version of wait_for_schema_agreement, called _wait_for_schema_agreement_async that schedules new task for each iteration of loop, instead of sleeping. That way, thread executor can run other functions instead of being stuck with wait_for_schema_agreement, allowing on_down notification to be handled and node registered as down, which in turn allows for schema agreement wait to finish.

Yes, this is not pretty, but I don't see any pretty way to fix this.

Before fix (mostly taken from the issue description):
1. The driver has control_connection established to node A
2. We kill a node B forcefully
3. Then we immediately schedule a schema change on A
4. A sends a notification to the driver
5. The driver schedules wait_for_schema_agreement tasks in the executor
6. Wait_for_schema_agreement gets stuck because A has a different schema version than B and B is considered up by the driver
7. Eventually, A notices that B is down and delivers a notification to the driver
8. The driver submits the on_down task, but there are no available threads in the pool, so we don't set is_up = False for B
9. wait_for_schema_agreeement never finishes. on_down is never executed. We've deadlocked.

After the fix:
1. The driver has control_connection established to node A
2. We kill a node B forcefully
3. Then we immediately schedule a schema change on A
4. A sends a notification to the driver
5. The driver starts _wait_for_schema_agreement_async
6. _wait_for_schema_agreement_async::inner() is executed in an interval. It continues to be scheduled because A has a different schema version than B and B is considered up by the driver, so it can't finish.
7. Eventually, A notices that B is down and delivers a notification to the driver
8. The driver submits the on_down task.
9. The task is executed by the thread pool. is_up = False is set for B.
9. _wait_for_schema_agreement_async::inner() ceases to be scheduled, callback is called.