### PR TITLE
tests/integration: set `skip_wait_for_gossip_to_settle=0`

### DIFF
--- a/ci/run_integration_test.sh
+++ b/ci/run_integration_test.sh
@@ -37,5 +37,5 @@ ccm remove
 # run test
 
 export MAPPED_SCYLLA_VERSION=3.11.4
-PROTOCOL_VERSION=4  pytest -rf --import-mode append $*
+PROTOCOL_VERSION=4  pytest -vv -s --log-cli-level=debug  -rf --import-mode append $*
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -499,7 +499,7 @@ def is_current_cluster(cluster_name, node_counts, workloads):
 
 
 def start_cluster_wait_for_up(cluster):
-    cluster.start(wait_for_binary_proto=True)
+    cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
     # Added to wait for slow nodes to start up
     log.debug("Cluster started waiting for binary ports")
     for node in CCM_CLUSTER.nodes.values():
@@ -623,6 +623,7 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None, 
                     else:
                         CCM_CLUSTER.set_configuration_options({'experimental_features': ['lwt', 'udf'], 'start_native_transport': True})
 
+                    CCM_CLUSTER.set_configuration_options({'skip_wait_for_gossip_to_settle': 0})
                     # Permit IS NOT NULL restriction on non-primary key columns of a materialized view
                     # This allows `test_metadata_with_quoted_identifiers` to run
                     CCM_CLUSTER.set_configuration_options({'strict_is_not_null_in_views': False})
@@ -659,7 +660,7 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None, 
                 node.set_workloads(workloads)
         if start:
             log.debug("Starting CCM cluster: {0}".format(cluster_name))
-            CCM_CLUSTER.start(jvm_args=jvm_args, wait_for_binary_proto=True)
+            CCM_CLUSTER.start(jvm_args=jvm_args, wait_for_binary_proto=True, wait_other_notice=True)
             # Added to wait for slow nodes to start up
             log.debug("Cluster started waiting for binary ports")
             for node in CCM_CLUSTER.nodes.values():

--- a/tests/integration/long/test_policies.py
+++ b/tests/integration/long/test_policies.py
@@ -29,7 +29,7 @@ class RetryPolicyTests(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cluster = get_cluster()
-        cluster.start(wait_for_binary_proto=True)  # make sure other nodes are restarted
+        cluster.start(wait_for_binary_proto=True, wait_other_notice=True)  # make sure other nodes are restarted
 
     def test_should_rethrow_on_unvailable_with_default_policy_if_cas(self):
         """

--- a/tests/integration/standard/test_authentication_misconfiguration.py
+++ b/tests/integration/standard/test_authentication_misconfiguration.py
@@ -31,7 +31,7 @@ class MisconfiguredAuthenticationTests(unittest.TestCase):
                 'authenticator': 'PasswordAuthenticator',
                 'authorizer': 'CassandraAuthorizer',
             })
-            ccm_cluster.start(wait_for_binary_proto=True)
+            ccm_cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
 
             cls.ccm_cluster = ccm_cluster
 

--- a/tests/integration/standard/test_custom_cluster.py
+++ b/tests/integration/standard/test_custom_cluster.py
@@ -26,11 +26,7 @@ def setup_module():
     config_options = {'native_transport_port': 9046}
     ccm_cluster.set_configuration_options(config_options)
     # can't use wait_for_binary_proto cause ccm tries on port 9042
-    ccm_cluster.start(wait_for_binary_proto=False)
-    # wait until all nodes are up
-    wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
-    wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
-    wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.3'], port=9046).connect().shutdown(), 1, 120)
+    ccm_cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
 
 
 def teardown_module():

--- a/tests/integration/standard/test_scylla_cloud.py
+++ b/tests/integration/standard/test_scylla_cloud.py
@@ -41,7 +41,7 @@ class ScyllaCloudConfigTests(TestCase):
 
         ccm_cluster._update_config()
 
-        ccm_cluster.start(wait_for_binary_proto=True)
+        ccm_cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
 
         nodes_info = get_cluster_info(ccm_cluster, port=ssl_port)
         refresh_certs(ccm_cluster, nodes_info)


### PR DESCRIPTION
to speed up the boot sequence of scylla nodes
we are using `skip_wait_for_gossip_to_settle=0` same as we are using for quite a while in dtest on almost all tests

also introduced `wait_other_notice=True` for places
where starting the cluster, because without it we can get
into situation we start a test, and cluster isn't fully
ready and up.

this change shaves 1h of integration tests run, and it's now finishes in 28min.