### PR TITLE
cqlengine: Remove deepcopy on UserType deserialization

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -1038,12 +1038,11 @@ class UserDefinedType(Column):
         if value is None:
             return
 
-        copied_value = deepcopy(value)
         for name, field in self.user_type._fields.items():
-            if copied_value[name] is not None or isinstance(field, BaseContainerColumn):
-                copied_value[name] = field.to_python(copied_value[name])
+            if value[name] is not None or isinstance(field, BaseContainerColumn):
+                value[name] = field.to_python(value[name])
 
-        return copied_value
+        return value
 
     def to_database(self, value):
         if value is None:


### PR DESCRIPTION
This change makes it so newly instanced UserType during deserialization
isn't immediately copied by deepcopy, which could cause huge slowdown if
that UserType contains a lot of data or nested UserTypes, in which case the
deepcopy calls would cascade as each to_python call would eventually clone
parts of source object. As there isn't a lot of information on why this
deepcopy is here in the first place this change could potentially break
something. Running integration tests against this commit does not produce
regressions, so this call looks safe to remove, but I'm leaving this
warning here for the future reference.

Fixes #152
