### PR TITLE
integration-tests: fix undefined `logger` variable

### DIFF
--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -506,11 +506,11 @@ class PreparedStatementArgTest(unittest.TestCase):
 
     def setUp(self):
         self.mock_handler = MockLoggingHandler()
-        logger = logging.getLogger(cluster.__name__)
-        logger.addHandler(self.mock_handler)
+        self.logger = logging.getLogger(cluster.__name__)
+        self.logger.addHandler(self.mock_handler)
     
     def tearDown(self):
-        logger.removeHandler(self.mock_handler)
+        self.logger.removeHandler(self.mock_handler)
 
     def test_prepare_on_all_hosts(self):
         """

--- a/tests/integration/upgrade/__init__.py
+++ b/tests/integration/upgrade/__init__.py
@@ -76,12 +76,12 @@ class UpgradeBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.logger_handler = MockLoggingHandler()
-        logger = logging.getLogger(cluster.__name__)
-        logger.addHandler(cls.logger_handler)
+        cls.logger = logging.getLogger(cluster.__name__)
+        cls.logger.addHandler(cls.logger_handler)
     
     @classmethod
     def tearDownClass(cls):
-        logger.removeHandler(cls.logger_handler)
+        cls.logger.removeHandler(cls.logger_handler)
 
     def _upgrade_step_setup(self):
         """


### PR DESCRIPTION
e6abdf125123e0a8d6b5611efc2a6722faadc6b3 seem to have broke some of the test teardown while trying to cleanup
log handlers

and failing like the following:

```
self = <tests.integration.standard.test_query.PreparedStatementArgTest testMethod=test_prepare_batch_statement>

    def tearDown(self):
>       logger.removeHandler(self.mock_handler)
E       NameError: name 'logger' is not defined

tests/integration/standard/test_query.py:513: NameError
```