### PR TITLE
cassandra/cluster.py: use raw string when appropriate

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5451,7 +5451,7 @@ class ResultSet(object):
         except AttributeError:
             raise DriverException("Attempted to cancel paging with no active session. This is only for requests with ContinuousdPagingOptions.")
 
-    batch_regex = re.compile('^\s*BEGIN\s+[a-zA-Z]*\s*BATCH')
+    batch_regex = re.compile(r'^\s*BEGIN\s+[a-zA-Z]*\s*BATCH')
 
     @property
     def was_applied(self):


### PR DESCRIPTION
Python complains at seeing
```py
re.compile(r'^\s*BEGIN\s+[a-zA-Z]*\s*BATCH', re.UNICODE)
```
```
<>:1: SyntaxWarning: invalid escape sequence '\s'
```

but the interpreter continues on, and take "\s" as it is without escaping it. still, it's not a valid string literal.

because "\s" is not an escape sequence, while "\\s" is, but we don't have to escape "\" here, we can just use the raw string. simpler this way.

in this change, we trade the invalid escape sequence with a raw string to silence this warning.