### PR TITLE
build-experimental.yml: use ubuntu-latest

### DIFF
--- a/.github/workflows/build-experimental.yml
+++ b/.github/workflows/build-experimental.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.11.2
+          python -m pip install cibuildwheel==2.12.1
 
       - name: Build wheels
         run: |

--- a/.github/workflows/build-experimental.yml
+++ b/.github/workflows/build-experimental.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 env:
  CIBW_BEFORE_BUILD_LINUX: "rm -rf ~/.pyxbld && yum install -y libev libev-devel openssl openssl-devel"
  CIBW_ENVIRONMENT: "CASS_DRIVER_BUILD_CONCURRENCY=2 CFLAGS='-g0 -O3'"
- CIBW_BUILD: "cp38* cp39* cp310*"
+ CIBW_BUILD: "cp38* cp39* cp310* cp311*"
  CIBW_SKIP: "*musllinux*"
 jobs:
   build_wheels:

--- a/.github/workflows/build-experimental.yml
+++ b/.github/workflows/build-experimental.yml
@@ -10,7 +10,7 @@ jobs:
   build_wheels:
     if: contains(github.event.pull_request.labels.*.name, 'test-build-experimental') || github.event_name == 'push' && endsWith(github.event.ref, 'scylla')
     # The host should always be linux
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Build experimental ${{ matrix.archs }} wheels
     strategy:
       fail-fast: false

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.11.2
+          python -m pip install cibuildwheel==2.12.1
 
       - name: Install OpenSSL for Windows
         if: runner.os == 'Windows'


### PR DESCRIPTION
by mistake this action was using ubutnu-1804 and it's now deprecated
and that made the build of 3.26.0 version to fail.

I've created them with this PR, and upload them manually to pypi