### PR TITLE
asyncioreactor: initial background_tasks set earlier

### DIFF
--- a/cassandra/io/asyncioreactor.py
+++ b/cassandra/io/asyncioreactor.py
@@ -87,6 +87,7 @@ class AsyncioConnection(Connection):
 
     def __init__(self, *args, **kwargs):
         Connection.__init__(self, *args, **kwargs)
+        self._background_tasks = set()
 
         self._connect_socket()
         self._socket.setblocking(0)
@@ -106,7 +107,7 @@ class AsyncioConnection(Connection):
         )
         self._send_options_message()
 
-        self._background_tasks = set()
+
 
     @classmethod
     def initialize_reactor(cls):


### PR DESCRIPTION
in b80960f9 we introduce this new set, but initialize it after starting the coroutines, which can lead to cases it won't yet be defined.

moveing it to the start of the the `__init__` method fixes the issue