### PR TITLE
Enable tests/integration/standard

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,5 +21,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        ./ci/run_integration_test.sh tests/integration/standard/test_authentication.py tests/integration/standard/test_cluster.py tests/integration/standard/test_concurrent.py tests/integration/standard/test_connection.py tests/integration/standard/test_control_connection.py tests/integration/standard/test_custom_payload.py tests/integration/standard/test_custom_protocol_handler.py tests/integration/standard/test_cython_protocol_handlers.py tests/integration/standard/test_scylla_cloud.py tests/integration/standard/test_use_keyspace.py tests/integration/standard/test_ip_change.py tests/integration/cqlengine/
-        # can't run this, cause only 2 cpus on github actions: tests/integration/standard/test_shard_aware.py
+        ./ci/run_integration_test.sh tests/integration/standard/ tests/integration/cqlengine/

--- a/ci/run_integration_test.sh
+++ b/ci/run_integration_test.sh
@@ -23,7 +23,7 @@ pip install -U pip wheel setuptools
 
 # install driver wheel
 pip install --ignore-installed -r test-requirements.txt pytest
-pip install .
+pip install -e .
 
 # download awscli
 pip install awscli

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 log_format = %(asctime)s.%(msecs)03d %(levelname)s [%(module)s:%(lineno)s]: %(message)s
 log_level = DEBUG
 log_date_format = %Y-%m-%d %H:%M:%S
+xfail_strict=true

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -366,8 +366,8 @@ greaterthanorequaldse50 = unittest.skipUnless(DSE_VERSION and DSE_VERSION >= Ver
 lessthandse51 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('5.1'), "DSE version less than 5.1 required")
 lessthandse60 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('6.0'), "DSE version less than 6.0 required")
 
-requirescollectionindexes = unittest.skipUnless(SCYLLA_VERSION is None or Version(SCYLLA_VERSION.split(':')[1]) >= Version('5.2'), 'Test requires Scylla >= 5.2 or Cassandra')
-requirescustomindexes = unittest.skipUnless(SCYLLA_VERSION is None, 'Currently, Scylla does not support SASI or any other CUSTOM INDEX class.')
+requires_collection_indexes = unittest.skipUnless(SCYLLA_VERSION is None or Version(SCYLLA_VERSION.split(':')[1]) >= Version('5.2'), 'Test requires Scylla >= 5.2 or Cassandra')
+requires_custom_indexes = unittest.skipUnless(SCYLLA_VERSION is None, 'Currently, Scylla does not support SASI or any other CUSTOM INDEX class.')
 
 pypy = unittest.skipUnless(platform.python_implementation() == "PyPy", "Test is skipped unless it's on PyPy")
 notpy3 = unittest.skipIf(sys.version_info >= (3, 0), "Test not applicable for Python 3.x runtime")

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -344,6 +344,7 @@ def local_decorator_creator():
 local = local_decorator_creator()
 notprotocolv1 = unittest.skipUnless(PROTOCOL_VERSION > 1, 'Protocol v1 not supported')
 lessthenprotocolv4 = unittest.skipUnless(PROTOCOL_VERSION < 4, 'Protocol versions 4 or greater not supported')
+lessthanprotocolv3 = unittest.skipUnless(PROTOCOL_VERSION < 3, 'Protocol versions 3 or greater not supported')
 greaterthanprotocolv3 = unittest.skipUnless(PROTOCOL_VERSION >= 4, 'Protocol versions less than 4 are not supported')
 protocolv6 = unittest.skipUnless(6 in get_supported_protocol_versions(), 'Protocol versions less than 6 are not supported')
 
@@ -375,6 +376,14 @@ requires_collection_indexes = pytest.mark.xfail(SCYLLA_VERSION is not None and V
                                               reason='Scylla supports collection indexes from 5.2 onwards') 
 requires_custom_indexes = pytest.mark.xfail(SCYLLA_VERSION is not None, 
                                           reason='Scylla does not support SASI or any other CUSTOM INDEX class')
+requires_java_udf = pytest.mark.xfail(SCYLLA_VERSION is not None,
+                                    reason='Scylla does not support UDFs written in Java')
+requires_composite_type = pytest.mark.xfail(SCYLLA_VERSION is not None,
+                                            reason='Scylla does not support composite types')
+requires_custom_payload = pytest.mark.xfail(SCYLLA_VERSION is not None or PROTOCOL_VERSION < 4,
+                                            reason='Scylla does not support custom payloads. Cassandra requires native protocol v4.0+')
+xfail_scylla = lambda reason, *args, **kwargs: pytest.mark.xfail(SCYLLA_VERSION is not None, reason=reason, *args, **kwargs)
+incorrect_test = lambda reason='This test seems to be incorrect and should be fixed', *args, **kwargs: pytest.mark.xfail(reason=reason, *args, **kwargs)
 
 pypy = unittest.skipUnless(platform.python_implementation() == "PyPy", "Test is skipped unless it's on PyPy")
 notpy3 = unittest.skipIf(sys.version_info >= (3, 0), "Test not applicable for Python 3.x runtime")

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -34,6 +34,7 @@ from subprocess import call
 from itertools import groupby
 import six
 import shutil
