### PR TITLE
add connect_timeout inside `set_keyspace_blocking`

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -1509,7 +1509,7 @@ class Connection(object):
         query = QueryMessage(query='USE "%s"' % (keyspace,),
                              consistency_level=ConsistencyLevel.ONE)
         try:
-            result = self.wait_for_response(query)
+            result = self.wait_for_response(query, timeout=self.connect_timeout)
         except InvalidRequestException as ire:
             # the keyspace probably doesn't exist
             raise ire.to_exception()


### PR DESCRIPTION
`set_keyspace_blocking` is called from places holding a lock, and in case that the connection is closed from the server side, it might hang forever.

using the `connect_timeout` on it to make sure it
won't hang forever.

Ref: https://github.com/scylladb/python-driver/issues/261