### PR TITLE
CI: run integration tests on multiple EVENT_LOOP_MANAGER and python versions

### DIFF
--- a/.github/workflows/build-experimental.yml
+++ b/.github/workflows/build-experimental.yml
@@ -18,7 +18,7 @@ jobs:
         archs: [ aarch64, ppc64le ]
 
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v3
 
       - name: Set up QEMU
         id: qemu
@@ -27,7 +27,7 @@ jobs:
           platforms: all
         if: runner.os == 'Linux'
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
 
       - name: Install cibuildwheel

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -46,9 +46,9 @@ jobs:
             platform: PyPy
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
 
       - name: Install cibuildwheel
@@ -113,7 +113,7 @@ jobs:
 
       - name: Build wheels
         run: |
-          python -m cibuildwheel --output-dir wheelhouse
+          python3 -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v2
         with:
@@ -124,9 +124,9 @@ jobs:
     if: "(!contains(github.event.pull_request.labels.*.name, 'disable-test-build'))|| github.event_name == 'push' && endsWith(github.event.ref, 'scylla')"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
 
       - name: Build sdist

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,15 +10,47 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    name: test ${{ matrix.event_loop_manager }} (${{ matrix.python-version }})
     if: "!contains(github.event.pull_request.labels.*.name, 'disable-integration-tests')"
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: "3.8"
+            event_loop_manager: "libev"
 
+          - os: ubuntu-latest
+            python-version: "3.8"
+            event_loop_manager: "asyncio"
+
+          - os: ubuntu-latest
+            python-version: "3.8"
+            event_loop_manager: "asyncore"
+
+          - os: ubuntu-latest
+            python-version: "3.11"
+            event_loop_manager: "libev"
+
+          - os: ubuntu-latest
+            python-version: "3.11"
+            event_loop_manager: "asyncio"
+
+          - os: ubuntu-latest
+            python-version: "3.11"
+            event_loop_manager: "asyncore"
+
+          - os: ubuntu-latest
+            python-version: "3.12"
+            event_loop_manager: "libev"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Test with pytest
       run: |
+        export EVENT_LOOP_MANAGER=${{ matrix.event_loop_manager }}
         ./ci/run_integration_test.sh tests/integration/standard/ tests/integration/cqlengine/

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,44 +12,23 @@ jobs:
   tests:
     name: test ${{ matrix.event_loop_manager }} (${{ matrix.python-version }})
     if: "!contains(github.event.pull_request.labels.*.name, 'disable-integration-tests')"
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            python-version: "3.8"
-            event_loop_manager: "libev"
-
-          - os: ubuntu-latest
-            python-version: "3.8"
-            event_loop_manager: "asyncio"
-
-          - os: ubuntu-latest
-            python-version: "3.8"
+        python-version: ["3.11.4", "3.12.0b4"]
+        event_loop_manager: ["libev", "asyncio", "asyncore"]
+        exclude:
+          - python-version: "3.12.0b4"
             event_loop_manager: "asyncore"
 
-          - os: ubuntu-latest
-            python-version: "3.11"
-            event_loop_manager: "libev"
-
-          - os: ubuntu-latest
-            python-version: "3.11"
-            event_loop_manager: "asyncio"
-
-          - os: ubuntu-latest
-            python-version: "3.11"
-            event_loop_manager: "asyncore"
-
-          - os: ubuntu-latest
-            python-version: "3.12"
-            event_loop_manager: "libev"
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - name: setup pyenv ${{ matrix.python-version }}
+      uses: "gabrielfalcao/pyenv-action@v16"
       with:
-        python-version: ${{ matrix.python-version }}
+        default: 2.7.14
+        versions: ${{ matrix.python-version }}
     - name: Test with pytest
       run: |
         export EVENT_LOOP_MANAGER=${{ matrix.event_loop_manager }}

--- a/ci/run_integration_test.sh
+++ b/ci/run_integration_test.sh
@@ -38,9 +38,7 @@ ccm remove
 
 # run test
 
-echo "export SCYLLA_VERSION=${SCYLLA_RELEASE}"
-echo "PROTOCOL_VERSION=4 EVENT_LOOP_MANAGER=asyncio pytest --import-mode append tests/integration/standard/"
 export SCYLLA_VERSION=${SCYLLA_RELEASE}
 export MAPPED_SCYLLA_VERSION=3.11.4
-PROTOCOL_VERSION=4 EVENT_LOOP_MANAGER=libev pytest -rf --import-mode append $*
+PROTOCOL_VERSION=4  pytest -rf --import-mode append $*
 


### PR DESCRIPTION
since we need to deprecate asyncore which was the default
event loop manager, we need to extend the testing of some of the
other so we can select a new default