+import pytest
 
 
 from cassandra import OperationTimedOut, ReadTimeout, ReadFailure, WriteTimeout, WriteFailure, AlreadyExists,\
@@ -366,8 +367,14 @@ greaterthanorequaldse50 = unittest.skipUnless(DSE_VERSION and DSE_VERSION >= Ver
 lessthandse51 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('5.1'), "DSE version less than 5.1 required")
 lessthandse60 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('6.0'), "DSE version less than 6.0 required")
 
-requires_collection_indexes = unittest.skipUnless(SCYLLA_VERSION is None or Version(SCYLLA_VERSION.split(':')[1]) >= Version('5.2'), 'Test requires Scylla >= 5.2 or Cassandra')
-requires_custom_indexes = unittest.skipUnless(SCYLLA_VERSION is None, 'Currently, Scylla does not support SASI or any other CUSTOM INDEX class.')
+# pytest.mark.xfail instead of unittest.expectedFailure because
+# 1. unittest doesn't skip setUpClass when used on class and we need it sometimes
+# 2. unittest doesn't have conditional xfail, and I prefer to use pytest than custom decorator
+# 3. unittest doesn't have a reason argument, so you don't see the reason in pytest report
+requires_collection_indexes = pytest.mark.xfail(SCYLLA_VERSION is not None and Version(SCYLLA_VERSION.split(':')[1]) < Version('5.2'),
+                                              reason='Scylla supports collection indexes from 5.2 onwards') 
+requires_custom_indexes = pytest.mark.xfail(SCYLLA_VERSION is not None, 
+                                          reason='Scylla does not support SASI or any other CUSTOM INDEX class')
 
 pypy = unittest.skipUnless(platform.python_implementation() == "PyPy", "Test is skipped unless it's on PyPy")
 notpy3 = unittest.skipIf(sys.version_info >= (3, 0), "Test not applicable for Python 3.x runtime")

--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -24,7 +24,7 @@ from cassandra.cqlengine.management import _get_table_metadata, sync_table, drop
 from cassandra.cqlengine.models import Model
 from cassandra.cqlengine import columns
 
-from tests.integration import DSE_VERSION, PROTOCOL_VERSION, greaterthancass20, requirescollectionindexes, MockLoggingHandler, CASSANDRA_VERSION
+from tests.integration import DSE_VERSION, PROTOCOL_VERSION, greaterthancass20, requires_collection_indexes, MockLoggingHandler, CASSANDRA_VERSION
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine.query.test_queryset import TestModel
 from cassandra.cqlengine.usertype import UserType
@@ -427,7 +427,7 @@ class IndexTests(BaseCassEngTestCase):
         self.assertIsNotNone(management._get_index_name_by_column(table_meta, 'second_key'))
 
     @greaterthancass20
