### PR TITLE
Add setting `connected_event` flag in libevreactor

### DIFF
--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -294,6 +294,7 @@ class LibevConnection(Connection):
         if not self.is_defunct:
             self.error_all_requests(
                 ConnectionShutdown("Connection to %s was closed" % self.endpoint))
+            self.connected_event.set()
 
     def handle_write(self, watcher, revents, errno=None):
         if revents & libev.EV_ERROR:


### PR DESCRIPTION
Before, the `connected_event` flag was set in every implementation of `Connection` but this utilizing `libev`. That was causing the driver to sometimes hang for >3 minutes when shutting down.

This PR adds setting the connected_event flag in `close()` in `LibevConnection`.

Fixes: https://github.com/scylladb/python-driver/issues/172