### PR TITLE
Merge upstream changes (3.26)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,36 @@
+3.26.0
+======
+March 13, 2023
+
+Features
+--------
+* Add support for execution profiles in execute_concurrent (PR 1122)
+
+Bug Fixes
+---------
+* Handle empty non-final result pages (PR 1110)
+* Do not re-use stream IDs for in-flight requests (PR 1114)
+* Asyncore race condition cause logging exception on shutdown (PYTHON-1266)
+
+Others
+------
+* Fix deprecation warning in query tracing (PR 1103)
+* Remove mutable default values from some tests (PR 1116)
+* Remove dependency on unittest2 (PYTHON-1289)
+* Fix deprecation warnings for asyncio.coroutine annotation in asyncioreactor (PYTTHON-1290)
+* Fix typos in source files (PR 1126)
+* HostFilterPolicyInitTest fix for Python 3.11 (PR 1131)
+* Fix for DontPrepareOnIgnoredHostsTest (PYTHON-1287)
+* tests.integration.simulacron.test_connection failures (PYTHON-1304)
+* tests.integration.standard.test_single_interface.py appears to be failing for C* 4.0 (PYTHON-1329)
+* Authentication tests appear to be failing fraudulently (PYTHON-1328)
+* PreparedStatementTests.test_fail_if_different_query_id_on_reprepare() failing unexpectedly (PTYHON-1327)
+* Refactor deprecated unittest aliases for Python 3.11 compatibility (PR 1112)
+
+Deprecations
+------------
+* This release removes support for Python 2.7.x as well as Python 3.5.x and 3.6.x
+
 3.25.0
 ======
 March 18, 2021

--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -22,7 +22,7 @@ class NullHandler(logging.Handler):
 
 logging.getLogger('cassandra').addHandler(NullHandler())
 
-__version_info__ = (3, 25, 11)
+__version_info__ = (3, 26, 0)
 __version__ = '.'.join(map(str, __version_info__))
 
 
@@ -55,7 +55,7 @@ class ConsistencyLevel(object):
 
     QUORUM = 4
     """
-    ``ceil(RF/2)`` replicas must respond to consider the operation a success
+    ``ceil(RF/2) + 1`` replicas must respond to consider the operation a success
     """
 
     ALL = 5

--- a/cassandra/io/asyncorereactor.py
+++ b/cassandra/io/asyncorereactor.py
@@ -249,18 +249,21 @@ class AsyncoreLoop(object):
                 try:
                     self._loop_dispatcher.loop(self.timer_resolution)
                     self._timers.service_timeouts()
-                except Exception:
-                    try:
-                        log.debug("Asyncore event loop stopped unexpectedly", exc_info=True)
-                    except Exception:
-                        # TODO: Remove when Python 2 support is removed
-                        # PYTHON-1266. If our logger has disappeared, there's nothing we
-                        # can do, so just log nothing.
-                        pass
+                except Exception as exc:
+                    self._maybe_log_debug("Asyncore event loop stopped unexpectedly", exc_info=exc)
                     break
             self._started = False
 
-        log.debug("Asyncore event loop ended")
+        self._maybe_log_debug("Asyncore event loop ended")
+
+    def _maybe_log_debug(self, *args, **kwargs):
+        try:
+            log.debug(*args, **kwargs)
+        except Exception:
+            # TODO: Remove when Python 2 support is removed
+            # PYTHON-1266. If our logger has disappeared, there's nothing we
+            # can do, so just log nothing.
+            pass
 
     def add_timer(self, timer):
         self._timers.add_timer(timer)

--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -873,7 +873,9 @@ class HostConnection(object):
 
     def get_state(self):
         in_flights = [c.in_flight for c in list(self._connections.values())]