-    @requirescollectionindexes
+    @requires_collection_indexes
     def test_sync_indexed_set(self):
         """
         Tests that models that have container types with indices can be synced.

--- a/tests/integration/cqlengine/query/test_named.py
+++ b/tests/integration/cqlengine/query/test_named.py
@@ -27,7 +27,7 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine.query.test_queryset import BaseQuerySetUsage
 
 
-from tests.integration import BasicSharedKeyspaceUnitTestCase, greaterthanorequalcass30, requirescollectionindexes
+from tests.integration import BasicSharedKeyspaceUnitTestCase, greaterthanorequalcass30, requires_collection_indexes
 
 
 class TestQuerySetOperation(BaseCassEngTestCase):
@@ -118,7 +118,7 @@ class TestQuerySetOperation(BaseCassEngTestCase):
         self.assertIsInstance(where.operator, GreaterThanOrEqualOperator)
         self.assertEqual(where.value, 1)
 
-@requirescollectionindexes
+@requires_collection_indexes
 class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
 
     @classmethod

--- a/tests/integration/cqlengine/query/test_queryset.py
+++ b/tests/integration/cqlengine/query/test_queryset.py
@@ -39,7 +39,7 @@ from cassandra.cqlengine import operators
 from cassandra.util import uuid_from_time
 from cassandra.cqlengine.connection import get_session
 from tests.integration import PROTOCOL_VERSION, CASSANDRA_VERSION, greaterthancass20, greaterthancass21, \
-    greaterthanorequalcass30, TestCluster, requirescollectionindexes
+    greaterthanorequalcass30, TestCluster, requires_collection_indexes
 from tests.integration.cqlengine import execute_count, DEFAULT_KEYSPACE
 
 
@@ -384,7 +384,7 @@ class BaseQuerySetUsage(BaseCassEngTestCase):
         drop_table(CustomIndexedTestModel)
         drop_table(TestMultiClusteringModel)
 
-@requirescollectionindexes
+@requires_collection_indexes
 class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
 
     @execute_count(2)
@@ -558,7 +558,7 @@ def test_non_quality_filtering():
     num = qa.count()
     assert num == 1, num
 
-@requirescollectionindexes
+@requires_collection_indexes
 class TestQuerySetDistinct(BaseQuerySetUsage):
 
     @execute_count(1)
@@ -597,7 +597,7 @@ class TestQuerySetDistinct(BaseQuerySetUsage):
         self.assertEqual(q.count(), 2)
 
 
-@requirescollectionindexes
+@requires_collection_indexes
 class TestQuerySetOrdering(BaseQuerySetUsage):
     @execute_count(2)
     def test_order_by_success_case(self):
@@ -646,7 +646,7 @@ class TestQuerySetOrdering(BaseQuerySetUsage):
         assert [r.three for r in results] == [1, 2, 3, 4, 5]
 
 
-@requirescollectionindexes
+@requires_collection_indexes
 class TestQuerySetSlicing(BaseQuerySetUsage):
 
     @execute_count(1)
@@ -701,7 +701,7 @@ class TestQuerySetSlicing(BaseQuerySetUsage):
             self.assertEqual(model.attempt_id, expect)
 
 
-@requirescollectionindexes
+@requires_collection_indexes
 class TestQuerySetValidation(BaseQuerySetUsage):
 
     def test_primary_key_or_index_must_be_specified(self):
@@ -783,7 +783,7 @@ class TestQuerySetValidation(BaseQuerySetUsage):
         list(CustomIndexedTestModel.objects.filter(test_id=1, description='test'))
 
 
-@requirescollectionindexes
+@requires_collection_indexes
 class TestQuerySetDelete(BaseQuerySetUsage):
 
     @execute_count(9)
@@ -942,7 +942,7 @@ class TestMinMaxTimeUUIDFunctions(BaseCassEngTestCase):
         assert '4' in datas
 
 
-@requirescollectionindexes
+@requires_collection_indexes
 class TestInOperator(BaseQuerySetUsage):
     @execute_count(1)
     def test_kwarg_success_case(self):
@@ -1003,7 +1003,7 @@ class TestInOperator(BaseQuerySetUsage):
 
 
 @greaterthancass20
-@requirescollectionindexes
+@requires_collection_indexes
 class TestContainsOperator(BaseQuerySetUsage):
 
     @execute_count(6)
@@ -1069,7 +1069,7 @@ class TestContainsOperator(BaseQuerySetUsage):
             self.assertEqual(q.count(), 0)
 
 
-@requirescollectionindexes
+@requires_collection_indexes
 class TestValuesList(BaseQuerySetUsage):
 
     @execute_count(2)
@@ -1082,7 +1082,7 @@ class TestValuesList(BaseQuerySetUsage):
         assert item == 10
 
 
-@requirescollectionindexes
+@requires_collection_indexes
 class TestObjectsProperty(BaseQuerySetUsage):
     @execute_count(1)
     def test_objects_property_returns_fresh_queryset(self):
@@ -1113,7 +1113,7 @@ class PageQueryTests(BaseCassEngTestCase):
         assert len(results) == 2
 
 
-@requirescollectionindexes
+@requires_collection_indexes
 class ModelQuerySetTimeoutTestCase(BaseQuerySetUsage):
     def test_default_timeout(self):
         with mock.patch.object(Session, 'execute') as mock_execute:
@@ -1131,7 +1131,7 @@ class ModelQuerySetTimeoutTestCase(BaseQuerySetUsage):
             self.assertEqual(mock_execute.call_args[-1]['timeout'], None)
 
 
-@requirescollectionindexes
+@requires_collection_indexes
 class DMLQueryTimeoutTestCase(BaseQuerySetUsage):
     def setUp(self):
         self.model = TestModel(test_id=1, attempt_id=1, description='timeout test')

--- a/tests/integration/cqlengine/statements/test_base_statement.py
+++ b/tests/integration/cqlengine/statements/test_base_statement.py
@@ -26,7 +26,7 @@ from cassandra.cqlengine.columns import Column
 
 from tests.integration.cqlengine.base import BaseCassEngTestCase, TestQueryUpdateModel
 from tests.integration.cqlengine import DEFAULT_KEYSPACE
-from tests.integration import greaterthanorequalcass3_10, requirescustomindexes, TestCluster
+from tests.integration import greaterthanorequalcass3_10, requires_custom_indexes, TestCluster
 
 from cassandra.cqlengine.connection import execute
 
@@ -102,7 +102,7 @@ class ExecuteStatementTest(BaseCassEngTestCase):
         self.assertEqual(TestQueryUpdateModel.objects.count(), 0)
 
     @greaterthanorequalcass3_10
-    @requirescustomindexes
+    @requires_custom_indexes
     def test_like_operator(self):
         """
         Test to verify the like operator works appropriately

