### PR TITLE
Fix wait_for_schema_agreement deadlock v2

### DIFF
--- a/tests/unit/test_control_connection.py
+++ b/tests/unit/test_control_connection.py
@@ -512,13 +512,13 @@ class ControlConnectionTest(unittest.TestCase):
             }
             self.cluster.scheduler.reset_mock()
             self.control_connection._handle_schema_change(event)
-            self.cluster.scheduler.schedule_unique.assert_called_once_with(ANY, self.control_connection.refresh_schema, **event)
+            self.cluster.scheduler.schedule_unique.assert_called_once_with(ANY, self.control_connection._refresh_schema_async, ANY, **event)
 
             self.cluster.scheduler.reset_mock()
             event['target_type'] = SchemaTargetType.KEYSPACE
             del event['table']
             self.control_connection._handle_schema_change(event)
-            self.cluster.scheduler.schedule_unique.assert_called_once_with(ANY, self.control_connection.refresh_schema, **event)
+            self.cluster.scheduler.schedule_unique.assert_called_once_with(ANY, self.control_connection._refresh_schema_async, ANY, **event)
 
     def test_refresh_disabled(self):
         cluster = MockCluster()
@@ -566,7 +566,7 @@ class ControlConnectionTest(unittest.TestCase):
         cc_no_topo_refresh._handle_status_change(status_event)
         cc_no_topo_refresh._handle_schema_change(schema_event)
         cluster.scheduler.schedule_unique.assert_has_calls([call(ANY, cc_no_topo_refresh.refresh_node_list_and_token_map),
-                                                            call(0.0, cc_no_topo_refresh.refresh_schema,
+                                                            call(0.0, cc_no_topo_refresh._refresh_schema_async, ANY,
                                                                  **schema_event)])
 
     def test_refresh_nodes_and_tokens_add_host_detects_port(self):


### PR DESCRIPTION
This is another attempt at https://github.com/scylladb/python-driver/pull/204 as @avelanarius identified some issues with the previous PR that were causing Scylla tests to fail (#225). See second commit for description of those issues.
I'd recommend squash merge - second and third commit exists only to make it easier to review.

Before this PR, schema agreement process (`wait_for_schema_agreement`) would block the thread executor, performing multiple rounds of schema agreement in a blocking fashion. As described in #168, there was a scenario where blocking the executor would cause a deadlock: schema agreement could not be reached, because of one of the nodes was actually `DOWN`, but the driver couldn't learn about `on_down` notification because the executor was blocked on schema agreement.

This fix works by creating a new version of `wait_for_schema_agreement`, called `_wait_for_schema_agreement_async` that schedules new task for each iteration of loop, instead of sleeping. That way, thread executor can run other functions instead of being stuck with `wait_for_schema_agreement`, allowing `on_down` notification to be handled and node registered as down, which in turn allows for schema agreement wait to finish. We also switched `refresh_schema_and_set_result` to use new async functions - otherwise another deadlock was happening.

Additionally, while developing this fix, we decided to remove `schema_agreement_lock`. This was an optimization to only perform a single schema agreement at a time. However, with new asynchronous `_wait_for_schema_agreement_async` it became clear that this lock introduced many problems: deadlocks, starvation of the lock, more code complexity.

Before fix (mostly taken from the issue description):
1. The driver has control_connection established to node A
2. We kill a node B forcefully
3. Then we immediately schedule a schema change on A
4. A sends a notification to the driver
5. The driver schedules wait_for_schema_agreement tasks in the executor
6. Wait_for_schema_agreement gets stuck because A has a different schema version than B and B is considered up by the driver
7. Eventually, A notices that B is down and delivers a notification to the driver
8. The driver submits the on_down task, but there are no available threads in the pool, so we don't set is_up = False for B
9. wait_for_schema_agreeement never finishes. on_down is never executed. We've deadlocked.

After the fix:
1. The driver has control_connection established to node A
2. We kill a node B forcefully
3. Then we immediately schedule a schema change on A
4. A sends a notification to the driver
5. The driver starts _wait_for_schema_agreement_async
6. _wait_for_schema_agreement_async::inner() is executed in an interval. It continues to be scheduled because A has a different schema version than B and B is considered up by the driver, so it can't finish.
7. Eventually, A notices that B is down and delivers a notification to the driver
8. The driver submits the on_down task.
9. The task is executed by the thread pool. is_up = False is set for B.
9. _wait_for_schema_agreement_async::inner() ceases to be scheduled, callback is called.

Fixes #168 
Fixes #225