### PR TITLE
Only add host if endpoint is not already present

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2169,6 +2169,9 @@ class Cluster(object):
         the metadata.
         Intended for internal use only.
         """
+        with self.metadata._hosts_lock:
+            if endpoint in self.metadata._host_id_by_endpoint:
+                return self.metadata._hosts[self.metadata._host_id_by_endpoint[endpoint]], False
         host, new = self.metadata.add_or_return_host(Host(endpoint, self.conviction_policy_factory, datacenter, rack, host_id=host_id))
         if new and signal:
             log.info("New Cassandra host %r discovered", host)


### PR DESCRIPTION
In d735957 there was a functionality added to reresolve hostnames when all hosts are unreachable. In such a scenario, the driver will try to save the situation by reresolving the contact points in case there was a DNS name change.

However, if there was no address change, this results in creation of a new Host for every host specified in `contact_points`. It has new randomly assigned `host_id`, but the same endpoint. This duplicate host starts new reconnection process. Those duplicate reconnection processes can make the situation worse when the driver regains connectivity with the cluster. Different Hosts with the same endpoint are reconnecting in different moments and this cause host to be unreachable in unpredictable moments.

This PR introduces checking if the resolved endpoint is already present in Cluster Metadata information. The new host is added only if this condition is not true.

Fixes: #295

Refs: https://github.com/scylladb/scylladb/issues/16709, https://github.com/scylladb/scylladb/issues/17353