-        return {'shutdown': self.is_shutdown, 'open_count': self.open_count, 'in_flights': in_flights}
+        orphan_requests = [c.orphaned_request_ids for c in list(self._connections.values())]
+        return {'shutdown': self.is_shutdown, 'open_count': self.open_count, \
+                'in_flights': in_flights, 'orphan_requests': orphan_requests}
 
     @property
     def num_missing_or_needing_replacement(self):
@@ -1245,4 +1247,6 @@ class HostConnectionPool(object):
 
     def get_state(self):
         in_flights = [c.in_flight for c in self._connections]
-        return {'shutdown': self.is_shutdown, 'open_count': self.open_count, 'in_flights': in_flights}
+        orphan_requests = [c.orphaned_request_ids for c in self._connections]
+        return {'shutdown': self.is_shutdown, 'open_count': self.open_count, \
+            'in_flights': in_flights, 'orphan_requests': orphan_requests}

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,6 @@ from distutils.errors import (CCompilerError, DistutilsPlatformError,
                               DistutilsExecError)
 from distutils.cmd import Command
 
-PY3 = sys.version_info[0] == 3
-
 try:
     import subprocess
     has_subprocess = True
@@ -407,9 +405,6 @@ def run_setup(extensions):
                     'geomet>=0.1,<0.3',
                     'pyyaml > 5.0']
 
-    if not PY3:
-        dependencies.append('futures')
-
     _EXTRAS_REQUIRE = {
         'graph': ['gremlinpython==3.4.6']
     }
@@ -444,9 +439,6 @@ def run_setup(extensions):
             'Natural Language :: English',
             'Operating System :: OS Independent',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: Implementation :: CPython',

--- a/tests/integration/advanced/graph/test_graph.py
+++ b/tests/integration/advanced/graph/test_graph.py
@@ -266,6 +266,6 @@ class GraphExecutionProfileOptionsResolveTest(GraphUnitTestCase):
         self.assertEqual(ep.row_factory, graph_object_row_factory)
 
         regex = re.compile(".*Variable.*is unknown.*", re.S)
-        with six.assertRaisesRegex(self, SyntaxException, regex):
+        with self.assertRaisesRegex(SyntaxException, regex):
             self.execute_graph_queries(CoreGraphSchema.fixtures.classic(),
                                        execution_profile=ep, verify_graphson=GraphProtocol.GRAPHSON_1_0)

--- a/tests/integration/cqlengine/management/test_compaction_settings.py
+++ b/tests/integration/cqlengine/management/test_compaction_settings.py
@@ -83,7 +83,7 @@ class AlterTableTest(BaseCassEngTestCase):
 
         table_meta = _get_table_metadata(tmp)
 
-        self.assertRegexpMatches(table_meta.export_as_string(), '.*SizeTieredCompactionStrategy.*')
+        self.assertRegex(table_meta.export_as_string(), '.*SizeTieredCompactionStrategy.*')
 
     def test_alter_options(self):
 
@@ -97,11 +97,11 @@ class AlterTableTest(BaseCassEngTestCase):
         drop_table(AlterTable)
         sync_table(AlterTable)
         table_meta = _get_table_metadata(AlterTable)
-        self.assertRegexpMatches(table_meta.export_as_string(), ".*'sstable_size_in_mb': '64'.*")
+        self.assertRegex(table_meta.export_as_string(), ".*'sstable_size_in_mb': '64'.*")
         AlterTable.__options__['compaction']['sstable_size_in_mb'] = '128'
         sync_table(AlterTable)
         table_meta = _get_table_metadata(AlterTable)
-        self.assertRegexpMatches(table_meta.export_as_string(), ".*'sstable_size_in_mb': '128'.*")
+        self.assertRegex(table_meta.export_as_string(), ".*'sstable_size_in_mb': '128'.*")
 
 
 class OptionsTest(BaseCassEngTestCase):

--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import unittest
 
+import six
 import mock
 import logging
 from packaging.version import Version
