### PR TITLE
docs: fix minor syntax issues

### DIFF
--- a/docs/scylla-specific.rst
+++ b/docs/scylla-specific.rst
@@ -114,8 +114,8 @@ New Error Types
 Tablet Awareness
 ----------------
 
-**scylla-driver** is tablet aware, which mean that it is able to parse `TABLETS_ROUTING_V1` extension to ProtocolFeatures, recieve tablet information send by Scylla in `custom_payload` part of `RESULT` message, and utilize it.
-Thanks to that queries to tablet based tables are still shard aware.
+**scylla-driver** is tablet-aware, which means that it is able to parse `TABLETS_ROUTING_V1` extension to ProtocolFeatures, recieve tablet information sent by Scylla in the `custom_payload` part of the `RESULT` message, and utilize it.
+Thanks to this, queries to tablet-based tables are still shard-aware.
 
 Details on the scylla cql protocol extensions
 https://github.com/scylladb/scylladb/blob/master/docs/dev/protocol-extensions.md#negotiate-sending-tablets-info-to-the-drivers


### PR DESCRIPTION
for instance, s/send/sent/: to use past-tense form of the verb to agree with the sentense's structure. and other trivial changes.