### PR TITLE
Fix cqlengine tests

### DIFF
--- a/.github/workflows/integration-tests-python2.yml
+++ b/.github/workflows/integration-tests-python2.yml
@@ -21,5 +21,5 @@ jobs:
 
     - name: Test with pytest
       run: |
-        ./ci/run_integration_test.sh tests/integration/standard/test_authentication.py tests/integration/standard/test_cluster.py tests/integration/standard/test_concurrent.py tests/integration/standard/test_connection.py tests/integration/standard/test_control_connection.py tests/integration/standard/test_custom_payload.py tests/integration/standard/test_custom_protocol_handler.py tests/integration/standard/test_cython_protocol_handlers.py tests/integration/standard/test_scylla_cloud.py tests/integration/standard/test_use_keyspace.py tests/integration/standard/test_ip_change.py
+        ./ci/run_integration_test.sh tests/integration/standard/test_authentication.py tests/integration/standard/test_cluster.py tests/integration/standard/test_concurrent.py tests/integration/standard/test_connection.py tests/integration/standard/test_control_connection.py tests/integration/standard/test_custom_payload.py tests/integration/standard/test_custom_protocol_handler.py tests/integration/standard/test_cython_protocol_handlers.py tests/integration/standard/test_scylla_cloud.py tests/integration/standard/test_use_keyspace.py tests/integration/standard/test_ip_change.py tests/integration/cqlengine/
         # can't run this, cause only 2 cpus on github actions: tests/integration/standard/test_shard_aware.py

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,5 +21,5 @@ jobs:
 
     - name: Test with pytest
       run: |
-        ./ci/run_integration_test.sh tests/integration/standard/test_authentication.py tests/integration/standard/test_cluster.py tests/integration/standard/test_concurrent.py tests/integration/standard/test_connection.py tests/integration/standard/test_control_connection.py tests/integration/standard/test_custom_payload.py tests/integration/standard/test_custom_protocol_handler.py tests/integration/standard/test_cython_protocol_handlers.py tests/integration/standard/test_scylla_cloud.py tests/integration/standard/test_use_keyspace.py tests/integration/standard/test_ip_change.py 
+        ./ci/run_integration_test.sh tests/integration/standard/test_authentication.py tests/integration/standard/test_cluster.py tests/integration/standard/test_concurrent.py tests/integration/standard/test_connection.py tests/integration/standard/test_control_connection.py tests/integration/standard/test_custom_payload.py tests/integration/standard/test_custom_protocol_handler.py tests/integration/standard/test_cython_protocol_handlers.py tests/integration/standard/test_scylla_cloud.py tests/integration/standard/test_use_keyspace.py tests/integration/standard/test_ip_change.py tests/integration/cqlengine/
         # can't run this, cause only 2 cpus on github actions: tests/integration/standard/test_shard_aware.py

--- a/cassandra/cqlengine/management.py
+++ b/cassandra/cqlengine/management.py
@@ -483,9 +483,17 @@ def _update_options(model, connection=None):
         else:
             try:
                 for k, v in value.items():
