### PR TITLE
Use version agnostic TLS protocol

### DIFF
--- a/cassandra/scylla/cloud.py
+++ b/cassandra/scylla/cloud.py
@@ -100,7 +100,7 @@ class CloudConfiguration:
         return address, port, node_domain
 
     def create_ssl_context(self):
-        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_SSLv23)
+        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
         ssl_context.verify_mode = ssl.CERT_NONE if self.skip_tls_verify else ssl.CERT_REQUIRED
         for data_center in self.data_centers.values():
             with file_or_memory(path=data_center.get('certificateAuthorityPath'),
@@ -124,7 +124,7 @@ class CloudConfiguration:
                     "PyOpenSSL must be installed to connect to scylla-cloud with the Eventlet or Twisted event loops"),
                 sys.exc_info()[2]
             )
-        ssl_context = SSL.Context(SSL.TLS_METHOD)
+        ssl_context = SSL.Context(SSL.TLS_CLIENT_METHOD)
         ssl_context.set_verify(SSL.VERIFY_PEER, callback=lambda _1, _2, _3, _4, ok: True if self.skip_tls_verify else ok)
         for data_center in self.data_centers.values():
             with file_or_memory(path=data_center.get('certificateAuthorityPath'),

--- a/tests/integration/long/test_ssl.py
+++ b/tests/integration/long/test_ssl.py
@@ -51,7 +51,7 @@ DRIVER_CERTFILE_BAD = os.path.abspath("tests/integration/long/ssl/client_bad.key
 USES_PYOPENSSL = "twisted" in EVENT_LOOP_MANAGER or "eventlet" in EVENT_LOOP_MANAGER
 if "twisted" in EVENT_LOOP_MANAGER:
     import OpenSSL
-    ssl_version = OpenSSL.SSL.TLSv1_2_METHOD
+    ssl_version = OpenSSL.SSL.TLS_METHOD
     verify_certs = {'cert_reqs': SSL.VERIFY_PEER,
                     'check_hostname': True}
 else:
@@ -401,7 +401,7 @@ class SSLConnectionWithSSLContextTests(unittest.TestCase):
         @test_category connection:ssl
         """
         if USES_PYOPENSSL:
-            ssl_context = SSL.Context(SSL.TLSv1_2_METHOD)
+            ssl_context = SSL.Context(SSL.TLS_CLIENT_METHOD)
             ssl_context.load_verify_locations(CLIENT_CA_CERTS)
         else:
             ssl_context = ssl.SSLContext(ssl_version)
@@ -425,7 +425,7 @@ class SSLConnectionWithSSLContextTests(unittest.TestCase):
         ssl_options = {}
 
         if USES_PYOPENSSL:
-            ssl_context = SSL.Context(SSL.TLSv1_2_METHOD)
+            ssl_context = SSL.Context(SSL.TLS_CLIENT_METHOD)
             ssl_context.use_certificate_file(abs_driver_certfile)
             with open(abs_driver_keyfile) as keyfile:
                 key = crypto.load_privatekey(crypto.FILETYPE_PEM, keyfile.read(), b'cassandra')
@@ -446,7 +446,7 @@ class SSLConnectionWithSSLContextTests(unittest.TestCase):
         """
         ssl_options = {}
         if USES_PYOPENSSL:
-            ssl_context = SSL.Context(SSL.TLSv1_2_METHOD)
+            ssl_context = SSL.Context(SSL.TLS_CLIENT_METHOD)
             ssl_context.use_certificate_file(DRIVER_CERTFILE)
             with open(DRIVER_KEYFILE_ENCRYPTED) as keyfile:
                 key = crypto.load_privatekey(crypto.FILETYPE_PEM, keyfile.read(), b'cassandra')
@@ -469,7 +469,7 @@ class SSLConnectionWithSSLContextTests(unittest.TestCase):
     def test_cannot_connect_ssl_context_with_invalid_hostname(self):
         ssl_options = {}
         if USES_PYOPENSSL:
-            ssl_context = SSL.Context(SSL.TLSv1_2_METHOD)
+            ssl_context = SSL.Context(SSL.TLS_CLIENT_METHOD)
             ssl_context.use_certificate_file(DRIVER_CERTFILE)
             with open(DRIVER_KEYFILE_ENCRYPTED) as keyfile:
                 key = crypto.load_privatekey(crypto.FILETYPE_PEM, keyfile.read(), b"cassandra")


### PR DESCRIPTION
Specifically, PROTOCOL_SSLv23 was changed to PROTOCOL_TLS_CLIENT and in the tests, TLSv1_2_METHOD was changed to TLS_CLIENT_METHOD

Fixes: https://github.com/scylladb/python-driver/issues/250