### PR TITLE
test_cluster.py::ClusterTests::test_idle_heartbeat: Fix failing test

### DIFF
--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -24,6 +24,7 @@ from uuid import uuid4
 import logging
 import warnings
 from packaging.version import Version
+import os
 
 import cassandra
 from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT, ControlConnection, Cluster
@@ -50,6 +51,7 @@ log = logging.getLogger(__name__)
 
 
 def setup_module():
+    os.environ['SCYLLA_EXT_OPTS'] = "--smp 1"
     use_singledc()
     warnings.simplefilter("always")
 


### PR DESCRIPTION
Recently ccm changed default smp from 1 to 2. This caused 1 of integration tests to fail.
The problem is, if I understand correctly, that `cluster.connect(wait_for_all_pools=True)` doesn't wait for all connections to be estabilished - so additional connections are opened during the test, causing it to fail.

The best fix would be to wait for all connection, but I don't see any method doing that - if I missed any please let me know.
Instead, this PR manually specifies SMP to fix the failure. 