### PR TITLE
Introduce support for tablets

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,4 +32,11 @@ jobs:
     - name: Test with pytest
       run: |
         export EVENT_LOOP_MANAGER=${{ matrix.event_loop_manager }}
+        export SCYLLA_VERSION='release:5.1'
         ./ci/run_integration_test.sh tests/integration/standard/ tests/integration/cqlengine/
+    
+    - name: Test tablets
+      run: |
+        export EVENT_LOOP_MANAGER=${{ matrix.event_loop_manager }}
+        export SCYLLA_VERSION='unstable/master:2024-01-03T08:06:57Z'
+        ./ci/run_integration_test.sh tests/integration/experiments/

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,7 @@ Features
 * `Concurrent execution utilities <http://python-driver.docs.scylladb.com/stable/api/cassandra/concurrent.html>`_
 * `Object mapper <http://python-driver.docs.scylladb.com/stable/object-mapper.html>`_
 * `Shard awareness <http://python-driver.docs.scylladb.com/stable/scylla-specific.html#shard-awareness>`_
+* `Tablet awareness <http://python-driver.docs.scylladb.com/stable/scylla-specific.html#tablet-awareness>`_
 
 Installation
 ------------

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -44,6 +44,7 @@ from cassandra.util import OrderedDict, Version
 from cassandra.pool import HostDistance
 from cassandra.connection import EndPoint
 from cassandra.compat import Mapping
+from cassandra.tablets import Tablets
 
 log = logging.getLogger(__name__)
 
@@ -126,6 +127,7 @@ class Metadata(object):
         self._hosts = {}
         self._host_id_by_endpoint = {}
         self._hosts_lock = RLock()
