### PR TITLE
Add support for ScyllaDB's per partition rate limiting's new error

### DIFF
--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import Enum
 import logging
 
 
@@ -728,3 +729,21 @@ class UnresolvableContactPoints(DriverException):
     contact points, only when lookup fails for all hosts
     """
     pass
+
+
+class OperationType(Enum):
+    Read = 0
+    Write = 1
+
+class RateLimitReached(ConfigurationException):
+    '''
+    Rate limit was exceeded for a partition affected by the request.
+    '''
+    op_type = None
+    rejected_by_coordinator = False
+
+    def __init__(self, op_type=None, rejected_by_coordinator=False):
+        self.op_type = op_type
+        self.rejected_by_coordinator = rejected_by_coordinator
+        message = f"[request_error_rate_limit_reached OpType={op_type.name} RejectedByCoordinator={rejected_by_coordinator}]"
+        Exception.__init__(self, message)

--- a/cassandra/c_shard_info.pyx
+++ b/cassandra/c_shard_info.pyx
@@ -36,24 +36,6 @@ cdef class ShardingInfo():
         self.shard_aware_port = int(shard_aware_port) if shard_aware_port else 0
         self.shard_aware_port_ssl = int(shard_aware_port_ssl) if shard_aware_port_ssl else 0
 
-    @staticmethod
-    def parse_sharding_info(message):
-        shard_id = message.options.get('SCYLLA_SHARD', [''])[0] or None
-        shards_count = message.options.get('SCYLLA_NR_SHARDS', [''])[0] or None
-        partitioner = message.options.get('SCYLLA_PARTITIONER', [''])[0] or None
-        sharding_algorithm = message.options.get('SCYLLA_SHARDING_ALGORITHM', [''])[0] or None
-        sharding_ignore_msb = message.options.get('SCYLLA_SHARDING_IGNORE_MSB', [''])[0] or None
-        shard_aware_port = message.options.get('SCYLLA_SHARD_AWARE_PORT', [''])[0] or None
-        shard_aware_port_ssl = message.options.get('SCYLLA_SHARD_AWARE_PORT_SSL', [''])[0] or None
-
-        if not (shard_id or shards_count or partitioner == "org.apache.cassandra.dht.Murmur3Partitioner" or
-            sharding_algorithm == "biased-token-round-robin" or sharding_ignore_msb):
-            return 0, None
-
-        return int(shard_id), ShardingInfo(shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb,
-                                           shard_aware_port, shard_aware_port_ssl)
-
-    
     def shard_id_from_token(self, int64_t token_input):
         cdef uint64_t biased_token = token_input + (<uint64_t>1 << 63);
         biased_token <<= self.sharding_ignore_msb;

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -126,10 +126,13 @@ class ErrorMessage(_MessageType, Exception):
         self.info = info
 
     @classmethod
-    def recv_body(cls, f, protocol_version, *args):
+    def recv_body(cls, f, protocol_version, protocol_features, *args):
         code = read_int(f)
         msg = read_string(f)
-        subcls = error_classes.get(code, cls)
+        if code == protocol_features.rate_limit_error:
+            subcls = RateLimitReachedException
+        else:
+            subcls = error_classes.get(code, cls)
         extra_info = subcls.recv_error_info(f, protocol_version)
         return subcls(code=code, message=msg, info=extra_info)
 
@@ -751,7 +754,7 @@ class ResultMessage(_MessageType):
             raise DriverException("Unknown RESULT kind: %d" % self.kind)
 
     @classmethod
-    def recv_body(cls, f, protocol_version, user_type_map, result_metadata):
+    def recv_body(cls, f, protocol_version, protocol_features, user_type_map, result_metadata):
         kind = read_int(f)
         msg = cls(kind)
         msg.recv(f, protocol_version, user_type_map, result_metadata)
@@ -1160,7 +1163,7 @@ class _ProtocolHandler(object):
         write_int(f, length)
 
     @classmethod
-    def decode_message(cls, protocol_version, user_type_map, stream_id, flags, opcode, body,
+    def decode_message(cls, protocol_version, protocol_features, user_type_map, stream_id, flags, opcode, body,
                        decompressor, result_metadata):
         """
         Decodes a native protocol message body
