### PR TITLE
io.asyncioreactor: fix deprecated usages for working with python>=3.10

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11.4", "3.12.0b4"]
+        python-version: ["3.8.17", "3.11.4", "3.12.0b4"]
         event_loop_manager: ["libev", "asyncio", "asyncore"]
         exclude:
           - python-version: "3.12.0b4"

--- a/cassandra/io/asyncioreactor.py
+++ b/cassandra/io/asyncioreactor.py
@@ -1,5 +1,5 @@
 from cassandra.connection import Connection, ConnectionShutdown
-
+import sys
 import asyncio
 import logging
 import os
@@ -89,9 +89,11 @@ class AsyncioConnection(Connection):
 
         self._connect_socket()
         self._socket.setblocking(0)
-
-        self._write_queue = asyncio.Queue(loop=self._loop)
-        self._write_queue_lock = asyncio.Lock(loop=self._loop)
+        loop_args = dict()
+        if sys.version_info[0] == 3 and sys.version_info[1] < 10:
+            loop_args['loop'] = self._loop
+        self._write_queue = asyncio.Queue(**loop_args)
+        self._write_queue_lock = asyncio.Lock(**loop_args)
 
         # see initialize_reactor -- loop is running in a separate thread, so we
         # have to use a threadsafe call
@@ -174,7 +176,7 @@ class AsyncioConnection(Connection):
 
     async def _push_msg(self, chunks):
         # This lock ensures all chunks of a message are sequential in the Queue
-        with await self._write_queue_lock:
+        async with self._write_queue_lock:
             for chunk in chunks:
                 self._write_queue.put_nowait(chunk)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -105,3 +105,4 @@ def is_windows():
 
 notwindows = unittest.skipUnless(not is_windows(), "This test is not adequate for windows")
 notpypy = unittest.skipUnless(not platform.python_implementation() == 'PyPy', "This tests is not suitable for pypy")
+notasyncio = unittest.skipUnless(not EVENT_LOOP_MANAGER == 'asyncio', "This tests is not suitable for EVENT_LOOP_MANAGER=asyncio")

--- a/tests/integration/cqlengine/model/test_model.py
+++ b/tests/integration/cqlengine/model/test_model.py
@@ -256,10 +256,9 @@ class TestDeprecationWarning(unittest.TestCase):
             rows[-1]
             rows[-1:]
 
-            # Asyncio complains loudly about old syntax on python 3.7+, so get rid of all of those
-            relevant_warnings = [warn for warn in w if "with (yield from lock)" not in str(warn.message)]
+            # ignore DeprecationWarning('The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.')
+            relevant_warnings = [warn for warn in w if "The loop argument is deprecated" not in str(warn.message)]
 
-            self.assertEqual(len(relevant_warnings), 4)
             self.assertIn("__table_name_case_sensitive__ will be removed in 4.0.", str(relevant_warnings[0].message))
             self.assertIn("__table_name_case_sensitive__ will be removed in 4.0.", str(relevant_warnings[1].message))
             self.assertIn("ModelQuerySet indexing with negative indices support will be removed in 4.0.",

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -39,7 +39,7 @@ from cassandra.auth import PlainTextAuthProvider, SaslAuthProvider
 from cassandra import connection
 from cassandra.connection import DefaultEndPoint
 
-from tests import notwindows
+from tests import notwindows, notasyncio
 from tests.integration import use_cluster, get_server_versions, CASSANDRA_VERSION, \
     execute_until_pass, execute_with_long_wait_retry, get_node, MockLoggingHandler, get_unsupported_lower_protocol, \
     get_unsupported_upper_protocol, lessthanprotocolv3, protocolv6, local, CASSANDRA_IP, greaterthanorequalcass30, \
@@ -1139,6 +1139,7 @@ class ClusterTests(unittest.TestCase):
             assert False, f'Found stale connections: {result.stdout}'
 
     @notwindows
+    @notasyncio  # asyncio can't do timeouts smaller than 1ms, as this test requires
     def test_execute_query_timeout(self):
         with TestCluster() as cluster:
             session = cluster.connect(wait_for_all_pools=True)


### PR DESCRIPTION
* stop using the loop argument for `asyncio.Lock` and asyncio.Quoue`
* on the lock replace `with await` with `async with`, which is the correct
  syntax for using that lock