+        self._tablets = Tablets({})
 
     def export_schema_as_string(self):
         """

--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -392,6 +392,8 @@ class HostConnection(object):
     # the number below, all excess connections will be closed.
     max_excess_connections_per_shard_multiplier = 3
 
+    tablets_routing_v1 = False
+
     def __init__(self, host, host_distance, session):
         self.host = host
         self.host_distance = host_distance
@@ -436,10 +438,11 @@ class HostConnection(object):
         if first_connection.features.sharding_info and not self._session.cluster.shard_aware_options.disable:
             self.host.sharding_info = first_connection.features.sharding_info
             self._open_connections_for_all_shards(first_connection.features.shard_id)
+        self.tablets_routing_v1 = first_connection.features.tablets_routing_v1
 
         log.debug("Finished initializing connection for host %s", self.host)
 
-    def _get_connection_for_routing_key(self, routing_key=None):
+    def _get_connection_for_routing_key(self, routing_key=None, keyspace=None, table=None):
         if self.is_shutdown:
             raise ConnectionException(
                 "Pool for %s is shutdown" % (self.host,), self.host)
@@ -450,7 +453,22 @@ class HostConnection(object):
         shard_id = None
         if not self._session.cluster.shard_aware_options.disable and self.host.sharding_info and routing_key:
             t = self._session.cluster.metadata.token_map.token_class.from_key(routing_key)
-            shard_id = self.host.sharding_info.shard_id_from_token(t.value)
+            
+            shard_id = None
+            if self.tablets_routing_v1 and table is not None:
+                if keyspace is None:
+                    keyspace = self._keyspace
+
+                tablet = self._session.cluster.metadata._tablets.get_tablet_for_key(keyspace, table, t)
+
+                if tablet is not None:
+                    for replica in tablet.replicas:
+                        if replica[0] == self.host.host_id:
+                            shard_id = replica[1]
+                            break
+
+            if shard_id is None:
+                shard_id = self.host.sharding_info.shard_id_from_token(t.value)
 
         conn = self._connections.get(shard_id)
 
@@ -496,15 +514,15 @@ class HostConnection(object):
             return random.choice(active_connections)
         return random.choice(list(self._connections.values()))
 
-    def borrow_connection(self, timeout, routing_key=None):
-        conn = self._get_connection_for_routing_key(routing_key)
+    def borrow_connection(self, timeout, routing_key=None, keyspace=None, table=None):
+        conn = self._get_connection_for_routing_key(routing_key, keyspace, table)
         start = time.time()
         remaining = timeout
         last_retry = False
         while True:
             if conn.is_closed:
                 # The connection might have been closed in the meantime - if so, try again
-                conn = self._get_connection_for_routing_key(routing_key)
+                conn = self._get_connection_for_routing_key(routing_key, keyspace, table)
             with conn.lock:
                 if (not conn.is_closed or last_retry) and conn.in_flight < conn.max_request_id:
                     # On last retry we ignore connection status, since it is better to return closed connection than

--- a/cassandra/protocol_features.py
+++ b/cassandra/protocol_features.py
@@ -6,22 +6,26 @@ log = logging.getLogger(__name__)
 
 
 RATE_LIMIT_ERROR_EXTENSION = "SCYLLA_RATE_LIMIT_ERROR"
+TABLETS_ROUTING_V1 = "TABLETS_ROUTING_V1"
 
 class ProtocolFeatures(object):
     rate_limit_error = None
     shard_id = 0
     sharding_info = None
+    tablets_routing_v1 = False
 
-    def __init__(self, rate_limit_error=None, shard_id=0, sharding_info=None):
+    def __init__(self, rate_limit_error=None, shard_id=0, sharding_info=None, tablets_routing_v1=False):
         self.rate_limit_error = rate_limit_error
         self.shard_id = shard_id
         self.sharding_info = sharding_info
+        self.tablets_routing_v1 = tablets_routing_v1
 
     @staticmethod
     def parse_from_supported(supported):
         rate_limit_error = ProtocolFeatures.maybe_parse_rate_limit_error(supported)
         shard_id, sharding_info = ProtocolFeatures.parse_sharding_info(supported)
-        return ProtocolFeatures(rate_limit_error, shard_id, sharding_info)
+        tablets_routing_v1 = ProtocolFeatures.parse_tablets_info(supported)
+        return ProtocolFeatures(rate_limit_error, shard_id, sharding_info, tablets_routing_v1)
 
     @staticmethod
     def maybe_parse_rate_limit_error(supported):
@@ -43,6 +47,8 @@ class ProtocolFeatures(object):
     def add_startup_options(self, options):
         if self.rate_limit_error is not None:
             options[RATE_LIMIT_ERROR_EXTENSION] = ""
+        if self.tablets_routing_v1:
+            options[TABLETS_ROUTING_V1] = ""
 
     @staticmethod
     def parse_sharding_info(options):
@@ -63,3 +69,6 @@ class ProtocolFeatures(object):
                                             shard_aware_port, shard_aware_port_ssl)
 
 
+    @staticmethod
+    def parse_tablets_info(options):
+        return TABLETS_ROUTING_V1 in options

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -253,6 +253,13 @@ class Statement(object):
     .. versionadded:: 2.1.3
     """
 
