### PR TITLE
Fix release script

### DIFF
--- a/scripts/merge_next_tag_from_upstream.sh
+++ b/scripts/merge_next_tag_from_upstream.sh
@@ -6,7 +6,7 @@
 
 # this script assumes remotes for scylladb/python-driver and for datastax/python-driver are configured
 
-upstream_repo_url=https://github.com/datastax/python-driver
+upstream_repo_url=datastax/python-driver
 
 upstream_repo=$(git remote -v | grep ${upstream_repo_url} | awk '{print $1}' | head -n1)
 scylla_repo=$(git remote -v | grep scylladb/python-driver | awk '{print $1}' | head -n1)

--- a/scripts/merge_next_tag_from_upstream.sh
+++ b/scripts/merge_next_tag_from_upstream.sh
@@ -46,7 +46,7 @@ case "$choice" in
 
       git merge --continue
       git tag ${new_scyla_tag}
-      git push --tags ${scylla_repo} ${new_scyla_tag}
+      git push --tags ${scylla_repo} master
 
    re-triggering a build of a tag in Travis:
 


### PR DESCRIPTION
1. Make the script work with SSH datastax remote
2. Use push command that pushes the branch alongside tags in order to properly build documentation.