--- a/tests/integration/standard/test_authentication_misconfiguration.py
+++ b/tests/integration/standard/test_authentication_misconfiguration.py
@@ -19,12 +19,6 @@ from tests.integration import USE_CASS_EXTERNAL, use_cluster, TestCluster
 
 class MisconfiguredAuthenticationTests(unittest.TestCase):
     """ One node (not the contact point) has password auth. The rest of the nodes have no auth """
-    # TODO: 	Fix ccm to apply following options to scylla.yaml
-    # 	node3.set_configuration_options(values={
-    # 	'authenticator': 'PasswordAuthenticator',
-    # 	'authorizer': 'CassandraAuthorizer',
-    # 	})
-    # To make it working for scylla
     @classmethod
     def setUpClass(cls):
         if not USE_CASS_EXTERNAL:
@@ -38,7 +32,6 @@ class MisconfiguredAuthenticationTests(unittest.TestCase):
 
             cls.ccm_cluster = ccm_cluster
 
-    @unittest.expectedFailure
     def test_connect_no_auth_provider(self):
         cluster = TestCluster()
         cluster.connect()

--- a/tests/integration/standard/test_client_warnings.py
+++ b/tests/integration/standard/test_client_warnings.py
@@ -18,7 +18,8 @@ import unittest
 import six
 from cassandra.query import BatchStatement
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, local, TestCluster
+from tests.integration import (use_singledc, PROTOCOL_VERSION, local, TestCluster,
+                               requires_custom_payload, xfail_scylla)
 
 
 def setup_module():
@@ -27,7 +28,7 @@ def setup_module():
 
 # Failing with scylla because there is no warning message when changing the value of 'batch_size_warn_threshold_in_kb'
 # config")
-@unittest.expectedFailure
+@xfail_scylla('Empty warnings: TypeError: object of type \'NoneType\' has no len()')
 class ClientWarningTests(unittest.TestCase):
 
     @classmethod
@@ -94,6 +95,7 @@ class ClientWarningTests(unittest.TestCase):
         self.assertIsNotNone(future.get_query_trace())
 
     @local
+    @requires_custom_payload
     def test_warning_with_custom_payload(self):
         """
         Test to validate client warning with custom payload
@@ -113,6 +115,7 @@ class ClientWarningTests(unittest.TestCase):
         self.assertDictEqual(future.custom_payload, payload)
 
     @local
+    @requires_custom_payload
     def test_warning_with_trace_and_custom_payload(self):
         """
         Test to validate client warning with tracing and client warning

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -40,7 +40,7 @@ from cassandra import connection
 from cassandra.connection import DefaultEndPoint
 
 from tests import notwindows
-from tests.integration import use_singledc, get_server_versions, CASSANDRA_VERSION, \
+from tests.integration import use_cluster, get_server_versions, CASSANDRA_VERSION, \
     execute_until_pass, execute_with_long_wait_retry, get_node, MockLoggingHandler, get_unsupported_lower_protocol, \
     get_unsupported_upper_protocol, lessthanprotocolv3, protocolv6, local, CASSANDRA_IP, greaterthanorequalcass30, \
     lessthanorequalcass40, DSE_VERSION, TestCluster, PROTOCOL_VERSION, xfail_scylla, incorrect_test
@@ -52,7 +52,7 @@ log = logging.getLogger(__name__)
 
 def setup_module():
     os.environ['SCYLLA_EXT_OPTS'] = "--smp 1"
-    use_singledc()
+    use_cluster("cluster_tests", [3], start=True, workloads=None)
     warnings.simplefilter("always")
 
 

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -42,8 +42,8 @@ from cassandra.connection import DefaultEndPoint
 from tests import notwindows
 from tests.integration import use_singledc, get_server_versions, CASSANDRA_VERSION, \
     execute_until_pass, execute_with_long_wait_retry, get_node, MockLoggingHandler, get_unsupported_lower_protocol, \
-    get_unsupported_upper_protocol, protocolv6, local, CASSANDRA_IP, greaterthanorequalcass30, lessthanorequalcass40, \
-    DSE_VERSION, TestCluster, PROTOCOL_VERSION
+    get_unsupported_upper_protocol, lessthanprotocolv3, protocolv6, local, CASSANDRA_IP, greaterthanorequalcass30, \
+    lessthanorequalcass40, DSE_VERSION, TestCluster, PROTOCOL_VERSION, xfail_scylla, incorrect_test
 from tests.integration.util import assert_quiescent_pool_state
 import sys
 
@@ -289,8 +289,7 @@ class ClusterTests(unittest.TestCase):
 
         cluster.shutdown()
 