+    table = None
+    """
+    The string name of the table this query acts on. This is used when the tablet
+    experimental feature is enabled and in the same time :class`~.TokenAwarePolicy`
+    is configured in the profile load balancing policy.
+    """
+
     custom_payload = None
     """
     :ref:`custom_payload` to be passed to the server.
@@ -272,7 +279,7 @@ class Statement(object):
 
     def __init__(self, retry_policy=None, consistency_level=None, routing_key=None,
                  serial_consistency_level=None, fetch_size=FETCH_SIZE_UNSET, keyspace=None, custom_payload=None,
-                 is_idempotent=False):
+                 is_idempotent=False, table=None):
         if retry_policy and not hasattr(retry_policy, 'on_read_timeout'):  # just checking one method to detect positional parameter errors
             raise ValueError('retry_policy should implement cassandra.policies.RetryPolicy')
         if retry_policy is not None:
@@ -286,6 +293,8 @@ class Statement(object):
             self.fetch_size = fetch_size
         if keyspace is not None:
             self.keyspace = keyspace
+        if table is not None:
+            self.table = table
         if custom_payload is not None:
             self.custom_payload = custom_payload
         self.is_idempotent = is_idempotent
@@ -548,6 +557,7 @@ class BoundStatement(Statement):
         meta = prepared_statement.column_metadata
         if meta:
             self.keyspace = meta[0].keyspace_name
+            self.table = meta[0].table_name
 
         Statement.__init__(self, retry_policy, consistency_level, routing_key,
                            serial_consistency_level, fetch_size, keyspace, custom_payload,

--- a/cassandra/tablets.py
+++ b/cassandra/tablets.py
@@ -1,0 +1,107 @@
+# Experimental, this interface and use may change
+from threading import Lock
+
+class Tablet(object):
+    """
+    Represents a single ScyllaDB tablet.
+    It stores information about each replica, its host and shard, 
+    and the token interval in the format (first_token, last_token].
+    """
+    first_token = 0
+    last_token = 0
+    replicas = None
+
+    def __init__(self, first_token = 0, last_token = 0, replicas = None):
+        self.first_token = first_token
+        self.last_token = last_token
+        self.replicas = replicas
+
+    def __str__(self):
+        return "<Tablet: first_token=%s last_token=%s replicas=%s>" \
+               % (self.first_token, self.last_token, self.replicas)
+    __repr__ = __str__
+
+    @staticmethod
+    def _is_valid_tablet(replicas):
+        return replicas is not None and len(replicas) != 0
+
+    @staticmethod
+    def from_row(first_token, last_token, replicas):
+        if Tablet._is_valid_tablet(replicas):
+            tablet = Tablet(first_token, last_token,replicas)
+            return tablet
+        return None
+
+# Experimental, this interface and use may change
+class Tablets(object):
+    _lock = None
+    _tablets = {}
+
+    def __init__(self, tablets):
+        self._tablets = tablets
+        self._lock = Lock()
+    
+    def get_tablet_for_key(self, keyspace, table, t):
+        tablet = self._tablets.get((keyspace, table), [])
+        if tablet == []:
+            return None
+        
+        id = bisect_left(tablet, t.value, key = lambda tablet: tablet.last_token)
+        if id < len(tablet) and t.value > tablet[id].first_token:
+            return tablet[id]
+        return None
+
+    def add_tablet(self, keyspace, table, tablet):
+        with self._lock:
+            tablets_for_table = self._tablets.setdefault((keyspace, table), [])
+
+            # find first overlaping range 
+            start = bisect_left(tablets_for_table, tablet.first_token, key = lambda t: t.first_token)
+            if start > 0 and tablets_for_table[start - 1].last_token > tablet.first_token:
+                start = start - 1
+
+            # find last overlaping range 
+            end = bisect_left(tablets_for_table, tablet.last_token, key = lambda t: t.last_token)
+            if end < len(tablets_for_table) and tablets_for_table[end].first_token >= tablet.last_token:
+                end = end - 1
+
+            if start <= end:
+                del tablets_for_table[start:end + 1]
+
+            tablets_for_table.insert(start, tablet)
+
+# bisect.bisect_left implementation from Python 3.11, needed untill support for
+# Python < 3.10 is dropped, it is needed to use `key` to extract last_token from
+# Tablet list - better solution performance-wise than materialize list of last_tokens
+def bisect_left(a, x, lo=0, hi=None, *, key=None):
+    """Return the index where to insert item x in list a, assuming a is sorted.
+
+    The return value i is such that all e in a[:i] have e < x, and all e in
+    a[i:] have e >= x.  So if x already appears in the list, a.insert(i, x) will
+    insert just before the leftmost x already there.
+
+    Optional args lo (default 0) and hi (default len(a)) bound the
+    slice of a to be searched.
+    """
+
+    if lo < 0:
+        raise ValueError('lo must be non-negative')
+    if hi is None:
+        hi = len(a)
+    # Note, the comparison uses "<" to match the
+    # __lt__() logic in list.sort() and in heapq.
+    if key is None:
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if a[mid] < x:
+                lo = mid + 1
+            else:
+                hi = mid
+    else:
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if key(a[mid]) < x:
+                lo = mid + 1
+            else:
+                hi = mid
+    return lo

--- a/ci/run_integration_test.sh
+++ b/ci/run_integration_test.sh
@@ -15,8 +15,6 @@ if (( aio_max_nr !=  aio_max_nr_recommended_value  )); then
    fi
 fi
 
-SCYLLA_RELEASE='release:5.1'
-
 python3 -m venv .test-venv
 source .test-venv/bin/activate
 pip install -U pip wheel setuptools
@@ -33,12 +31,11 @@ pip install https://github.com/scylladb/scylla-ccm/archive/master.zip
 
 # download version
 
-ccm create scylla-driver-temp -n 1 --scylla --version ${SCYLLA_RELEASE}
+ccm create scylla-driver-temp -n 1 --scylla --version ${SCYLLA_VERSION}
 ccm remove
 
 # run test
 
-export SCYLLA_VERSION=${SCYLLA_RELEASE}
 export MAPPED_SCYLLA_VERSION=3.11.4
 PROTOCOL_VERSION=4  pytest -rf --import-mode append $*
 

--- a/docs/scylla-specific.rst
+++ b/docs/scylla-specific.rst
@@ -109,3 +109,16 @@ New Error Types
             self.session.execute(prepared.bind((123, 456)))
     except RateLimitReached:
         raise
+
+
+Tablet Awareness
+----------------
+
+**scylla-driver** is tablet aware, which mean that it is able to parse `TABLETS_ROUTING_V1` extension to ProtocolFeatures, recieve tablet information send by Scylla in `custom_payload` part of `RESULT` message, and utilize it.
+Thanks to that queries to tablet based tables are still shard aware.
+
+Details on the scylla cql protocol extensions
+https://github.com/scylladb/scylladb/blob/master/docs/dev/protocol-extensions.md#negotiate-sending-tablets-info-to-the-drivers
+
+Details on the sending tablet information to the drivers
+https://github.com/scylladb/scylladb/blob/master/docs/dev/protocol-extensions.md#sending-tablet-info-to-the-drivers

--- a/tests/integration/experiments/test_tablets.py
+++ b/tests/integration/experiments/test_tablets.py
@@ -1,0 +1,156 @@
+import time
+import unittest
+import pytest
+import os
+from cassandra.cluster import Cluster
+from cassandra.policies import ConstantReconnectionPolicy, RoundRobinPolicy, TokenAwarePolicy
+
+from tests.integration import PROTOCOL_VERSION, use_cluster
+from tests.unit.test_host_connection_pool import LOGGER
+
+def setup_module():
+    use_cluster('tablets', [3], start=True, use_tablets=True)
+
+class TestTabletsIntegration(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.cluster = Cluster(contact_points=["127.0.0.1", "127.0.0.2", "127.0.0.3"], protocol_version=PROTOCOL_VERSION,
+                              load_balancing_policy=TokenAwarePolicy(RoundRobinPolicy()),
+                              reconnection_policy=ConstantReconnectionPolicy(1))
+        cls.session = cls.cluster.connect()
+        cls.create_ks_and_cf(cls)
+        cls.create_data(cls.session)
+    
+    @classmethod
+    def teardown_class(cls):
+        cls.cluster.shutdown()
+
+    def verify_same_host_in_tracing(self, results):
+        traces = results.get_query_trace()
+        events = traces.events
+        host_set = set()
+        for event in events:
+            LOGGER.info("TRACE EVENT: %s %s %s", event.source, event.thread_name, event.description)
+            host_set.add(event.source)
+        
+        self.assertEqual(len(host_set), 1)
+        self.assertIn('locally', "\n".join([event.description for event in events]))
+
+        trace_id = results.response_future.get_query_trace_ids()[0]
+        traces = self.session.execute("SELECT * FROM system_traces.events WHERE session_id = %s", (trace_id,))
+        events = [event for event in traces]
+        host_set = set()
+        for event in events:
+            LOGGER.info("TRACE EVENT: %s %s", event.source, event.activity)
+            host_set.add(event.source)
+        
+        self.assertEqual(len(host_set), 1)
+        self.assertIn('locally', "\n".join([event.activity for event in events]))
+
+    def verify_same_shard_in_tracing(self, results):
+        traces = results.get_query_trace()
+        events = traces.events
+        shard_set = set()
+        for event in events:
+            LOGGER.info("TRACE EVENT: %s %s %s", event.source, event.thread_name, event.description)
+            shard_set.add(event.thread_name)
+            
+        self.assertEqual(len(shard_set), 1)
+        self.assertIn('locally', "\n".join([event.description for event in events]))
+
+        trace_id = results.response_future.get_query_trace_ids()[0]
+        traces = self.session.execute("SELECT * FROM system_traces.events WHERE session_id = %s", (trace_id,))
+        events = [event for event in traces]
+        shard_set = set()
+        for event in events:
+            LOGGER.info("TRACE EVENT: %s %s", event.thread, event.activity)
+            shard_set.add(event.thread)
+            
+        self.assertEqual(len(shard_set), 1)
+        self.assertIn('locally', "\n".join([event.activity for event in events]))
+    
+    def create_ks_and_cf(self):
+        self.session.execute(
+            """
+            DROP KEYSPACE IF EXISTS test1
+            """
+        )
+        self.session.execute(
+            """
+            CREATE KEYSPACE test1
+            WITH replication = {
+                'class': 'NetworkTopologyStrategy', 
+                'replication_factor': 1, 
+                'initial_tablets': 8
+            }
+            """)
+
+        self.session.execute(
+            """
+            CREATE TABLE test1.table1 (pk int, ck int, v int, PRIMARY KEY (pk, ck));
+            """)
+        
+    @staticmethod
+    def create_data(session):
+        prepared = session.prepare(
+            """
+            INSERT INTO test1.table1 (pk, ck, v) VALUES (?, ?, ?)
+            """)
+        
+        for i in range(50):
+            bound = prepared.bind((i, i%5, i%2))
+            session.execute(bound)
+
+    def query_data_shard_select(self, session, verify_in_tracing=True):
+        prepared = session.prepare(
+            """
+            SELECT pk, ck, v FROM test1.table1 WHERE pk = ?
+            """)
+
+        bound = prepared.bind([(2)])
+        results = session.execute(bound, trace=True)
+        self.assertEqual(results, [(2, 2, 0)])
+        if verify_in_tracing:
+            self.verify_same_shard_in_tracing(results)
+
+    def query_data_host_select(self, session, verify_in_tracing=True):
+        prepared = session.prepare(
+            """
+            SELECT pk, ck, v FROM test1.table1 WHERE pk = ?
+            """)
+
+        bound = prepared.bind([(2)])
+        results = session.execute(bound, trace=True)
+        self.assertEqual(results, [(2, 2, 0)])
+        if verify_in_tracing:
+            self.verify_same_host_in_tracing(results)
+
+    def query_data_shard_insert(self, session, verify_in_tracing=True):
+        prepared = session.prepare(
+            """
+            INSERT INTO test1.table1 (pk, ck, v) VALUES (?, ?, ?)
+            """)
+
+        bound = prepared.bind([(51), (1), (2)])
+        results = session.execute(bound, trace=True)
+        if verify_in_tracing:
+            self.verify_same_shard_in_tracing(results)
+
+    def query_data_host_insert(self, session, verify_in_tracing=True):
+        prepared = session.prepare(
+            """
+            INSERT INTO test1.table1 (pk, ck, v) VALUES (?, ?, ?)
+            """)
+
+        bound = prepared.bind([(52), (1), (2)])
+        results = session.execute(bound, trace=True)
+        if verify_in_tracing:
+            self.verify_same_host_in_tracing(results)
+
+    def test_tablets(self):
+        self.query_data_host_select(self.session)
+        self.query_data_host_insert(self.session)
+
+    def test_tablets_shard_awareness(self):
+        self.query_data_shard_select(self.session)
+        self.query_data_shard_insert(self.session)

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -526,6 +526,7 @@ class TokenAwarePolicyTest(unittest.TestCase):
     def test_wrap_round_robin(self):
         cluster = Mock(spec=Cluster)
         cluster.metadata = Mock(spec=Metadata)
+        cluster.control_connection._tablets_routing_v1 = False
         hosts = [Host(DefaultEndPoint(str(i)), SimpleConvictionPolicy) for i in range(4)]
         for host in hosts:
             host.set_up()
@@ -557,6 +558,7 @@ class TokenAwarePolicyTest(unittest.TestCase):
     def test_wrap_dc_aware(self):
         cluster = Mock(spec=Cluster)
         cluster.metadata = Mock(spec=Metadata)
+        cluster.control_connection._tablets_routing_v1 = False
         hosts = [Host(DefaultEndPoint(str(i)), SimpleConvictionPolicy) for i in range(4)]
         for host in hosts:
             host.set_up()
@@ -685,6 +687,7 @@ class TokenAwarePolicyTest(unittest.TestCase):
 
         cluster = Mock(spec=Cluster)
         cluster.metadata = Mock(spec=Metadata)
+        cluster.control_connection._tablets_routing_v1 = False
         replicas = hosts[2:]
         cluster.metadata.get_replicas.return_value = replicas
 
@@ -775,6 +778,7 @@ class TokenAwarePolicyTest(unittest.TestCase):
 
         cluster = Mock(spec=Cluster)
         cluster.metadata = Mock(spec=Metadata)
+        cluster.control_connection._tablets_routing_v1 = False
         replicas = hosts[2:]
         cluster.metadata.get_replicas.return_value = replicas
 
@@ -1448,6 +1452,7 @@ class HostFilterPolicyQueryPlanTest(unittest.TestCase):
 
     def test_wrap_token_aware(self):
         cluster = Mock(spec=Cluster)
+        cluster.control_connection._tablets_routing_v1 = False
         hosts = [Host(DefaultEndPoint("127.0.0.{}".format(i)), SimpleConvictionPolicy) for i in range(1, 6)]
         for host in hosts:
             host.set_up()

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -24,7 +24,7 @@ import struct
 from threading import Thread
 
 from cassandra import ConsistencyLevel
-from cassandra.cluster import Cluster
+from cassandra.cluster import Cluster, ControlConnection
 from cassandra.metadata import Metadata
 from cassandra.policies import (RoundRobinPolicy, WhiteListRoundRobinPolicy, DCAwareRoundRobinPolicy,
                                 TokenAwarePolicy, SimpleConvictionPolicy,
@@ -601,6 +601,7 @@ class TokenAwarePolicyTest(unittest.TestCase):
     class FakeCluster:
         def __init__(self):
             self.metadata = Mock(spec=Metadata)
+            self.control_connection = Mock(spec=ControlConnection)
 
     def test_get_distance(self):
         """

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -40,6 +40,7 @@ class ResponseFutureTests(unittest.TestCase):
     def make_basic_session(self):
         s = Mock(spec=Session)
         s.row_factory = lambda col_names, rows: [(col_names, rows)]
