### PR TITLE
Workflows: Automatically add new issues to Drivers-Team Project

### DIFF
--- a/.github/workflows/add-opened-issues-to-project.yaml
+++ b/.github/workflows/add-opened-issues-to-project.yaml
@@ -1,0 +1,25 @@
+name: Project automations
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+
+# map fields with customized labels
+env:
+  new: NEW
+
+jobs:
+  issue_opened_or_reopened:
+    name: issue_opened_or_reopened
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    steps:
+      - name: Move issue to ${{ env.new }}
+        uses: leonsteinhaeuser/project-beta-automations@v2.0.0
+        with:
+          gh_token:  ${{ secrets.GITHUB_TOKEN }}
+          organization: scylladb
+          project_id: 71
+          resource_node_id: ${{ github.event.issue.node_id }}
+          status_value: ${{ env.new }} # Target status


### PR DESCRIPTION
Every issue that is opened and reopend will be autoamtically added to the team project with status "NEW".