### PR TITLE
Add support for unix domain sockets to `WhiteListRoundRobinPolicy`

### DIFF
--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -34,7 +34,7 @@ from cassandra.policies import (RoundRobinPolicy, WhiteListRoundRobinPolicy, DCA
                                 LoadBalancingPolicy, ConvictionPolicy, ReconnectionPolicy, FallthroughRetryPolicy,
                                 IdentityTranslator, EC2MultiRegionTranslator, HostFilterPolicy)
 from cassandra.pool import Host
-from cassandra.connection import DefaultEndPoint
+from cassandra.connection import DefaultEndPoint, UnixSocketEndPoint
 from cassandra.query import Statement
 
 from six.moves import xrange
@@ -1248,6 +1248,17 @@ class WhiteListRoundRobinPolicyTest(unittest.TestCase):
         hosts = ['localhost']
         policy = WhiteListRoundRobinPolicy(hosts)
         host = Host(DefaultEndPoint("127.0.0.1"), SimpleConvictionPolicy)
+        policy.populate(None, [host])
+
+        qplan = list(policy.make_query_plan())
+        self.assertEqual(sorted(qplan), [host])
+
+        self.assertEqual(policy.distance(host), HostDistance.LOCAL)
+    
+    def test_hosts_with_socket_hostname(self):
+        hosts = [UnixSocketEndPoint('/tmp/scylla-workdir/cql.m')]
+        policy = WhiteListRoundRobinPolicy(hosts)
+        host = Host(UnixSocketEndPoint('/tmp/scylla-workdir/cql.m'), SimpleConvictionPolicy)
         policy.populate(None, [host])
 
         qplan = list(policy.make_query_plan())


### PR DESCRIPTION
If the contact point is unix domain socket, there is no need to try to resolve it and use `socket.getaddrinfo`. In fact calling this function on unix domain socket makes it fail. 

This PR adds checking if host is `UnixSocketEndPoint` and adapts the behavior to the type of endpoint.

I tested it manually by running this example:
```python
from cassandra.cluster import Cluster
from cassandra.connection import UnixSocketEndPoint
from cassandra.policies import HostFilterPolicy, RoundRobinPolicy

socket = "<node's workdir>/cql.m"
cluster = Cluster([UnixSocketEndPoint(socket)],
                  # Driver tries to connect to other nodes in the cluster, so we need to filter them out.
                  load_balancing_policy=WhiteListRoundRobinPolicy([UnixSocketEndPoint(socket)])
session = cluster.connect()
```

Partially fixes: https://github.com/scylladb/python-driver/issues/280 (it adds support in`WhiteListRoundRobinPolicy`, but it is not enough for cqlsh to work)