@@ -261,7 +262,7 @@ class TablePropertiesTests(BaseCassEngTestCase):
         option = 'no way will this ever be an option'
         try:
             ModelWithTableProperties.__options__[option] = 'what was I thinking?'
-            self.assertRaisesRegexp(KeyError, "Invalid table option.*%s.*" % option, sync_table, ModelWithTableProperties)
+            self.assertRaisesRegex(KeyError, "Invalid table option.*%s.*" % option, sync_table, ModelWithTableProperties)
         finally:
             ModelWithTableProperties.__options__.pop(option, None)
 

--- a/tests/integration/cqlengine/model/test_class_construction.py
+++ b/tests/integration/cqlengine/model/test_class_construction.py
@@ -15,6 +15,7 @@
 from uuid import uuid4
 import warnings
 
+import six
 from cassandra.cqlengine import columns, CQLEngineException
 from cassandra.cqlengine.models import Model, ModelException, ModelDefinitionException, ColumnQueryEvaluator
 from cassandra.cqlengine.query import ModelQuerySet, DMLQuery
@@ -91,7 +92,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
         Tests that trying to create conflicting db column names will fail
         """
 
-        with self.assertRaisesRegexp(ModelException, r".*more than once$"):
+        with self.assertRaisesRegex(ModelException, r".*more than once$"):
             class BadNames(Model):
                 words = columns.Text(primary_key=True)
                 content = columns.Text(db_field='words')

--- a/tests/integration/cqlengine/test_batch_query.py
+++ b/tests/integration/cqlengine/test_batch_query.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import warnings
 
+import six
 import sure
 
 from cassandra.cqlengine import columns
@@ -224,7 +225,7 @@ class BatchQueryCallbacksTests(BaseCassEngTestCase):
                 batch.execute()
             batch.execute()
         self.assertEqual(len(w), 2)  # package filter setup to warn always
-        self.assertRegexpMatches(str(w[0].message), r"^Batch.*multiple.*")
+        self.assertRegex(str(w[0].message), r"^Batch.*multiple.*")
 
     def test_disable_multiple_callback_warning(self):
         """

--- a/tests/integration/long/test_ipv6.py
+++ b/tests/integration/long/test_ipv6.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os, socket, errno
+import six
 from ccmlib import common
 
 from cassandra.cluster import NoHostAvailable
@@ -82,7 +83,7 @@ class IPV6ConnectionTest(object):
     def test_error(self):
         cluster = TestCluster(connection_class=self.connection_class, contact_points=['::1'], port=9043,
                               connect_timeout=10)
