### PR TITLE
test_scylla_cloud: align with ccm

### DIFF
--- a/tests/integration/standard/test_scylla_cloud.py
+++ b/tests/integration/standard/test_scylla_cloud.py
@@ -41,7 +41,7 @@ class ScyllaCloudConfigTests(TestCase):
 
         docker_id, listen_address, listen_port = \
             start_sni_proxy(ccm_cluster.get_path(), nodes_info=nodes_info, listen_port=sni_port)
-        ccm_cluster.sni_proxy_docker_id = docker_id
+        ccm_cluster.sni_proxy_docker_ids = [docker_id]
         ccm_cluster.sni_proxy_listen_port = listen_port
         ccm_cluster._update_config()
 


### PR DESCRIPTION
ccm had implemention of multi dc support for sni_proxy and changed the `sni_proxy_docker_id` to a list `sni_proxy_docker_ids` since the code in the test was using the new list, the sni_proxy was stop and removed, causing the next test to fail, since it would reuse the sni_proxy