-                    if existing_value[k] != v:
-                        update_options[name] = value
-                        break
+                    # When creating table with compaction 'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy' in Scylla,
+                    # it will be silently changed to 'class': 'LeveledCompactionStrategy' - same for at least SizeTieredCompactionStrategy,
+                    # probably others too. We need to handle this case here.
+                    if k == 'class' and name == 'compaction':
+                        if existing_value[k] != v and existing_value[k] != v.split('.')[-1]:
+                            update_options[name] = value
+                            break
+                    else:
+                        if existing_value[k] != v:
+                            update_options[name] = value
+                            break
             except KeyError:
                 update_options[name] = value
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -337,6 +337,7 @@ notprotocolv1 = unittest.skipUnless(PROTOCOL_VERSION > 1, 'Protocol v1 not suppo
 lessthenprotocolv4 = unittest.skipUnless(PROTOCOL_VERSION < 4, 'Protocol versions 4 or greater not supported')
 greaterthanprotocolv3 = unittest.skipUnless(PROTOCOL_VERSION >= 4, 'Protocol versions less than 4 are not supported')
 protocolv6 = unittest.skipUnless(6 in get_supported_protocol_versions(), 'Protocol versions less than 6 are not supported')
+
 greaterthancass20 = unittest.skipUnless(CASSANDRA_VERSION >= Version('2.1'), 'Cassandra version 2.1 or greater required')
 greaterthancass21 = unittest.skipUnless(CASSANDRA_VERSION >= Version('2.2'), 'Cassandra version 2.2 or greater required')
 greaterthanorequalcass30 = unittest.skipUnless(CASSANDRA_VERSION >= Version('3.0'), 'Cassandra version 3.0 or greater required')
@@ -348,6 +349,7 @@ greaterthanorequalcass40 = unittest.skipUnless(CASSANDRA_VERSION >= Version('4.0
 lessthanorequalcass40 = unittest.skipUnless(CASSANDRA_VERSION <= Version('4.0-a'), 'Cassandra version less or equal to 4.0 required')
 lessthancass40 = unittest.skipUnless(CASSANDRA_VERSION < Version('4.0-a'), 'Cassandra version less than 4.0 required')
 lessthancass30 = unittest.skipUnless(CASSANDRA_VERSION < Version('3.0'), 'Cassandra version less then 3.0 required')
+
 greaterthanorequaldse68 = unittest.skipUnless(DSE_VERSION and DSE_VERSION >= Version('6.8'), "DSE 6.8 or greater required for this test")
 greaterthanorequaldse67 = unittest.skipUnless(DSE_VERSION and DSE_VERSION >= Version('6.7'), "DSE 6.7 or greater required for this test")
 greaterthanorequaldse60 = unittest.skipUnless(DSE_VERSION and DSE_VERSION >= Version('6.0'), "DSE 6.0 or greater required for this test")
@@ -355,6 +357,8 @@ greaterthanorequaldse51 = unittest.skipUnless(DSE_VERSION and DSE_VERSION >= Ver
 greaterthanorequaldse50 = unittest.skipUnless(DSE_VERSION and DSE_VERSION >= Version('5.0'), "DSE 5.0 or greater required for this test")
 lessthandse51 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('5.1'), "DSE version less than 5.1 required")
 lessthandse60 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('6.0'), "DSE version less than 6.0 required")
+
+requirescollectionindexes = unittest.skipUnless(SCYLLA_VERSION is None or Version(SCYLLA_VERSION.split(':')[1]) >= Version('5.2'), 'Test requires Scylla >= 5.2 or Cassandra')
 
 pypy = unittest.skipUnless(platform.python_implementation() == "PyPy", "Test is skipped unless it's on PyPy")
 notpy3 = unittest.skipIf(sys.version_info >= (3, 0), "Test not applicable for Python 3.x runtime")

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -359,6 +359,7 @@ lessthandse51 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('5.1')
 lessthandse60 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('6.0'), "DSE version less than 6.0 required")
 
 requirescollectionindexes = unittest.skipUnless(SCYLLA_VERSION is None or Version(SCYLLA_VERSION.split(':')[1]) >= Version('5.2'), 'Test requires Scylla >= 5.2 or Cassandra')
+requirescustomindexes = unittest.skipUnless(SCYLLA_VERSION is None, 'Currently, Scylla does not support SASI or any other CUSTOM INDEX class.')
 
 pypy = unittest.skipUnless(platform.python_implementation() == "PyPy", "Test is skipped unless it's on PyPy")
 notpy3 = unittest.skipIf(sys.version_info >= (3, 0), "Test not applicable for Python 3.x runtime")

--- a/tests/integration/cqlengine/__init__.py
+++ b/tests/integration/cqlengine/__init__.py
@@ -13,34 +13,18 @@
 # limitations under the License.
 
 import os
-import warnings
 import unittest
 from cassandra import ConsistencyLevel
 
 from cassandra.cqlengine import connection
-from cassandra.cqlengine.management import create_keyspace_simple, drop_keyspace, CQLENG_ALLOW_SCHEMA_MANAGEMENT
 import cassandra
 
-from tests.integration import get_server_versions, use_single_node, PROTOCOL_VERSION, CASSANDRA_IP, ALLOW_BETA_PROTOCOL
+from tests.integration import get_server_versions, PROTOCOL_VERSION, CASSANDRA_IP, ALLOW_BETA_PROTOCOL
 
 DEFAULT_KEYSPACE = 'cqlengine_test'
 
 
 CQL_SKIP_EXECUTE = bool(os.getenv('CQL_SKIP_EXECUTE', False))
-
-
-def setup_package():
-    warnings.simplefilter('always')  # for testing warnings, make sure all are let through
-    os.environ[CQLENG_ALLOW_SCHEMA_MANAGEMENT] = '1'
-
-    use_single_node()
-
-    setup_connection(DEFAULT_KEYSPACE)
-    create_keyspace_simple(DEFAULT_KEYSPACE, 1)
-
-
-def teardown_package():
-    connection.unregister_connection("default")
 
 def is_prepend_reversed():
     # do we have https://issues.apache.org/jira/browse/CASSANDRA-8733 ?

--- a/tests/integration/cqlengine/conftest.py
+++ b/tests/integration/cqlengine/conftest.py
@@ -1,0 +1,54 @@
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+import os
+
+import pytest
+
+from cassandra.cqlengine import connection
+from cassandra.cqlengine.management import create_keyspace_simple, drop_keyspace, CQLENG_ALLOW_SCHEMA_MANAGEMENT
+from tests.integration import use_single_node
+
+from . import setup_connection, DEFAULT_KEYSPACE
+
+
+@pytest.fixture(scope='package', autouse=True)
+def cqlengine_fixture():
+    warnings.simplefilter('always')  # for testing warnings, make sure all are let through
+    os.environ[CQLENG_ALLOW_SCHEMA_MANAGEMENT] = '1'
+
+    use_single_node()
+
+    setup_connection(DEFAULT_KEYSPACE)
+    create_keyspace_simple(DEFAULT_KEYSPACE, 1)
+
+    yield
+
+    drop_keyspace(DEFAULT_KEYSPACE)
+    connection.unregister_connection("default")

--- a/tests/integration/cqlengine/management/test_compaction_settings.py
+++ b/tests/integration/cqlengine/management/test_compaction_settings.py
@@ -118,8 +118,16 @@ class OptionsTest(BaseCassEngTestCase):
                 for subname, subvalue in value.items():
                     attr = "'%s': '%s'" % (subname, subvalue)
                     found_at = cql.find(attr, start)
-                    self.assertTrue(found_at > start)
-                    self.assertTrue(found_at < end)
+                    # When creating table with compaction 'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy' in Scylla,
+                    # it will be silently changed to 'class': 'LeveledCompactionStrategy' - same for at least SizeTieredCompactionStrategy,
+                    # probably others too. We need to handle this case here.
+                    if found_at == -1 and name == 'compaction' and subname == 'class':
+                        attr = "'%s': '%s'" % (subname, subvalue.split('.')[-1])
+                        found_at = cql.find(attr, start)
+                    else:
+                        
+                        self.assertTrue(found_at > start)
+                        self.assertTrue(found_at < end)
 
     def test_all_size_tiered_options(self):
         class AllSizeTieredOptionsModel(Model):

--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -23,7 +23,7 @@ from cassandra.cqlengine.management import _get_table_metadata, sync_table, drop
 from cassandra.cqlengine.models import Model
 from cassandra.cqlengine import columns
 
-from tests.integration import DSE_VERSION, PROTOCOL_VERSION, greaterthancass20, MockLoggingHandler, CASSANDRA_VERSION
+from tests.integration import DSE_VERSION, PROTOCOL_VERSION, greaterthancass20, requirescollectionindexes, MockLoggingHandler, CASSANDRA_VERSION
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine.query.test_queryset import TestModel
 from cassandra.cqlengine.usertype import UserType
@@ -426,6 +426,7 @@ class IndexTests(BaseCassEngTestCase):
         self.assertIsNotNone(management._get_index_name_by_column(table_meta, 'second_key'))
 
     @greaterthancass20
+    @requirescollectionindexes
     def test_sync_indexed_set(self):
         """
         Tests that models that have container types with indices can be synced.

--- a/tests/integration/cqlengine/query/test_named.py
+++ b/tests/integration/cqlengine/query/test_named.py
@@ -27,7 +27,7 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine.query.test_queryset import BaseQuerySetUsage
 
 
-from tests.integration import BasicSharedKeyspaceUnitTestCase, greaterthanorequalcass30
+from tests.integration import BasicSharedKeyspaceUnitTestCase, greaterthanorequalcass30, requirescollectionindexes
 
 
 class TestQuerySetOperation(BaseCassEngTestCase):
@@ -118,7 +118,7 @@ class TestQuerySetOperation(BaseCassEngTestCase):
         self.assertIsInstance(where.operator, GreaterThanOrEqualOperator)
         self.assertEqual(where.value, 1)
 
-
+@requirescollectionindexes
 class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
 
     @classmethod

--- a/tests/integration/cqlengine/query/test_queryset.py
+++ b/tests/integration/cqlengine/query/test_queryset.py
@@ -39,7 +39,7 @@ from cassandra.cqlengine import operators
 from cassandra.util import uuid_from_time
 from cassandra.cqlengine.connection import get_session
 from tests.integration import PROTOCOL_VERSION, CASSANDRA_VERSION, greaterthancass20, greaterthancass21, \
-    greaterthanorequalcass30, TestCluster
+    greaterthanorequalcass30, TestCluster, requirescollectionindexes
 from tests.integration.cqlengine import execute_count, DEFAULT_KEYSPACE
 
 
@@ -384,7 +384,7 @@ class BaseQuerySetUsage(BaseCassEngTestCase):
         drop_table(CustomIndexedTestModel)
         drop_table(TestMultiClusteringModel)
 
-
+@requirescollectionindexes
 class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
 
     @execute_count(2)
@@ -558,7 +558,7 @@ def test_non_quality_filtering():
     num = qa.count()
     assert num == 1, num
 
-
+@requirescollectionindexes
 class TestQuerySetDistinct(BaseQuerySetUsage):
 
     @execute_count(1)
@@ -597,6 +597,7 @@ class TestQuerySetDistinct(BaseQuerySetUsage):
         self.assertEqual(q.count(), 2)
 
 
+@requirescollectionindexes
 class TestQuerySetOrdering(BaseQuerySetUsage):
     @execute_count(2)
     def test_order_by_success_case(self):
@@ -645,6 +646,7 @@ class TestQuerySetOrdering(BaseQuerySetUsage):
         assert [r.three for r in results] == [1, 2, 3, 4, 5]
 
 
+@requirescollectionindexes
 class TestQuerySetSlicing(BaseQuerySetUsage):
 
     @execute_count(1)
@@ -699,6 +701,7 @@ class TestQuerySetSlicing(BaseQuerySetUsage):
             self.assertEqual(model.attempt_id, expect)
 
 
+@requirescollectionindexes
 class TestQuerySetValidation(BaseQuerySetUsage):
 
     def test_primary_key_or_index_must_be_specified(self):
@@ -780,6 +783,7 @@ class TestQuerySetValidation(BaseQuerySetUsage):
         list(CustomIndexedTestModel.objects.filter(test_id=1, description='test'))
 
 
+@requirescollectionindexes
 class TestQuerySetDelete(BaseQuerySetUsage):
 
     @execute_count(9)
@@ -938,6 +942,7 @@ class TestMinMaxTimeUUIDFunctions(BaseCassEngTestCase):
         assert '4' in datas
 
 
+@requirescollectionindexes
 class TestInOperator(BaseQuerySetUsage):
     @execute_count(1)
     def test_kwarg_success_case(self):
@@ -998,6 +1003,7 @@ class TestInOperator(BaseQuerySetUsage):
 
 
 @greaterthancass20
+@requirescollectionindexes
 class TestContainsOperator(BaseQuerySetUsage):
 
     @execute_count(6)
@@ -1063,6 +1069,7 @@ class TestContainsOperator(BaseQuerySetUsage):
             self.assertEqual(q.count(), 0)
 
 
+@requirescollectionindexes
 class TestValuesList(BaseQuerySetUsage):
 
     @execute_count(2)
@@ -1075,6 +1082,7 @@ class TestValuesList(BaseQuerySetUsage):
         assert item == 10
 
 
+@requirescollectionindexes
 class TestObjectsProperty(BaseQuerySetUsage):
     @execute_count(1)
     def test_objects_property_returns_fresh_queryset(self):
@@ -1105,6 +1113,7 @@ class PageQueryTests(BaseCassEngTestCase):
         assert len(results) == 2
 
 
+@requirescollectionindexes
 class ModelQuerySetTimeoutTestCase(BaseQuerySetUsage):
     def test_default_timeout(self):
         with mock.patch.object(Session, 'execute') as mock_execute:
@@ -1122,6 +1131,7 @@ class ModelQuerySetTimeoutTestCase(BaseQuerySetUsage):
             self.assertEqual(mock_execute.call_args[-1]['timeout'], None)
 
 
+@requirescollectionindexes
 class DMLQueryTimeoutTestCase(BaseQuerySetUsage):
     def setUp(self):
         self.model = TestModel(test_id=1, attempt_id=1, description='timeout test')

--- a/tests/integration/cqlengine/statements/test_base_statement.py
+++ b/tests/integration/cqlengine/statements/test_base_statement.py
@@ -26,7 +26,7 @@ from cassandra.cqlengine.columns import Column
 
 from tests.integration.cqlengine.base import BaseCassEngTestCase, TestQueryUpdateModel
 from tests.integration.cqlengine import DEFAULT_KEYSPACE
-from tests.integration import greaterthanorequalcass3_10, TestCluster
+from tests.integration import greaterthanorequalcass3_10, requirescustomindexes, TestCluster
 
 from cassandra.cqlengine.connection import execute
 
@@ -102,6 +102,7 @@ class ExecuteStatementTest(BaseCassEngTestCase):
         self.assertEqual(TestQueryUpdateModel.objects.count(), 0)
 
     @greaterthanorequalcass3_10
+    @requirescustomindexes
     def test_like_operator(self):
         """
         Test to verify the like operator works appropriately

--- a/tests/integration/cqlengine/test_batch_query.py
+++ b/tests/integration/cqlengine/test_batch_query.py
@@ -218,6 +218,7 @@ class BatchQueryCallbacksTests(BaseCassEngTestCase):
             call_history.append(args)
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             with BatchQuery() as batch:
                 batch.add_callback(my_callback)
                 batch.execute()
@@ -243,6 +244,7 @@ class BatchQueryCallbacksTests(BaseCassEngTestCase):
 
         with patch('cassandra.cqlengine.query.BatchQuery.warn_multiple_exec', False):
             with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
                 with BatchQuery() as batch:
                     batch.add_callback(my_callback)
                     batch.execute()

--- a/tests/integration/cqlengine/test_ifexists.py
+++ b/tests/integration/cqlengine/test_ifexists.py
@@ -105,17 +105,13 @@ class IfExistsUpdateTests(BaseIfExistsTest):
         with self.assertRaises(LWTException) as assertion:
             m.if_exists().update()
 
-        self.assertEqual(assertion.exception.existing, {
-            '[applied]': False,
-        })
+        self.assertEqual(assertion.exception.existing.get('[applied]'), False)
 
         # queryset update
         with self.assertRaises(LWTException) as assertion:
             TestIfExistsModel.objects(id=uuid4()).if_exists().update(count=8)
 
-        self.assertEqual(assertion.exception.existing, {
-            '[applied]': False,
-        })
+        self.assertEqual(assertion.exception.existing.get('[applied]'), False)
 
     @unittest.skipUnless(PROTOCOL_VERSION >= 2, "only runs against the cql3 protocol v2.0")
     def test_batch_update_if_exists_success(self):
@@ -142,9 +138,7 @@ class IfExistsUpdateTests(BaseIfExistsTest):
                 m = TestIfExistsModel(id=uuid4(), count=42)  # Doesn't exist
                 m.batch(b).if_exists().update()
 
-        self.assertEqual(assertion.exception.existing, {
-            '[applied]': False,
-        })
+        self.assertEqual(assertion.exception.existing.get('[applied]'), False)
 
         q = TestIfExistsModel.objects(id=id)
         self.assertEqual(len(q), 1)
@@ -198,17 +192,13 @@ class IfExistsUpdateTests(BaseIfExistsTest):
         with self.assertRaises(LWTException) as assertion:
             m.if_exists().delete()
 
-        self.assertEqual(assertion.exception.existing, {
-            '[applied]': False,
-        })
+        self.assertEqual(assertion.exception.existing.get('[applied]'), False)
 
         # queryset delete
         with self.assertRaises(LWTException) as assertion:
             TestIfExistsModel.objects(id=uuid4()).if_exists().delete()
 
-        self.assertEqual(assertion.exception.existing, {
-            '[applied]': False,
-        })
+        self.assertEqual(assertion.exception.existing.get('[applied]'), False)
 
     @unittest.skipUnless(PROTOCOL_VERSION >= 2, "only runs against the cql3 protocol v2.0")
     def test_batch_delete_if_exists_success(self):
@@ -237,9 +227,7 @@ class IfExistsUpdateTests(BaseIfExistsTest):
                 m = TestIfExistsModel(id=uuid4(), count=42)  # Doesn't exist
                 m.batch(b).if_exists().delete()
 
-        self.assertEqual(assertion.exception.existing, {
-            '[applied]': False,
-        })
+        self.assertEqual(assertion.exception.existing.get('[applied]'), False)
 
     @unittest.skipUnless(PROTOCOL_VERSION >= 2, "only runs against the cql3 protocol v2.0")
     def test_batch_delete_mixed(self):


### PR DESCRIPTION
This gets us a step closed to fixing tests (see https://github.com/scylladb/python-driver/issues/207 for reference).

This PR fixes (or skips) all the tests in tests/integration/cqlengine and enables them in CI.
Changes are divided into commits - see commit messages and changes to learn about individual fixes.