### PR TITLE
Fix CI failures

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,7 +9,7 @@ twisted[tls]; python_version >= '3.5' or python_version < '3.0'
 twisted[tls]==19.2.1; python_version < '3.5' and python_version >= '3.0'
 gevent>=1.0; platform_machine != 'i686' and platform_machine != 'win32'
 gevent==20.5.0; platform_machine == 'i686' or platform_machine == 'win32'
-eventlet
+eventlet>=0.33.3
 cython>=0.20,<0.30 ; python_version > '3.0'
 cython==0.23.1 ;  python_version < '3.0'
 packaging


### PR DESCRIPTION
CI was failing because of this error:
https://github.com/eventlet/eventlet/issues/781
This commit applies the recommended fix - moving to eventlet>=0.33.3