### PR TITLE
doc: remove "Upgrading from dse-driver" section

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -4,14 +4,6 @@ Upgrading
 .. toctree::
    :maxdepth: 1
 
-Upgrading from dse-driver
--------------------------
-
-Since 3.21.0, scylla-driver fully supports DataStax products. dse-driver and
-dse-graph users should now migrate to scylla-driver to benefit from latest bug fixes
-and new features. The upgrade to this new unified driver version is straightforward
-with no major API changes.
-
 Installation
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
This commit fixes a bug reported in https://github.com/scylladb/python-driver/issues/244 by removing the incorrect section from
the Upgrading page.