-    # "Failing with scylla because there is option to create a cluster with 'lower bound' protocol
-    @unittest.expectedFailure
+    @xfail_scylla("Failing with scylla because there is option to create a cluster with 'lower bound' protocol")
     def test_invalid_protocol_negotation(self):
         """
         Test for protocol negotiation when explicit versions are set
@@ -411,12 +410,11 @@ class ClusterTests(unittest.TestCase):
                               protocol_version=PROTOCOL_VERSION)
         self.assertRaises(NoHostAvailable, cluster.connect)
 
+    @lessthanprotocolv3
     def test_cluster_settings(self):
         """
         Test connection setting getters and setters
         """
-        if PROTOCOL_VERSION >= 3:
-            raise unittest.SkipTest("min/max requests and core/max conns aren't used with v3 protocol")
 
         cluster = TestCluster()
 
@@ -1228,8 +1226,7 @@ class ClusterTests(unittest.TestCase):
 
     @greaterthanorequalcass30
     @lessthanorequalcass40
-    # The scylla failed because 'Unknown identifier column1'
-    @unittest.expectedFailure
+    @incorrect_test()
     def test_compact_option(self):
         """
         Test the driver can connect with the no_compact option and the results

--- a/tests/integration/standard/test_custom_cluster.py
+++ b/tests/integration/standard/test_custom_cluster.py
@@ -30,7 +30,7 @@ def setup_module():
     # wait until all nodes are up
     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
-    wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.3'], port=9046).connect().shutdown(), 1, 20)
+    wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.3'], port=9046).connect().shutdown(), 1, 120)
 
 
 def teardown_module():

--- a/tests/integration/standard/test_custom_payload.py
+++ b/tests/integration/standard/test_custom_payload.py
@@ -19,7 +19,8 @@ import six
 
 from cassandra.query import (SimpleStatement, BatchStatement, BatchType)
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, local, TestCluster
+from tests.integration import (use_singledc, PROTOCOL_VERSION, local, TestCluster,
+                              requires_custom_payload)
 
 
 def setup_module():
@@ -28,13 +29,10 @@ def setup_module():
 #These test rely on the custom payload being returned but by default C*
 #ignores all the payloads.
 @local
+@requires_custom_payload
 class CustomPayloadTests(unittest.TestCase):
 
     def setUp(self):
-        if PROTOCOL_VERSION < 4:
-            raise unittest.SkipTest(
-                "Native protocol 4,0+ is required for custom payloads, currently using %r"
-                % (PROTOCOL_VERSION,))
         self.cluster = TestCluster()
         self.session = self.cluster.connect()
 
@@ -43,7 +41,6 @@ class CustomPayloadTests(unittest.TestCase):
         self.cluster.shutdown()
 
     # Scylla error: 'truncated frame: expected 65540 bytes, length is 64'
-    @unittest.expectedFailure
     def test_custom_query_basic(self):
         """
         Test to validate that custom payloads work with simple queries
@@ -67,7 +64,6 @@ class CustomPayloadTests(unittest.TestCase):
         self.validate_various_custom_payloads(statement=statement)
 
     # Scylla error: 'Invalid query kind in BATCH messages. Must be 0 or 1 but got 4'"
-    @unittest.expectedFailure
     def test_custom_query_batching(self):
         """
         Test to validate that custom payloads work with batch queries
@@ -94,7 +90,6 @@ class CustomPayloadTests(unittest.TestCase):
 
     # Scylla error: 'Got different query ID in server response (b'\x00') than we had before
     # (b'\x84P\xd0K0\xe2=\x11\xba\x02\x16W\xfatN\xf1')'")
-    @unittest.expectedFailure
     def test_custom_query_prepared(self):
         """
         Test to validate that custom payloads work with prepared queries

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -23,6 +23,7 @@ import time
 import os
 from packaging.version import Version
 from mock import Mock, patch
+import pytest
 
 from cassandra import AlreadyExists, SignatureDescriptor, UserFunctionDescriptor, UserAggregateDescriptor
 
@@ -1209,7 +1210,7 @@ CREATE TABLE export_udts.users (
         cluster.shutdown()
 
     @greaterthancass21
-    @unittest.expectedFailure
+    @pytest.mark.xfail(reason='Column name in CREATE INDEX is not quoted. It\'s a bug in driver or in Scylla')
     def test_case_sensitivity(self):
         """
         Test that names that need to be escaped in CREATE statements are