@@ -1206,7 +1209,7 @@ class _ProtocolHandler(object):
             log.warning("Unknown protocol flags set: %02x. May cause problems.", flags)
 
         msg_class = cls.message_types_by_opcode[opcode]
-        msg = msg_class.recv_body(body, protocol_version, user_type_map, result_metadata)
+        msg = msg_class.recv_body(body, protocol_version, protocol_features, user_type_map, result_metadata)
         msg.stream_id = stream_id
         msg.trace_id = trace_id
         msg.custom_payload = custom_payload

--- a/cassandra/protocol_features.py
+++ b/cassandra/protocol_features.py
@@ -1,0 +1,38 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+
+RATE_LIMIT_ERROR_EXTENSION = "SCYLLA_RATE_LIMIT_ERROR"
+
+class ProtocolFeatures(object):
+    rate_limit_error = None
+
+    def __init__(self, rate_limit_error=None):
+        self.rate_limit_error = rate_limit_error
+
+    @staticmethod
+    def parse_from_supported(supported):
+        return ProtocolFeatures(rate_limit_error = ProtocolFeatures.maybe_parse_rate_limit_error(supported))
+
+    @staticmethod
+    def maybe_parse_rate_limit_error(supported):
+        vals = supported.get(RATE_LIMIT_ERROR_EXTENSION)
+        if vals is not None:
+            code_str = ProtocolFeatures.get_cql_extension_field(vals, "ERROR_CODE")
+            return int(code_str)
+
+    #  Looks up a field which starts with `key=` and returns the rest
+    @staticmethod
+    def get_cql_extension_field(vals, key):
+        for v in vals:
+            stripped_v = v.strip()
+            if stripped_v.startswith(key) and stripped_v[len(key)] == '=':
+                result = stripped_v[len(key) + 1:]
+                return result
+        return None
+
+    def add_startup_options(self, options):
+        if self.rate_limit_error is not None:
+            options[RATE_LIMIT_ERROR_EXTENSION] = ""
+

--- a/cassandra/shard_info.py
+++ b/cassandra/shard_info.py
@@ -28,24 +28,6 @@ class _ShardingInfo(object):
         self.shard_aware_port = int(shard_aware_port) if shard_aware_port else None
         self.shard_aware_port_ssl = int(shard_aware_port_ssl) if shard_aware_port_ssl else None
 
