### PR TITLE
Disable test_metadata.py::SchemaMetadataTests::test_indexes

### DIFF
--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -476,7 +476,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         tablemeta = self.get_table_metadata()
         self.check_create_statement(tablemeta, create_statement)
 
-    @xfail_scylla('https://github.com/scylladb/scylladb/issues/6058')
+    @pytest.mark.skip(reason='https://github.com/scylladb/scylladb/issues/6058')
     def test_indexes(self):
         create_statement = self.make_create_statement(["a"], ["b", "c"], ["d", "e", "f"])
         create_statement += " WITH CLUSTERING ORDER BY (b ASC, c ASC)"


### PR DESCRIPTION
This test was marked as xfail, but it turns out it sometimes passes, so this PR skips it completely.