### PR TITLE
Move schema agreement to asyncio

### DIFF
--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import with_statement
+import asyncio
 import calendar
 import datetime
 from functools import total_ordering
@@ -2037,3 +2038,8 @@ class Version(object):
                 (is_major_ge and is_minor_ge and is_patch_ge and is_build_gt) or
                 (is_major_ge and is_minor_ge and is_patch_ge and is_build_ge and is_prerelease_gt)
                 )
+
+
+async def coroutine_delay(delay, coroutine):
+    await asyncio.sleep(delay)
+    return await coroutine

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -119,7 +119,7 @@ class ResponseFutureTests(unittest.TestCase):
                       schema_change_event=event_results)
         connection = Mock()
         rf._set_result(None, connection, None, result)
-        session.submit.assert_called_once_with(ANY, ANY, rf, connection, **event_results)
+        session.cluster.spawn_coroutine_task.assert_called_once_with(ANY, ANY, rf, connection, **event_results)
 
     def test_other_result_message_kind(self):
         session = self.make_session()


### PR DESCRIPTION
Fixes #168. See the issue description for more detailed description of the bug.

This commit introduces asyncio Event Loop to Cluster object. This loop is now responsible for executing most of wait_for_schema_agreement code, the only part delegated to executor is the one that actually sends request to a node. This way parts delegated to executor don't have to wait on any locks, preventing deadlocks.

In the future we can move more code to `Cluster.loop`  and eventually retire `Cluster.scheduler`.

Fixes https://github.com/scylladb/python-driver/issues/168
Fixes https://github.com/scylladb/python-driver/issues/225