-    @staticmethod
-    def parse_sharding_info(message):
-        shard_id = message.options.get('SCYLLA_SHARD', [''])[0] or None
-        shards_count = message.options.get('SCYLLA_NR_SHARDS', [''])[0] or None
-        partitioner = message.options.get('SCYLLA_PARTITIONER', [''])[0] or None
-        sharding_algorithm = message.options.get('SCYLLA_SHARDING_ALGORITHM', [''])[0] or None
-        sharding_ignore_msb = message.options.get('SCYLLA_SHARDING_IGNORE_MSB', [''])[0] or None
-        shard_aware_port = message.options.get('SCYLLA_SHARD_AWARE_PORT', [''])[0] or None
-        shard_aware_port_ssl = message.options.get('SCYLLA_SHARD_AWARE_PORT_SSL', [''])[0] or None
-        log.debug("Parsing sharding info from message options %s", message.options)
-
-        if not (shard_id or shards_count or partitioner == "org.apache.cassandra.dht.Murmur3Partitioner" or
-            sharding_algorithm == "biased-token-round-robin" or sharding_ignore_msb):
-            return 0, None
-
-        return int(shard_id), _ShardingInfo(shard_id, shards_count, partitioner, sharding_algorithm, sharding_ignore_msb,
-                                            shard_aware_port, shard_aware_port_ssl)
-
     def shard_id_from_token(self, token):
         """
         Convert a Murmur3 token to shard_id based on the number of shards on the host

--- a/docs/scylla-specific.rst
+++ b/docs/scylla-specific.rst
@@ -75,37 +75,6 @@ New Cluster Helpers
         print("successfully connected to all shards of all scylla nodes")
 
 
-New Table Attributes
---------------------
-
-* ``in_memory`` flag
-
-  New flag available on ``TableMetadata.options`` to indicate that it is an `In Memory <https://docs.scylladb.com/using-scylla/in-memory/>`_ table
-
-.. note::  in memory tables is a feature existing only in Scylla Enterprise
-
-.. code:: python
-
-    from cassandra.cluster import Cluster
-
-    cluster = Cluster()
-    session = cluster.connect()
-    session.execute("""
-        CREATE KEYSPACE IF NOT EXISTS keyspace1
-        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
-    """)
-
-    session.execute("""
-        CREATE TABLE IF NOT EXISTS keyspace1.standard1 (
-            key blob PRIMARY KEY,
-            "C0" blob
-        ) WITH in_memory=true AND compaction={'class': 'InMemoryCompactionStrategy'}
-    """)
-
-    cluster.refresh_table_metadata("keyspace1", "standard1")
-    assert cluster.metadata.keyspaces["keyspace1"].tables["standard1"].options["in_memory"] == True
-
-
 New Error Types
 --------------------
 

--- a/docs/scylla-specific.rst
+++ b/docs/scylla-specific.rst
@@ -104,3 +104,39 @@ New Table Attributes
 
     cluster.refresh_table_metadata("keyspace1", "standard1")
     assert cluster.metadata.keyspaces["keyspace1"].tables["standard1"].options["in_memory"] == True
+
+
+New Error Types
+--------------------
+
+* ``SCYLLA_RATE_LIMIT_ERROR`` Error
+
+  The ScyllaDB 5.1 introduced a feature called per-partition rate limiting. In case the (user defined) per-partition rate limit is exceeded, the database will start returning a Scylla-specific type of error: RateLimitReached.
+
+.. code:: python
+
+    from cassandra import RateLimitReached
+    from cassandra.cluster import Cluster
+
+    cluster = Cluster()
+    session = cluster.connect()
+    session.execute("""
+        CREATE KEYSPACE IF NOT EXISTS keyspace1 
+        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
+    """)
+
+    session.execute("USE keyspace1")
+    session.execute("""
+        CREATE TABLE tbl (pk int PRIMARY KEY, v int) 
+        WITH per_partition_rate_limit = {'max_writes_per_second': 1}
+    """)
+
+    prepared = session.prepare("""
+        INSERT INTO tbl (pk, v) VALUES (?, ?)
+    """)
+    
+    try:
+        for _ in range(1000):
+            self.session.execute(prepared.bind((123, 456)))
+    except RateLimitReached:
+        raise

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -91,7 +91,7 @@ DC-aware load balancing policy and to match other drivers.
 Execution API Updates
 ^^^^^^^^^^^^^^^^^^^^^
 Result return normalization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 `PYTHON-368 <https://datastax-oss.atlassian.net/browse/PYTHON-368>`_
 
 Previously results would be returned as a ``list`` of rows for result rows
@@ -129,7 +129,7 @@ This can send requests and load (possibly large) results into memory, so
 `~.ResultSet` will log a warning on implicit materialization.
 
 Trace information is not attached to executed Statements
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------
 `PYTHON-318 <https://datastax-oss.atlassian.net/browse/PYTHON-318>`_
 
 Previously trace data was attached to Statements if tracing was enabled. This
@@ -147,7 +147,7 @@ returned for each query:
 :meth:`.ResultSet.get_all_query_traces()`
 
 Binding named parameters now ignores extra names
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------
 `PYTHON-178 <https://datastax-oss.atlassian.net/browse/PYTHON-178Cassadfasdf>`_
 
 Previously, :meth:`.BoundStatement.bind()` would raise if a mapping

--- a/tests/integration/standard/test_rate_limit_exceeded.py
+++ b/tests/integration/standard/test_rate_limit_exceeded.py
@@ -1,0 +1,59 @@
+import logging
+import unittest
+from cassandra import OperationType, RateLimitReached
+from cassandra.cluster import Cluster
+from cassandra.policies import ConstantReconnectionPolicy, RoundRobinPolicy, TokenAwarePolicy
+
+from tests.integration import PROTOCOL_VERSION, use_cluster
+
+LOGGER = logging.getLogger(__name__)
+
+def setup_module():
+    use_cluster('rate_limit', [3], start=True)
+
+class TestRateLimitExceededException(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.cluster = Cluster(contact_points=["127.0.0.1"], protocol_version=PROTOCOL_VERSION,
+                              load_balancing_policy=TokenAwarePolicy(RoundRobinPolicy()),
+                              reconnection_policy=ConstantReconnectionPolicy(1))
+        cls.session = cls.cluster.connect()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.cluster.shutdown()
+
+    def test_rate_limit_exceeded(self):
+        self.session.execute(
+            """
+            DROP KEYSPACE IF EXISTS ratetests
+            """
+        )
+        self.session.execute(
+            """
+            CREATE KEYSPACE IF NOT EXISTS ratetests 
+            WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}
+            """)
+
+        self.session.execute("USE ratetests")
+        self.session.execute(
+            """
+            CREATE TABLE tbl (pk int PRIMARY KEY, v int) 
+            WITH per_partition_rate_limit = {'max_writes_per_second': 1}
+            """)
+    
+        prepared = self.session.prepare(
+            """
+            INSERT INTO tbl (pk, v) VALUES (?, ?)
+            """)
+
+        # The rate limit is 1 write/s, so repeat the same query
+        # until an error occurs, it should happen quickly
+        def execute_write():
+            for _ in range(1000):
+                self.session.execute(prepared.bind((123, 456)))
+
+        with self.assertRaises(RateLimitReached) as context:
+            execute_write()
+
+        self.assertEqual(context.exception.op_type, OperationType.Write)

--- a/tests/unit/test_host_connection_pool.py
+++ b/tests/unit/test_host_connection_pool.py
@@ -14,6 +14,7 @@
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import time
+from cassandra.protocol_features import ProtocolFeatures
 
 from cassandra.shard_info import _ShardingInfo
 
@@ -300,11 +301,11 @@ class HostConnectionTests(_PoolTests):
                 connection.is_shutdown = False
                 connection.is_defunct = False
                 connection.is_closed = False
-                connection.shard_id = self.connection_counter
+                connection.features = ProtocolFeatures(shard_id=self.connection_counter, 
+                                                       sharding_info=_ShardingInfo(shard_id=1, shards_count=14,
+                                                                    partitioner="", sharding_algorithm="", sharding_ignore_msb=0,
+                                                                    shard_aware_port="", shard_aware_port_ssl=""))
                 self.connection_counter += 1
-                connection.sharding_info = _ShardingInfo(shard_id=1, shards_count=14,
-                                                         partitioner="", sharding_algorithm="", sharding_ignore_msb=0,
-                                                         shard_aware_port="", shard_aware_port_ssl="")
 
                 return connection
 

--- a/tests/unit/test_protocol_features.py
+++ b/tests/unit/test_protocol_features.py
@@ -1,0 +1,27 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest  # noqa
+
+import logging
+
+from cassandra.protocol_features import ProtocolFeatures
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestProtocolFeatures(unittest.TestCase):
+    def test_parsing_rate_limit_error(self):
+        """
+        Testing the parsing of the options command
+        """
+        class OptionsHolder(object):
+            options = {
+                'SCYLLA_RATE_LIMIT_ERROR': ["ERROR_CODE=123"]
+            }
+
+        protocol_features = ProtocolFeatures.parse_from_supported(OptionsHolder().options)
+
+        self.assertEqual(protocol_features.rate_limit_error, 123)
+        self.assertEqual(protocol_features.shard_id, 0)
+        self.assertEqual(protocol_features.sharding_info, None)


### PR DESCRIPTION
This PR adds support for a Scylla-specific type of error returned from the database: RateLimitExceeded. The RateLimitExceeded error is sent when Scylla detects that the per-partition rate limit is exceeded.

In order for Scylla to be able to send this error, the driver must tell the database during connection handshake that it is able to interpret it (otherwise Scylla falls back to the ConfigurationExceptionerror). This PR adds support for Scylla-specific protocol extensions, negotiates the SCYLLA_RATE_LIMIT_ERROR during handshake and adds support for the RateLimitExceeded error decoding.

Fixes: #173 