### PR TITLE
Fix test logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ docs/poetry.lock
 tests/integration/ccm
 setuptools*.tar.gz
 setuptools*.egg
+venv/
 
 cassandra/*.c
 !cassandra/cmurmur3.c

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+log_format = %(asctime)s.%(msecs)03d %(levelname)s [%(module)s:%(lineno)s]: %(message)s
+log_level = DEBUG
+log_date_format = %Y-%m-%d %H:%M:%S

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,13 +21,6 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 
 log = logging.getLogger()
-log.setLevel('DEBUG')
-# if nose didn't already attach a log handler, add one here
-if not log.handlers:
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s [%(module)s:%(lineno)s]: %(message)s'))
-    log.addHandler(handler)
-
 
 def is_eventlet_monkey_patched():
     if 'eventlet.patcher' not in sys.modules:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -896,7 +896,7 @@ class MockLoggingHandler(logging.Handler):
         return self
 
     def __exit__(self, *args):
-        pass
+        self.logger.removeHandler(self)
 
 
 class BasicExistingKeyspaceUnitTestCase(BasicKeyspaceUnitTestCase):

--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -360,18 +360,15 @@ class InconsistentTable(BaseCassEngTestCase):
 
         @test_category object_mapper
         """
-        mock_handler = MockLoggingHandler()
-        logger = logging.getLogger(management.__name__)
-        logger.addHandler(mock_handler)
-        sync_table(BaseInconsistent)
-        sync_table(ChangedInconsistent)
-        self.assertTrue('differing from the model type' in mock_handler.messages.get('warning')[0])
-        if CASSANDRA_VERSION >= Version('2.1'):
-            sync_type(DEFAULT_KEYSPACE, BaseInconsistentType)
-            mock_handler.reset()
-            sync_type(DEFAULT_KEYSPACE, ChangedInconsistentType)
-            self.assertTrue('differing from the model user type' in mock_handler.messages.get('warning')[0])
-        logger.removeHandler(mock_handler)
+        with MockLoggingHandler().set_module_name(management.__name__) as mock_handler:
+            sync_table(BaseInconsistent)
+            sync_table(ChangedInconsistent)
+            self.assertTrue('differing from the model type' in mock_handler.messages.get('warning')[0])
+            if CASSANDRA_VERSION >= Version('2.1'):
+                sync_type(DEFAULT_KEYSPACE, BaseInconsistentType)
+                mock_handler.reset()
+                sync_type(DEFAULT_KEYSPACE, ChangedInconsistentType)
+                self.assertTrue('differing from the model user type' in mock_handler.messages.get('warning')[0])
 
 
 class TestIndexSetModel(Model):

--- a/tests/integration/upgrade/__init__.py
+++ b/tests/integration/upgrade/__init__.py
@@ -78,6 +78,10 @@ class UpgradeBase(unittest.TestCase):
         cls.logger_handler = MockLoggingHandler()
         logger = logging.getLogger(cluster.__name__)
         logger.addHandler(cls.logger_handler)
+    
+    @classmethod
+    def tearDownClass(cls):
+        logger.removeHandler(cls.logger_handler)
 
     def _upgrade_step_setup(self):
         """


### PR DESCRIPTION
This PR fixes some problems with logging in tests.
The biggest one was this code in `tests/__init__.py`:
```
log.setLevel('DEBUG')
# if nose didn't already attach a log handler, add one here
if not log.handlers:
    handler = logging.StreamHandler()
    handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s [%(module)s:%(lineno)s]: %(message)s'))
    log.addHandler(handler)
```

It caused:
1. Errors while logging in atexit handlers (which cluster.py does)
2. Each log to be duplicated.

Commit [tests: Don't add StreamHandler to logger](https://github.com/scylladb/python-driver/commit/9d2e684d0bcba3e22d17c9c1d151e1409c1a6708) removes this code and instead adds `pytest.ini` to fix those problems.

Output of one of integration tests before: https://gist.github.com/Lorak-mmk/4b9b8ef2125522462d03f4551fdec290
and after: https://gist.github.com/Lorak-mmk/59345562b29c76860671c8916d3a1826
Differences: no duplication of log entries, no errors at the end of the log.

Last commit fixes minor issues: some mock log handlers that were added were not always removed.