### PR TITLE
connection: fix logging of non-IP sockets

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -940,7 +940,7 @@ class Connection(object):
                 self._initiate_connection(sockaddr)
                 self._socket.settimeout(None)
                 local_addr = self._socket.getsockname()
-                log.debug('Connection %s %s:%s -> %s:%s', id(self), local_addr[0], local_addr[1], sockaddr[0], sockaddr[1])
+                log.debug("Connection %s: '%s' -> '%s'", id(self), local_addr, sockaddr)
                 if self._check_hostname:
                     self._match_hostname()
                 sockerr = None


### PR DESCRIPTION
Before this fix, the debug log would crash `_connect_socket` for UNIX  domain sockets. `getsockname()` for UNIX domain sockets returns a single string instead of a tuple (as is the case for IPv4/IPv6). Therefore the code could crash as it tried to get the second element of a non-tuple (empty string):

```
Traceback (most recent call last):
  File "/home/margdoc/Workspace/scylla/maintenance_mode_testing.py", line 5, in <module>
    s = c.connect()
      ^^^^^^^^^^^
  File "cassandra/cluster.py", line 1750, in cassandra.cluster.Cluster.connect
  File "cassandra/cluster.py", line 1776, in cassandra.cluster.Cluster.connect
  File "cassandra/cluster.py", line 1763, in cassandra.cluster.Cluster.connect
  File "cassandra/cluster.py", line 3581, in cassandra.cluster.ControlConnection.connect
  File "cassandra/cluster.py", line 3642, in cassandra.cluster.ControlConnection._reconnect_internal
cassandra.cluster.NoHostAvailable: ('Unable to connect to any servers', {'test_socket': IndexError('string index out of range')})
```

Fix the issue by not unpacking those values and just printing them as-is, relying on `%s` formatter to print all elements of a tuple (host, port) for IP sockets and string for UNIX domain sockets. The printed log is not formatted as nice as before, however this is a `DEBUG` print so few users will ever see it. The new approach should work with any format of `getsockname()`.

Fixes #278