### PR TITLE
CI: enable Trusted publishing

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -186,6 +186,9 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_wheels_extra_arch, build_sdist]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && endsWith(github.event.ref, 'scylla')
     # alternatively, to publish when a GitHub Release is created, use the following rule:
@@ -199,4 +202,3 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
enable a bit more secure way to publish into pypi
without the need of a token key

Ref: https://docs.pypi.org/trusted-publishers/