### PR TITLE
Update CI to use new way of initializing keyspace with tablets

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,5 +38,5 @@ jobs:
     - name: Test tablets
       run: |
         export EVENT_LOOP_MANAGER=${{ matrix.event_loop_manager }}
-        export SCYLLA_VERSION='unstable/master:2024-01-03T08:06:57Z'
+        export SCYLLA_VERSION='unstable/master:2024-01-17T17:56:00Z'
         ./ci/run_integration_test.sh tests/integration/experiments/

--- a/tests/integration/experiments/test_tablets.py
+++ b/tests/integration/experiments/test_tablets.py
@@ -80,8 +80,9 @@ class TestTabletsIntegration(unittest.TestCase):
             CREATE KEYSPACE test1
             WITH replication = {
                 'class': 'NetworkTopologyStrategy', 
-                'replication_factor': 1, 
-                'initial_tablets': 8
+                'replication_factor': 1 
+            } AND tablets = {
+                'initial': 8
             }
             """)
 


### PR DESCRIPTION
https://github.com/scylladb/scylladb/pull/16364 changed the way keyspace should be initialize to use tablets.

This PR updates the version used to run tablets test and updates the way that keyspace with tablets is initialized.
