### PR TITLE
Fix ScyllaCloudConfigTests that was failing with missing argument

### DIFF
--- a/tests/integration/standard/test_scylla_cloud.py
+++ b/tests/integration/standard/test_scylla_cloud.py
@@ -46,7 +46,8 @@ class ScyllaCloudConfigTests(TestCase):
         ccm_cluster._update_config()
 
         config_data_yaml, config_path_yaml = create_cloud_config(ccm_cluster.get_path(),
-                                                                 port=listen_port, address=listen_address)
+                                                                 port=listen_port, address=listen_address,
+                                                                 nodes_info=nodes_info)
         return config_data_yaml, config_path_yaml
 
     def test_1_node_cluster(self):


### PR DESCRIPTION
scylladb/scylla-ccm#441 introduced a change to a function signiture, and the test was failing since it wasn't passing down the node_info parameter.

Ref: https://github.com/scylladb/scylla-ccm/pull/441