### PR TITLE
Support the deprecation of asyncore in python 3.12

### DIFF
--- a/.github/workflows/build-experimental.yml
+++ b/.github/workflows/build-experimental.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 env:
  CIBW_BEFORE_BUILD_LINUX: "rm -rf ~/.pyxbld && yum install -y libev libev-devel openssl openssl-devel"
  CIBW_ENVIRONMENT: "CASS_DRIVER_BUILD_CONCURRENCY=2 CFLAGS='-g0 -O3'"
- CIBW_BUILD: "cp38* cp39* cp310* cp311*"
+ CIBW_BUILD: "cp39* cp310* cp311* cp312*"
  CIBW_SKIP: "*musllinux*"
 jobs:
   build_wheels:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -10,7 +10,7 @@ env:
  CIBW_BEFORE_TEST: "pip install -r {project}/test-requirements.txt"
  CIBW_BEFORE_BUILD_LINUX: "rm -rf ~/.pyxbld && yum install -y libffi-devel libev libev-devel openssl openssl-devel"
  CIBW_ENVIRONMENT: "CASS_DRIVER_BUILD_CONCURRENCY=2 CFLAGS='-g0 -O3'"
- CIBW_SKIP: cp35* cp36* *musllinux* cp312*
+ CIBW_SKIP: cp35* cp36* *musllinux*
 
 jobs:
   build_wheels:

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -101,7 +101,9 @@ except ImportError:
 
 try:
     from cassandra.io.eventletreactor import EventletConnection
-except ImportError:
+except (ImportError, AttributeError):
+    # AttributeError was add for handling python 3.12 https://github.com/eventlet/eventlet/issues/812
+    # TODO: remove it when eventlet issue would be fixed
     EventletConnection = None
 
 try:
@@ -115,9 +117,13 @@ if six.PY3:
 def _is_eventlet_monkey_patched():
     if 'eventlet.patcher' not in sys.modules:
         return False
-    import eventlet.patcher
-    return eventlet.patcher.is_monkey_patched('socket')
-
+    try:
+        import eventlet.patcher
+        return eventlet.patcher.is_monkey_patched('socket')
+    except (ImportError, AttributeError):
+        # AttributeError was add for handling python 3.12 https://github.com/eventlet/eventlet/issues/812
+        # TODO: remove it when eventlet issue would be fixed
+        return False
 
 def _is_gevent_monkey_patched():
     if 'gevent.monkey' not in sys.modules:

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -143,7 +143,10 @@ else:
     try:
         from cassandra.io.libevreactor import LibevConnection as DefaultConnection  # NOQA
     except ImportError:
-        from cassandra.io.asyncorereactor import AsyncoreConnection as DefaultConnection  # NOQA
+        try:
+            from cassandra.io.asyncorereactor import AsyncoreConnection as DefaultConnection # NOQA
+        except ImportError:
+            from cassandra.io.asyncioreactor import AsyncioConnection as DefaultConnection  # NOQA
 
 # Forces load of utf8 encoding module to avoid deadlock that occurs
 # if code that is being imported tries to import the module in a seperate

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import asyncore
 import subprocess
 
 import unittest

--- a/tests/integration/standard/test_connection.py
+++ b/tests/integration/standard/test_connection.py
@@ -26,8 +26,12 @@ from unittest import SkipTest
 
 from cassandra import ConsistencyLevel, OperationTimedOut
 from cassandra.cluster import NoHostAvailable, ConnectionShutdown, ExecutionProfile, EXEC_PROFILE_DEFAULT
-import cassandra.io.asyncorereactor
-from cassandra.io.asyncorereactor import AsyncoreConnection
+
+try:
+    from cassandra.io.asyncorereactor import AsyncoreConnection
+except ImportError:
+    AsyncoreConnection = None
+
 from cassandra.protocol import QueryMessage
 from cassandra.connection import Connection
 from cassandra.policies import HostFilterPolicy, RoundRobinPolicy, HostStateListener

--- a/tests/integration/standard/test_scylla_cloud.py
+++ b/tests/integration/standard/test_scylla_cloud.py
@@ -6,15 +6,22 @@ from ccmlib.utils.sni_proxy import refresh_certs, get_cluster_info, start_sni_pr
 
 from tests.integration import use_cluster
 from cassandra.cluster import Cluster, TwistedConnection
-from cassandra.io.asyncorereactor import AsyncoreConnection
-from cassandra.io.libevreactor import LibevConnection
-from cassandra.io.geventreactor import GeventConnection
-from cassandra.io.eventletreactor import EventletConnection
-from cassandra.io.asyncioreactor import AsyncioConnection
 
-supported_connection_classes = [AsyncoreConnection, LibevConnection, TwistedConnection]
+
+from cassandra.io.libevreactor import LibevConnection
+supported_connection_classes = [LibevConnection, TwistedConnection]
+try:
+    from cassandra.io.asyncorereactor import AsyncoreConnection
+    supported_connection_classes += [AsyncoreConnection]
+except ImportError:
+    pass
+
+#from cassandra.io.geventreactor import GeventConnection
+#from cassandra.io.eventletreactor import EventletConnection
+#from cassandra.io.asyncioreactor import AsyncioConnection
+
 # need to run them with specific configuration like `gevent.monkey.patch_all()` or under async functions
-unsupported_connection_classes = [GeventConnection, AsyncioConnection, EventletConnection]
+# unsupported_connection_classes = [GeventConnection, AsyncioConnection, EventletConnection]
 
 
 class ScyllaCloudConfigTests(TestCase):


### PR DESCRIPTION
since we need to deprecate asyncore which was the default event loop manager, we need to extend the testing of some of the other so we can select a new default