### PR TITLE
Close pending connections during shutdown

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1691,13 +1691,13 @@ class Cluster(object):
                 "when using protocol_version 1 or 2.")
         self._max_connections_per_host[host_distance] = max_connections
 
-    def connection_factory(self, endpoint, *args, **kwargs):
+    def connection_factory(self, endpoint, host_conn = None, *args, **kwargs):
         """
         Called to create a new connection with proper configuration.
         Intended for internal use only.
         """
         kwargs = self._make_connection_kwargs(endpoint, kwargs)
-        return self.connection_class.factory(endpoint, self.connect_timeout, *args, **kwargs)
+        return self.connection_class.factory(endpoint, self.connect_timeout, host_conn, *args, **kwargs)
 
     def _make_connection_factory(self, host, *args, **kwargs):
         kwargs = self._make_connection_kwargs(host.endpoint, kwargs)

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -865,7 +865,7 @@ class Connection(object):
         raise NotImplementedError()
 
     @classmethod
-    def factory(cls, endpoint, timeout, *args, **kwargs):
+    def factory(cls, endpoint, timeout, host_conn = None, *args, **kwargs):
         """
         A factory function which returns connections which have
         succeeded in connecting and are ready for service (or
@@ -874,6 +874,10 @@ class Connection(object):
         start = time.time()
         kwargs['connect_timeout'] = timeout
         conn = cls(endpoint, *args, **kwargs)
+        if host_conn is not None:
+            host_conn._pending_connections.append(conn)
+            if host_conn.is_shutdown:
+                conn.close()
         elapsed = time.time() - start
         conn.connected_event.wait(timeout - elapsed)
         if conn.last_error:


### PR DESCRIPTION
Previously, if the shutdown occurred in the middle of creating a connection to the missing shard in `HostConnection`, there was no way to close that connection, resulting in the driver hanging for >3 minutes.

This PR introduces a new field in the `HostConnection` class - `_pending_connections` - to keep track of connections that are in the middle of being created, along with a mechanism to close these connections if shutdown was executed.

Fixes: #262 (this reproducer - https://github.com/kbr-scylla/scylladb/commits/test-pause - doesn’t reproduce with that fix)