+        s.cluster.control_connection._tablets_routing_v1 = False
         return s
 
     def make_pool(self):

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -75,7 +75,7 @@ class ResponseFutureTests(unittest.TestCase):
         rf.send_request()
 
         rf.session._pools.get.assert_called_once_with('ip1')
-        pool.borrow_connection.assert_called_once_with(timeout=ANY, routing_key=ANY)
+        pool.borrow_connection.assert_called_once_with(timeout=ANY, routing_key=ANY, keyspace=ANY, table=ANY)
 
         connection.send_msg.assert_called_once_with(rf.message, 1, cb=ANY, encoder=ProtocolHandler.encode_message, decoder=ProtocolHandler.decode_message, result_metadata=[])
 
@@ -257,7 +257,7 @@ class ResponseFutureTests(unittest.TestCase):
         rf.send_request()
 
         rf.session._pools.get.assert_called_once_with('ip1')
-        pool.borrow_connection.assert_called_once_with(timeout=ANY, routing_key=ANY)
+        pool.borrow_connection.assert_called_once_with(timeout=ANY, routing_key=ANY, keyspace=ANY, table=ANY)
         connection.send_msg.assert_called_once_with(rf.message, 1, cb=ANY, encoder=ProtocolHandler.encode_message, decoder=ProtocolHandler.decode_message, result_metadata=[])
 
         result = Mock(spec=UnavailableErrorMessage, info={})