@@ -1279,7 +1280,7 @@ CREATE TABLE export_udts.users (
         cluster.shutdown()
 
     @local
-    @unittest.expectedFailure
+    @pytest.mark.xfail(reason='AssertionError: \'RAC1\' != \'r1\' - probably a bug in driver or in Scylla')
     def test_replicas(self):
         """
         Ensure cluster.metadata.get_replicas return correctly when not attached to keyspace

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -39,7 +39,8 @@ from tests.integration import (get_cluster, use_singledc, PROTOCOL_VERSION, exec
                                get_supported_protocol_versions, greaterthancass20,
                                greaterthancass21, assert_startswith, greaterthanorequalcass40,
                                greaterthanorequaldse67, lessthancass40,
-                               TestCluster, DSE_VERSION)
+                               TestCluster, DSE_VERSION, requires_java_udf, requires_composite_type,
+                               requires_collection_indexes, xfail_scylla)
 
 from tests.util import wait_until
 
@@ -474,7 +475,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         tablemeta = self.get_table_metadata()
         self.check_create_statement(tablemeta, create_statement)
 
-    @unittest.expectedFailure
+    @xfail_scylla('https://github.com/scylladb/scylladb/issues/6058')
     def test_indexes(self):
         create_statement = self.make_create_statement(["a"], ["b", "c"], ["d", "e", "f"])
         create_statement += " WITH CLUSTERING ORDER BY (b ASC, c ASC)"
@@ -500,7 +501,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.assertIn('CREATE INDEX e_index', statement)
 
     @greaterthancass21
-    @unittest.expectedFailure
+    @requires_collection_indexes
     def test_collection_indexes(self):
 
         self.session.execute("CREATE TABLE %s.%s (a int PRIMARY KEY, b map<text, text>)"
@@ -530,7 +531,8 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
             tablemeta = self.get_table_metadata()
             self.assertIn('(full(b))', tablemeta.export_as_string())
 
-    @unittest.expectedFailure
+    #TODO: Fix Scylla or test
+    @xfail_scylla('Scylla prints `compression = {}` instead of `compression = {\'enabled\': \'false\'}`.')
     def test_compression_disabled(self):
         create_statement = self.make_create_statement(["a"], ["b"], ["c"])
         create_statement += " WITH compression = {}"
@@ -565,7 +567,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
             self.assertNotIn("min_threshold", cql)
             self.assertNotIn("max_threshold", cql)
 
-    @unittest.expectedFailure
+    @requires_java_udf
     def test_refresh_schema_metadata(self):
         """
         test for synchronously refreshing all cluster metadata
@@ -838,7 +840,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
             self.assertEqual(cluster.metadata.keyspaces[self.keyspace_name].user_types, {})
             cluster.shutdown()
 
-    @unittest.expectedFailure
+    @requires_java_udf
     def test_refresh_user_function_metadata(self):
         """
         test for synchronously refreshing UDF metadata in keyspace
@@ -875,7 +877,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         cluster2.shutdown()
 
-    @unittest.expectedFailure
+    @requires_java_udf
     def test_refresh_user_aggregate_metadata(self):
         """
         test for synchronously refreshing UDA metadata in keyspace
@@ -919,7 +921,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         cluster2.shutdown()
 
     @greaterthanorequalcass30
-    @unittest.expectedFailure
+    @requires_collection_indexes
     def test_multiple_indices(self):
         """
         test multiple indices on the same column.
@@ -1544,7 +1546,7 @@ class FunctionTest(unittest.TestCase):
             super(FunctionTest.VerifiedAggregate, self).__init__(test_case, Aggregate, test_case.keyspace_aggregate_meta, **kwargs)
 
 
-@unittest.expectedFailure
+@requires_java_udf
 class FunctionMetadata(FunctionTest):
 
     def make_function_kwargs(self, called_on_null=True):
@@ -1699,6 +1701,7 @@ class FunctionMetadata(FunctionTest):
             self.assertRegex(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) RETURNS NULL ON NULL INPUT RETURNS .*")
 
 
+@requires_java_udf
 class AggregateMetadata(FunctionTest):
 
     @classmethod
@@ -1743,7 +1746,6 @@ class AggregateMetadata(FunctionTest):
                 'return_type': "does not matter for creation",
                 'deterministic': False}
 
-    @unittest.expectedFailure
     def test_return_type_meta(self):
         """
         Test to verify to that the return type of a an aggregate is honored in the metadata
@@ -1761,7 +1763,6 @@ class AggregateMetadata(FunctionTest):
         with self.VerifiedAggregate(self, **self.make_aggregate_kwargs('sum_int', 'int', init_cond='1')) as va:
             self.assertEqual(self.keyspace_aggregate_meta[va.signature].return_type, 'int')
 
-    @unittest.expectedFailure
     def test_init_cond(self):
         """
         Test to verify that various initial conditions are correctly surfaced in various aggregate functions
@@ -1812,7 +1813,6 @@ class AggregateMetadata(FunctionTest):
                 self.assertDictContainsSubset(init_not_updated, map_res)
         c.shutdown()
 
-    @unittest.expectedFailure
     def test_aggregates_after_functions(self):
         """
         Test to verify that aggregates are listed after function in metadata
@@ -1835,7 +1835,6 @@ class AggregateMetadata(FunctionTest):
             self.assertNotIn(-1, (aggregate_idx, func_idx), "AGGREGATE or FUNCTION not found in keyspace_cql: " + keyspace_cql)
             self.assertGreater(aggregate_idx, func_idx)
 
-    @unittest.expectedFailure
     def test_same_name_diff_types(self):
         """
         Test to verify to that aggregates with different signatures are differentiated in metadata
@@ -1858,7 +1857,6 @@ class AggregateMetadata(FunctionTest):
                 self.assertEqual(len(aggregates), 2)
                 self.assertNotEqual(aggregates[0].argument_types, aggregates[1].argument_types)
 
-    @unittest.expectedFailure
     def test_aggregates_follow_keyspace_alter(self):
         """
         Test to verify to that aggregates maintain equality after a keyspace is altered
@@ -1883,7 +1881,6 @@ class AggregateMetadata(FunctionTest):
             finally:
                 self.session.execute('ALTER KEYSPACE %s WITH durable_writes = true' % self.keyspace_name)
 
-    @unittest.expectedFailure
     def test_cql_optional_params(self):
         """
         Test to verify that the initial_cond and final_func parameters are correctly honored
@@ -2018,7 +2015,7 @@ class BadMetaTest(unittest.TestCase):
             self.assertIn("/*\nWarning:", m.export_as_string())
 
     @greaterthancass21
-    @unittest.expectedFailure
+    @requires_java_udf
     def test_bad_user_function(self):
         self.session.execute("""CREATE FUNCTION IF NOT EXISTS %s (key int, val int)
                                 RETURNS NULL ON NULL INPUT
@@ -2037,7 +2034,7 @@ class BadMetaTest(unittest.TestCase):
                 self.assertIn("/*\nWarning:", m.export_as_string())
 
     @greaterthancass21
-    @unittest.expectedFailure
+    @requires_java_udf
     def test_bad_user_aggregate(self):
         self.session.execute("""CREATE FUNCTION IF NOT EXISTS sum_int (key int, val int)
                                 RETURNS NULL ON NULL INPUT
@@ -2058,7 +2055,7 @@ class BadMetaTest(unittest.TestCase):
 
 class DynamicCompositeTypeTest(BasicSharedKeyspaceUnitTestCase):
 
-    @unittest.expectedFailure
+    @requires_composite_type
     def test_dct_alias(self):
         """
         Tests to make sure DCT's have correct string formatting

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -25,7 +25,7 @@ from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DE
 from cassandra.policies import HostDistance, RoundRobinPolicy, WhiteListRoundRobinPolicy
 from tests.integration import use_singledc, PROTOCOL_VERSION, BasicSharedKeyspaceUnitTestCase, \
     greaterthanprotocolv3, MockLoggingHandler, get_supported_protocol_versions, local, get_cluster, setup_keyspace, \
-    USE_CASS_EXTERNAL, greaterthanorequalcass40, DSE_VERSION, TestCluster, requirecassandra
+    USE_CASS_EXTERNAL, greaterthanorequalcass40, DSE_VERSION, TestCluster, requirecassandra, xfail_scylla
 from tests import notwindows
 from tests.integration import greaterthanorequalcass30, get_node
 
@@ -950,8 +950,7 @@ class LightweightTransactionTests(unittest.TestCase):
         # Make sure test passed
         self.assertTrue(received_timeout)
 
-    # Failed on Scylla because error `SERIAL/LOCAL_SERIAL consistency may only be requested for one partition at a time`
-    @unittest.expectedFailure
+    @xfail_scylla('Fails on Scylla with error `SERIAL/LOCAL_SERIAL consistency may only be requested for one partition at a time`')
     def test_was_applied_batch_stmt(self):
         """
         Test to ensure `:attr:cassandra.cluster.ResultSet.was_applied` works as expected

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -17,6 +17,7 @@ from cassandra import DriverException
 
 import unittest
 import logging
+import pytest
 from cassandra import ProtocolVersion
 from cassandra import ConsistencyLevel, Unavailable, InvalidRequest, cluster
 from cassandra.query import (PreparedStatement, BoundStatement, SimpleStatement,
@@ -1036,8 +1037,7 @@ class LightweightTransactionTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             results.was_applied
 
-    # Skipping until PYTHON-943 is resolved
-    @unittest.expectedFailure
+    @pytest.mark.xfail(reason='Skipping until PYTHON-943 is resolved')
     def test_was_applied_batch_string(self):
         batch_statement = BatchStatement(BatchType.LOGGED)
         batch_statement.add_all(["INSERT INTO test3rf.lwt_clustering (k, c, v) VALUES (0, 0, 10);",

--- a/tests/integration/standard/test_shard_aware.py
+++ b/tests/integration/standard/test_shard_aware.py
@@ -26,6 +26,7 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest  # noqa
+import pytest
 
 from cassandra.cluster import Cluster
 from cassandra.policies import TokenAwarePolicy, RoundRobinPolicy, ConstantReconnectionPolicy
@@ -188,7 +189,7 @@ class TestShardAwareIntegration(unittest.TestCase):
         time.sleep(10)
         self.query_data(self.session)
 
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_blocking_connections(self):
         """
         Verify that reconnection is working as expected, when connection are being blocked.

--- a/tests/integration/standard/test_shard_aware.py
+++ b/tests/integration/standard/test_shard_aware.py
@@ -39,7 +39,7 @@ LOGGER = logging.getLogger(__name__)
 
 def setup_module():
     os.environ['SCYLLA_EXT_OPTS'] = "--smp 4 --memory 2048M"
-    use_cluster('shared_aware', [3], start=True)
+    use_cluster('shard_aware', [3], start=True)
 
 
 class TestShardAwareIntegration(unittest.TestCase):

--- a/tests/integration/standard/test_shard_aware.py
+++ b/tests/integration/standard/test_shard_aware.py
@@ -38,7 +38,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def setup_module():
-    os.environ['SCYLLA_EXT_OPTS'] = "--smp 4 --memory 2048M"
+    os.environ['SCYLLA_EXT_OPTS'] = "--smp 2"
     use_cluster('shard_aware', [3], start=True)
 
 
@@ -109,7 +109,7 @@ class TestShardAwareIntegration(unittest.TestCase):
         session.execute(bound)
         bound = prepared.bind(('e', 'f', 'g'))
         session.execute(bound)
-        bound = prepared.bind(('100000', 'f', 'g'))
+        bound = prepared.bind(('100002', 'f', 'g'))
         session.execute(bound)
 
     def query_data(self, session, verify_in_tracing=True):
@@ -122,20 +122,20 @@ class TestShardAwareIntegration(unittest.TestCase):
         results = session.execute(bound, trace=True)
         self.assertEqual(results, [('a', 'b', 'c')])
         if verify_in_tracing:
-            self.verify_same_shard_in_tracing(results, "shard 1")
+            self.verify_same_shard_in_tracing(results, "shard 0")
 
-        bound = prepared.bind(('100000', 'f'))
+        bound = prepared.bind(('100002', 'f'))
         results = session.execute(bound, trace=True)
-        self.assertEqual(results, [('100000', 'f', 'g')])
+        self.assertEqual(results, [('100002', 'f', 'g')])
 
         if verify_in_tracing:
-            self.verify_same_shard_in_tracing(results, "shard 0")
+            self.verify_same_shard_in_tracing(results, "shard 1")
 
         bound = prepared.bind(('e', 'f'))
         results = session.execute(bound, trace=True)
 
         if verify_in_tracing:
-            self.verify_same_shard_in_tracing(results, "shard 1")
+            self.verify_same_shard_in_tracing(results, "shard 0")
 
     def test_all_tracing_coming_one_shard(self):
         """

--- a/tests/integration/standard/test_shard_aware.py
+++ b/tests/integration/standard/test_shard_aware.py
@@ -168,6 +168,7 @@ class TestShardAwareIntegration(unittest.TestCase):
             for result in as_completed(futures):
                 print(result)
 
+    @pytest.mark.skip(reason='https://github.com/scylladb/python-driver/issues/221')
     def test_closing_connections(self):
         """
         Verify that reconnection is working as expected, when connection are being closed.

--- a/tests/integration/standard/test_shard_aware.py
+++ b/tests/integration/standard/test_shard_aware.py
@@ -60,7 +60,7 @@ class TestShardAwareIntegration(unittest.TestCase):
         traces = results.get_query_trace()
         events = traces.events
         for event in events:
-            LOGGER.info("%s %s", event.thread_name, event.description)
+            LOGGER.info("%s %s %s", event.source, event.thread_name, event.description)
         for event in events:
             self.assertEqual(event.thread_name, shard_name)
         self.assertIn('querying locally', "\n".join([event.description for event in events]))

--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -31,7 +31,7 @@ from tests.unit.cython.utils import cythontest
 
 from tests.integration import use_singledc, execute_until_pass, notprotocolv1, \
     BasicSharedKeyspaceUnitTestCase, greaterthancass21, lessthancass30, greaterthanorequaldse51, \
-    DSE_VERSION, greaterthanorequalcass3_10, requiredse, TestCluster
+    DSE_VERSION, greaterthanorequalcass3_10, requiredse, TestCluster, requires_composite_type
 from tests.integration.datatype_utils import update_datatypes, PRIMITIVE_DATATYPES, COLLECTION_TYPES, PRIMITIVE_DATATYPES_KEYS, \
     get_sample, get_all_samples, get_collection_sample
 
@@ -731,7 +731,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         s.execute(u"SELECT * FROM system.local WHERE key = 'ef\u2052ef'")
         s.execute(u"SELECT * FROM system.local WHERE key = %s", (u"fe\u2051fe",))
 
-    @unittest.expectedFailure
+    @requires_composite_type
     def test_can_read_composite_type(self):
         """
         Test to ensure that CompositeTypes can be used in a query


### PR DESCRIPTION
Some integration tests were disabled in CI, and so have rotten a bit and were not passing - most notably, our shard-awareness tests.
This PR fixes / disables failing tests in tests/integration/standard and enables them in CI.

There are also some minor general fixes in tests (strict xfail, `pip install -e`). See commit messages for descriptions of each change.