-        self.assertRaisesRegexp(NoHostAvailable, '\(\'Unable to connect.*%s.*::1\', 9043.*Connection refused.*'
+        self.assertRaisesRegex(NoHostAvailable, '\(\'Unable to connect.*%s.*::1\', 9043.*Connection refused.*'
                                 % errno.ECONNREFUSED, cluster.connect)
 
     def test_error_multiple(self):
@@ -90,7 +91,7 @@ class IPV6ConnectionTest(object):
             raise unittest.SkipTest('localhost only resolves one address')
         cluster = TestCluster(connection_class=self.connection_class, contact_points=['localhost'], port=9043,
                               connect_timeout=10)
-        self.assertRaisesRegexp(NoHostAvailable, '\(\'Unable to connect.*Tried connecting to \[\(.*\(.*\].*Last error',
+        self.assertRaisesRegex(NoHostAvailable, '\(\'Unable to connect.*Tried connecting to \[\(.*\(.*\].*Last error',
                                 cluster.connect)
 
 

--- a/tests/integration/simulacron/test_connection.py
+++ b/tests/integration/simulacron/test_connection.py
@@ -14,6 +14,7 @@
 import unittest
 
 import logging
+import six
 import time
 
 from mock import Mock, patch
@@ -262,7 +263,7 @@ class ConnectionTests(SimulacronBase):
         prime_request(PrimeOptions(then={"result": "no_result", "delay_in_ms": never}))
         prime_request(RejectConnections("unbind"))
 
-        self.assertRaisesRegexp(OperationTimedOut, "Connection defunct by heartbeat", future.result)
+        self.assertRaisesRegex(OperationTimedOut, "Connection defunct by heartbeat", future.result)
 
     def test_close_when_query(self):
         """

--- a/tests/integration/standard/test_client_warnings.py
+++ b/tests/integration/standard/test_client_warnings.py
@@ -15,6 +15,7 @@
 
 import unittest
 
+import six
 from cassandra.query import BatchStatement
 
 from tests.integration import use_singledc, PROTOCOL_VERSION, local, TestCluster
@@ -73,7 +74,7 @@ class ClientWarningTests(unittest.TestCase):
         future = self.session.execute_async(self.warn_batch)
         future.result()
         self.assertEqual(len(future.warnings), 1)
-        self.assertRegexpMatches(future.warnings[0], 'Batch.*exceeding.*')
+        self.assertRegex(future.warnings[0], 'Batch.*exceeding.*')
 
     def test_warning_with_trace(self):
         """
@@ -89,7 +90,7 @@ class ClientWarningTests(unittest.TestCase):
         future = self.session.execute_async(self.warn_batch, trace=True)
         future.result()
         self.assertEqual(len(future.warnings), 1)
-        self.assertRegexpMatches(future.warnings[0], 'Batch.*exceeding.*')
+        self.assertRegex(future.warnings[0], 'Batch.*exceeding.*')
         self.assertIsNotNone(future.get_query_trace())
 
     @local
@@ -108,7 +109,7 @@ class ClientWarningTests(unittest.TestCase):
         future = self.session.execute_async(self.warn_batch, custom_payload=payload)
         future.result()
         self.assertEqual(len(future.warnings), 1)
-        self.assertRegexpMatches(future.warnings[0], 'Batch.*exceeding.*')
+        self.assertRegex(future.warnings[0], 'Batch.*exceeding.*')
         self.assertDictEqual(future.custom_payload, payload)
 
     @local
@@ -127,6 +128,6 @@ class ClientWarningTests(unittest.TestCase):
         future = self.session.execute_async(self.warn_batch, trace=True, custom_payload=payload)
         future.result()
         self.assertEqual(len(future.warnings), 1)
-        self.assertRegexpMatches(future.warnings[0], 'Batch.*exceeding.*')
+        self.assertRegex(future.warnings[0], 'Batch.*exceeding.*')
         self.assertIsNotNone(future.get_query_trace())
         self.assertDictEqual(future.custom_payload, payload)

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -151,7 +151,7 @@ class ClusterTests(unittest.TestCase):
         get_node(1).pause()
         cluster = TestCluster(contact_points=['127.0.0.1'], connect_timeout=1)
 
-        with self.assertRaisesRegexp(NoHostAvailable, "OperationTimedOut\('errors=Timed out creating connection \(1 seconds\)"):
+        with self.assertRaisesRegex(NoHostAvailable, "OperationTimedOut\('errors=Timed out creating connection \(1 seconds\)"):
             cluster.connect()
         cluster.shutdown()
 
@@ -541,7 +541,7 @@ class ClusterTests(unittest.TestCase):
             # cluster agreement wait used for refresh
             original_meta = c.metadata.keyspaces
             start_time = time.time()
-            self.assertRaisesRegexp(Exception, r"Schema metadata was not refreshed.*", c.refresh_schema_metadata)
+            self.assertRaisesRegex(Exception, r"Schema metadata was not refreshed.*", c.refresh_schema_metadata)
             end_time = time.time()
             self.assertGreaterEqual(end_time - start_time, agreement_timeout)
             self.assertIs(original_meta, c.metadata.keyspaces)
@@ -578,7 +578,7 @@ class ClusterTests(unittest.TestCase):
             # refresh wait overrides cluster value
             original_meta = c.metadata.keyspaces
             start_time = time.time()
-            self.assertRaisesRegexp(Exception, r"Schema metadata was not refreshed.*", c.refresh_schema_metadata,
+            self.assertRaisesRegex(Exception, r"Schema metadata was not refreshed.*", c.refresh_schema_metadata,
                                     max_schema_agreement_wait=agreement_timeout)
             end_time = time.time()
             self.assertGreaterEqual(end_time - start_time, agreement_timeout)

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -1643,7 +1643,7 @@ class FunctionMetadata(FunctionTest):
 
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegexpMatches(fn_meta.as_cql_query(), "CREATE FUNCTION.*%s\(\) .*" % kwargs['name'])
+            self.assertRegex(fn_meta.as_cql_query(), "CREATE FUNCTION.*%s\(\) .*" % kwargs['name'])
 
     def test_functions_follow_keyspace_alter(self):
         """
@@ -1691,12 +1691,12 @@ class FunctionMetadata(FunctionTest):
         kwargs['called_on_null_input'] = True
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegexpMatches(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) CALLED ON NULL INPUT RETURNS .*")
+            self.assertRegex(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) CALLED ON NULL INPUT RETURNS .*")
 
         kwargs['called_on_null_input'] = False
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegexpMatches(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) RETURNS NULL ON NULL INPUT RETURNS .*")
+            self.assertRegex(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) RETURNS NULL ON NULL INPUT RETURNS .*")
 
 
 class AggregateMetadata(FunctionTest):

--- a/tests/integration/standard/test_prepared_statements.py
+++ b/tests/integration/standard/test_prepared_statements.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
+from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster, CASSANDRA_VERSION
 
 import unittest
+
+from packaging.version import Version
+
 from cassandra import InvalidRequest, DriverException
 
 from cassandra import ConsistencyLevel, ProtocolVersion
@@ -392,6 +395,9 @@ class PreparedStatementTests(unittest.TestCase):
         with self.assertRaises(InvalidRequest):
             self.session.execute(prepared, [0])
 
+    @unittest.skipIf((CASSANDRA_VERSION >= Version('3.11.12') and CASSANDRA_VERSION < Version('4.0')) or \
+        CASSANDRA_VERSION >= Version('4.0.2'),
+        "Fixed server-side in Cassandra 3.11.12, 4.0.2")
     def test_fail_if_different_query_id_on_reprepare(self):
         """ PYTHON-1124 and CASSANDRA-15252 """
         keyspace = "test_fail_if_different_query_id_on_reprepare"

--- a/tests/integration/standard/test_single_interface.py
+++ b/tests/integration/standard/test_single_interface.py
@@ -22,7 +22,7 @@ from cassandra.query import SimpleStatement
 from packaging.version import Version
 from tests.integration import use_singledc, PROTOCOL_VERSION, \
     remove_cluster, greaterthanorequalcass40, notdse, \
-    CASSANDRA_VERSION, DSE_VERSION, TestCluster
+    CASSANDRA_VERSION, DSE_VERSION, TestCluster, DEFAULT_SINGLE_INTERFACE_PORT
 
 
 def setup_module():
@@ -39,7 +39,7 @@ def teardown_module():
 class SingleInterfaceTest(unittest.TestCase):
 
     def setUp(self):
-        self.cluster = TestCluster()
+        self.cluster = TestCluster(port=DEFAULT_SINGLE_INTERFACE_PORT)
         self.session = self.cluster.connect()
 
     def tearDown(self):
@@ -73,4 +73,4 @@ class SingleInterfaceTest(unittest.TestCase):
                                                  consistency_level=ConsistencyLevel.ALL))
 
         for pool in self.session.get_pools():
-            self.assertEquals(1, pool.get_state()['open_count'])
+            self.assertEqual(1, pool.get_state()['open_count'])

--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -69,7 +69,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
                 msg = r'.*Invalid STRING constant \(.*?\) for "b" of type blob.*'
             else:
                 msg = r'.*Invalid STRING constant \(.*?\) for b of type blob.*'
-            self.assertRaisesRegexp(InvalidRequest, msg, s.execute, query, params)
+            self.assertRaisesRegex(InvalidRequest, msg, s.execute, query, params)
             return
 
         # In python2, with Cassandra < 2.0, we can manually encode the 'byte str' type as hex for insertion in a blob.
@@ -1061,7 +1061,7 @@ class TestDateRangePrepared(AbstractDateRangeTest, BasicSharedKeyspaceUnitTestCa
             results =  self.session.execute(prep_sel)
 
         dr = results[0].dr
-        # sometimes this is truncated in the assertEquals output on failure;
+        # sometimes this is truncated in the assertEqual output on failure;
         if isinstance(expected, six.string_types):
             self.assertEqual(str(dr), expected)
         else:
@@ -1115,7 +1115,7 @@ class TestDateRangeSimple(AbstractDateRangeTest, BasicSharedKeyspaceUnitTestCase
         results= self.session.execute("SELECT * FROM tab WHERE dr = '{0}' ".format(to_insert))
 
         dr = results[0].dr
-        # sometimes this is truncated in the assertEquals output on failure;
+        # sometimes this is truncated in the assertEqual output on failure;
         if isinstance(expected, six.string_types):
             self.assertEqual(str(dr), expected)
         else:

--- a/tests/unit/advanced/test_graph.py
+++ b/tests/unit/advanced/test_graph.py
@@ -259,7 +259,7 @@ class GraphOptionTests(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             GraphOptions(unknown_param=42)
         self.assertEqual(len(w), 1)
-        self.assertRegexpMatches(str(w[0].message), r"^Unknown keyword.*GraphOptions.*")
+        self.assertRegex(str(w[0].message), r"^Unknown keyword.*GraphOptions.*")
 
     def test_update(self):
         opts = GraphOptions(**self.api_params)

--- a/tests/unit/cqlengine/test_connection.py
+++ b/tests/unit/cqlengine/test_connection.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import six
+
 from cassandra.cluster import _ConfigMode
 from cassandra.cqlengine import connection
 from cassandra.query import dict_factory
@@ -50,12 +52,12 @@ class ConnectionTest(unittest.TestCase):
         """
         Users can't get the default session without having a default connection set.
         """
-        with self.assertRaisesRegexp(connection.CQLEngineException, self.no_registered_connection_msg):
+        with self.assertRaisesRegex(connection.CQLEngineException, self.no_registered_connection_msg):
             connection.get_session(connection=None)
 
     def test_get_cluster_fails_without_existing_connection(self):
         """
         Users can't get the default cluster without having a default connection set.
         """
-        with self.assertRaisesRegexp(connection.CQLEngineException, self.no_registered_connection_msg):
+        with self.assertRaisesRegex(connection.CQLEngineException, self.no_registered_connection_msg):
             connection.get_cluster(connection=None)

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -392,7 +392,7 @@ class ConnectionHeartbeatTest(unittest.TestCase):
         connection.defunct.assert_has_calls([call(ANY)] * get_holders.call_count)
         exc = connection.defunct.call_args_list[0][0][0]
         self.assertIsInstance(exc, ConnectionException)
-        self.assertRegexpMatches(exc.args[0], r'^Received unexpected response to OptionsMessage.*')
+        self.assertRegex(exc.args[0], r'^Received unexpected response to OptionsMessage.*')
         holder.return_connection.assert_has_calls(
             [call(connection)] * get_holders.call_count)
 

--- a/tests/unit/test_control_connection.py
+++ b/tests/unit/test_control_connection.py
@@ -585,7 +585,7 @@ class ControlConnectionTest(unittest.TestCase):
         self.assertEqual(self.cluster.added_hosts[0].broadcast_rpc_address, "192.168.1.3")
         self.assertEqual(self.cluster.added_hosts[0].broadcast_rpc_port, 555)
         self.assertEqual(self.cluster.added_hosts[0].broadcast_address, "10.0.0.3")
-        self.assertEquals(self.cluster.added_hosts[0].broadcast_port, 666)
+        self.assertEqual(self.cluster.added_hosts[0].broadcast_port, 666)
         self.assertEqual(self.cluster.added_hosts[0].datacenter, "dc1")
         self.assertEqual(self.cluster.added_hosts[0].rack, "rack1")
 
@@ -605,7 +605,7 @@ class ControlConnectionTest(unittest.TestCase):
         self.assertEqual(self.cluster.added_hosts[0].broadcast_rpc_address, "192.168.1.3")
         self.assertEqual(self.cluster.added_hosts[0].broadcast_rpc_port, None)
         self.assertEqual(self.cluster.added_hosts[0].broadcast_address, "10.0.0.3")
-        self.assertEquals(self.cluster.added_hosts[0].broadcast_port, None)
+        self.assertEqual(self.cluster.added_hosts[0].broadcast_port, None)
         self.assertEqual(self.cluster.added_hosts[0].datacenter, "dc1")
         self.assertEqual(self.cluster.added_hosts[0].rack, "rack1")
 

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -1295,10 +1295,13 @@ class HostFilterPolicyInitTest(unittest.TestCase):
         ))
 
     def test_immutable_predicate(self):
-        expected_message_regex = "can't set attribute|object has no setter"
+        if sys.version_info >= (3, 11):
+            expected_message_regex = "has no setter"
+        else:
+            expected_message_regex = "can't set attribute"
         hfp = HostFilterPolicy(child_policy=Mock(name='child_policy'),
                                predicate=Mock(name='predicate'))
-        with self.assertRaisesRegexp(AttributeError, expected_message_regex):
+        with self.assertRaisesRegex(AttributeError, expected_message_regex):
             hfp.predicate = object()
 
 

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+import six
 from mock import Mock
 
 from cassandra import ProtocolVersion, UnsupportedOperation
@@ -172,7 +173,7 @@ class MessageTest(unittest.TestCase):
         keyspace_message = QueryMessage('a', consistency_level=3, keyspace='ks')
         io = Mock(name='io')
 
-        with self.assertRaisesRegexp(UnsupportedOperation, 'Keyspaces.*set'):
+        with self.assertRaisesRegex(UnsupportedOperation, 'Keyspaces.*set'):
             keyspace_message.send_body(io, protocol_version=4)
         io.assert_not_called()
 

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -16,6 +16,8 @@ import unittest
 
 from collections import deque
 from threading import RLock
+
+import six
 from mock import Mock, MagicMock, ANY
 
 from cassandra import ConsistencyLevel, Unavailable, SchemaTargetType, SchemaChangeType, OperationTimedOut
@@ -158,7 +160,7 @@ class ResponseFutureTests(unittest.TestCase):
 
         # Simulate ResponseFuture timing out
         rf._on_timeout()
-        self.assertRaisesRegexp(OperationTimedOut, "Connection defunct by heartbeat", rf.result)
+        self.assertRaisesRegex(OperationTimedOut, "Connection defunct by heartbeat", rf.result)
 
     def test_read_timeout_error_message(self):
         session = self.make_session()

--- a/tests/unit/test_timestamps.py
+++ b/tests/unit/test_timestamps.py
@@ -15,6 +15,7 @@
 import unittest
 
 import mock
+import six
 
 from cassandra import timestamps
 from threading import Thread, Lock
@@ -105,7 +106,7 @@ class TestTimestampGeneratorLogging(unittest.TestCase):
         last_warn_args, last_warn_kwargs = call
         self.assertEqual(len(last_warn_args), 1)
         self.assertEqual(len(last_warn_kwargs), 0)
-        self.assertRegexpMatches(
+        six.assertRegex(self,
             last_warn_args[0],
             pattern,
         )


### PR DESCRIPTION
DO NOT MERGE.

Opening this PR so that changes (conflict resolutions) can be reviewed and integration tests are run.
This PR merges upstream changes from version 3.26. Conflicts I encountered:
 - .travis.yml: empty file in our fork, some changes in upstream. Resolution: remove the file, we don't need it.
 - cassandra/__init__.py: version number. Bump to 3.26.0
 - test_policies.py:
```
    def test_immutable_predicate(self):
<<<<<<< HEAD
        expected_message_regex = "can't set attribute|object has no setter"
=======
        if sys.version_info >= (3, 11):
            expected_message_regex = "has no setter"
        else:
            expected_message_regex = "can't set attribute"
>>>>>>> d92b9455e99fcd1c64c75bf2d81e2771329d6c3a
        hfp = HostFilterPolicy(child_policy=Mock(name='child_policy'),
                               predicate=Mock(name='predicate'))
        with self.assertRaisesRegex(AttributeError, expected_message_regex):
            hfp.predicate = object()
```
resolution: upstream, it's more precise.

 - test_cluster.py:
```
        # the length of mock_calls will vary, but all should use the unignored
        # address
        for c in cluster.connection_factory.mock_calls:
<<<<<<< HEAD
            self.assertEqual(unignored_address, c.args[0].address)
=======
            # PYTHON-1287
            #
            # Cluster._prepare_all_queries() will call connection_factory _without_ the
            # on_orphaned_stream_released arg introduced in commit
            # 387150acc365b6cf1daaee58c62db13e4929099a.  The reconnect handler for the
            # downed node _will_ add this arg when it tries to rebuild it's conn pool, and
            # whether this occurs while running this test amounts to a race condition.  So
            # to cover this case we assert one of two call styles here... the key is that
            # the _only_ address we should see is the unignored_address.
            self.assertTrue( \
                c == call(DefaultEndPoint(unignored_address)) or \
                c == call(DefaultEndPoint(unignored_address), on_orphaned_stream_released=ANY))
>>>>>>> d92b9455e99fcd1c64c75bf2d81e2771329d6c3a
        cluster.shutdown()
```

Resolution: ours, it does what we want (checks the address), which is what upstream version aims to do. Using their approach would be harder because of additional argument (port number) required by shard awareness.

 - pool.py:
```
    def get_state(self):
<<<<<<< HEAD
        in_flights = [c.in_flight for c in list(self._connections.values())]
        return {'shutdown': self.is_shutdown, 'open_count': self.open_count, 'in_flights': in_flights}

    @property
    def num_missing_or_needing_replacement(self):
        return self.host.sharding_info.shards_count \
            - sum(1 for c in self._connections.values() if not c.orphaned_threshold_reached)
=======
        connection = self._connection
        open_count = 1 if connection and not (connection.is_closed or connection.is_defunct) else 0
        in_flights = [connection.in_flight] if connection else []
        orphan_requests = [connection.orphaned_request_ids] if connection else []
        return {'shutdown': self.is_shutdown, 'open_count': open_count, \
            'in_flights': in_flights, 'orphan_requests': orphan_requests}
>>>>>>> d92b9455e99fcd1c64c75bf2d81e2771329d6c3a
```

Resolution:
```
    def get_state(self):
        in_flights = [c.in_flight for c in list(self._connections.values())]
        orphan_requests = [c.orphaned_request_ids for c in list(self._connections.values())]
        return {'shutdown': self.is_shutdown, 'open_count': self.open_count, \
                'in_flights': in_flights, 'orphan_requests': orphan_requests}

    @property
    def num_missing_or_needing_replacement(self):
        return self.host.sharding_info.shards_count \
            - sum(1 for c in self._connections.values() if not c.orphaned_threshold_reached)
```
Explanation: this resolution applies the upstream change, but in a way that works with shard awareness.