@@ -276,7 +276,7 @@ class ResponseFutureTests(unittest.TestCase):
         # it should try again with the same host since this was
         # an UnavailableException
         rf.session._pools.get.assert_called_with(host)
-        pool.borrow_connection.assert_called_with(timeout=ANY, routing_key=ANY)
+        pool.borrow_connection.assert_called_with(timeout=ANY, routing_key=ANY, keyspace=ANY, table=ANY)
         connection.send_msg.assert_called_with(rf.message, 2, cb=ANY, encoder=ProtocolHandler.encode_message, decoder=ProtocolHandler.decode_message, result_metadata=[])
 
     def test_retry_with_different_host(self):
@@ -291,7 +291,7 @@ class ResponseFutureTests(unittest.TestCase):
         rf.send_request()
 
         rf.session._pools.get.assert_called_once_with('ip1')
-        pool.borrow_connection.assert_called_once_with(timeout=ANY, routing_key=ANY)
+        pool.borrow_connection.assert_called_once_with(timeout=ANY, routing_key=ANY, keyspace=ANY, table=ANY)
         connection.send_msg.assert_called_once_with(rf.message, 1, cb=ANY, encoder=ProtocolHandler.encode_message, decoder=ProtocolHandler.decode_message, result_metadata=[])
         self.assertEqual(ConsistencyLevel.QUORUM, rf.message.consistency_level)
 
@@ -310,7 +310,7 @@ class ResponseFutureTests(unittest.TestCase):
 
         # it should try with a different host
         rf.session._pools.get.assert_called_with('ip2')
-        pool.borrow_connection.assert_called_with(timeout=ANY, routing_key=ANY)
+        pool.borrow_connection.assert_called_with(timeout=ANY, routing_key=ANY, keyspace=ANY, table=ANY)
         connection.send_msg.assert_called_with(rf.message, 2, cb=ANY, encoder=ProtocolHandler.encode_message, decoder=ProtocolHandler.decode_message, result_metadata=[])
 
         # the consistency level should be the same

--- a/tests/unit/test_tablets.py
+++ b/tests/unit/test_tablets.py
@@ -1,0 +1,88 @@
+import unittest
+
+from cassandra.tablets import Tablets, Tablet
+
+class TabletsTest(unittest.TestCase):
+    def compare_ranges(self, tablets, ranges):
+        self.assertEqual(len(tablets), len(ranges))
+
+        for idx, tablet in enumerate(tablets):
+            self.assertEqual(tablet.first_token, ranges[idx][0], "First token is not correct in tablet: {}".format(tablet))
+            self.assertEqual(tablet.last_token, ranges[idx][1], "Last token is not correct in tablet: {}".format(tablet))
+
+    def test_add_tablet_to_empty_tablets(self):
+        tablets = Tablets({("test_ks", "test_tb"): []})
+        
+        tablets.add_tablet("test_ks", "test_tb", Tablet(-6917529027641081857, -4611686018427387905, None))
+        
+        tablets_list = tablets._tablets.get(("test_ks", "test_tb"))
+
+        self.compare_ranges(tablets_list, [(-6917529027641081857, -4611686018427387905)])
+
+    def test_add_tablet_at_the_beggining(self):
+        tablets = Tablets({("test_ks", "test_tb"): [Tablet(-6917529027641081857, -4611686018427387905, None)]})
+
+        tablets.add_tablet("test_ks", "test_tb", Tablet(-8611686018427387905, -7917529027641081857, None))
+        
+        tablets_list = tablets._tablets.get(("test_ks", "test_tb"))
+
+        self.compare_ranges(tablets_list, [(-8611686018427387905, -7917529027641081857),
+                                           (-6917529027641081857, -4611686018427387905)])
+
+    def test_add_tablet_at_the_end(self):
+        tablets = Tablets({("test_ks", "test_tb"): [Tablet(-6917529027641081857, -4611686018427387905, None)]})
+
+        tablets.add_tablet("test_ks", "test_tb", Tablet(-1, 2305843009213693951, None))
+        
+        tablets_list = tablets._tablets.get(("test_ks", "test_tb"))
+
+        self.compare_ranges(tablets_list, [(-6917529027641081857, -4611686018427387905),
+                                           (-1, 2305843009213693951)])
+
+    def test_add_tablet_in_the_middle(self):
+        tablets = Tablets({("test_ks", "test_tb"): [Tablet(-6917529027641081857, -4611686018427387905, None), 
+                                                    Tablet(-1, 2305843009213693951, None)]},)
+        
+        tablets.add_tablet("test_ks", "test_tb", Tablet(-4611686018427387905, -2305843009213693953, None))
+        
+        tablets_list = tablets._tablets.get(("test_ks", "test_tb"))
+
+        self.compare_ranges(tablets_list, [(-6917529027641081857, -4611686018427387905),
+                                           (-4611686018427387905, -2305843009213693953),
+                                           (-1, 2305843009213693951)])
+
+    def test_add_tablet_intersecting(self):
+        tablets = Tablets({("test_ks", "test_tb"): [Tablet(-6917529027641081857, -4611686018427387905, None), 
+                                                    Tablet(-4611686018427387905, -2305843009213693953, None),
+                                                    Tablet(-2305843009213693953, -1, None),
+                                                    Tablet(-1, 2305843009213693951, None)]})
+        
+        tablets.add_tablet("test_ks", "test_tb", Tablet(-3611686018427387905, -6, None))
+        
+        tablets_list = tablets._tablets.get(("test_ks", "test_tb"))
+
+        self.compare_ranges(tablets_list, [(-6917529027641081857, -4611686018427387905),
+                                           (-3611686018427387905, -6),
+                                           (-1, 2305843009213693951)])
+
+    def test_add_tablet_intersecting_with_first(self):
+        tablets = Tablets({("test_ks", "test_tb"): [Tablet(-8611686018427387905, -7917529027641081857, None),
+                                                    Tablet(-6917529027641081857, -4611686018427387905, None)]})
+        
+        tablets.add_tablet("test_ks", "test_tb", Tablet(-8011686018427387905, -7987529027641081857, None))
+        
+        tablets_list = tablets._tablets.get(("test_ks", "test_tb"))
+
+        self.compare_ranges(tablets_list, [(-8011686018427387905, -7987529027641081857),
+                                           (-6917529027641081857, -4611686018427387905)])
+
+    def test_add_tablet_intersecting_with_last(self):
+        tablets = Tablets({("test_ks", "test_tb"): [Tablet(-8611686018427387905, -7917529027641081857, None),
+                                                    Tablet(-6917529027641081857, -4611686018427387905, None)]})
+        
+        tablets.add_tablet("test_ks", "test_tb", Tablet(-5011686018427387905, -2987529027641081857, None))
+        
+        tablets_list = tablets._tablets.get(("test_ks", "test_tb"))
+
+        self.compare_ranges(tablets_list, [(-8611686018427387905, -7917529027641081857),
+                                           (-5011686018427387905, -2987529027641081857)])


### PR DESCRIPTION
This PR introduces changes to the driver that are necessary for shard-awareness and token-awareness to work effectively with the tablets.

Now if driver send the request to the wrong node/shard it will get the correct tablet information from Scylla in `custom_payload`. It uses this information to obtain target replicas and shard numbers for tables managed by tablet replication. 

I also added parsing TABLETS_ROUTING_V1 extension to ProtocolFeatures. In order for Scylla to send the tablet info, the driver must tell the database during connection handshake that it is able to interpret it. This negotiation is added as a part of ProtocolFeatures class.

To test this change I created integration and unit tests.

Fixes: https://github.com/scylladb/python-driver/issues/281