### PR TITLE
CI: add integration tests with python 3.13

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,23 +16,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8.17", "3.11.4", "3.12.0b4"]
+        python-version: ["3.8", "3.11", "3.12", "3.13"]
         event_loop_manager: ["libev", "asyncio", "asyncore"]
         exclude:
-          - python-version: "3.12.0b4"
+          - python-version: "3.12"
+            event_loop_manager: "asyncore"
+          - python-version: "3.13"
             event_loop_manager: "asyncore"
 
     steps:
-    - uses: actions/checkout@v3
-    - name: setup pyenv ${{ matrix.python-version }}
-      uses: "gabrielfalcao/pyenv-action@v16"
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      name: Install Python
       with:
-        default: 2.7.14
-        versions: ${{ matrix.python-version }}
+        python-version: "${{ matrix.python_version }}"
+        allow-prereleases: true
+
     - name: Test with pytest
       run: |
         export EVENT_LOOP_MANAGER=${{ matrix.event_loop_manager }}
-        export SCYLLA_VERSION='release:5.1'
+        export SCYLLA_VERSION='release:5.4'
         ./ci/run_integration_test.sh tests/integration/standard/ tests/integration/cqlengine/
     
     - name: Test tablets

--- a/cassandra/cqlengine/management.py
+++ b/cassandra/cqlengine/management.py
@@ -154,9 +154,10 @@ def _get_index_name_by_column(table, column_name):
     Find the index name for a given table and column.
     """
     protected_name = metadata.protect_name(column_name)
-    possible_index_values = [protected_name, "values(%s)" % protected_name]
+    possible_index_values = [protected_name, "values(%s)" % protected_name, "keys(%s)" % protected_name]
     for index_metadata in table.indexes.values():
         options = dict(index_metadata.index_options)
+
         if options.get('target') in possible_index_values:
             return index_metadata.name
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -390,6 +390,17 @@ requires_composite_type = pytest.mark.skipif(SCYLLA_VERSION is not None,
 requires_custom_payload = pytest.mark.skipif(SCYLLA_VERSION is not None or PROTOCOL_VERSION < 4,
                                             reason='Scylla does not support custom payloads. Cassandra requires native protocol v4.0+')
 xfail_scylla = lambda reason, *args, **kwargs: pytest.mark.xfail(SCYLLA_VERSION is not None, reason=reason, *args, **kwargs)
+
+
+def xfail_scylla_version(reason, oss_scylla_version, ent_scylla_version, *args, **kwargs):
+    current_version = Version(get_scylla_version(SCYLLA_VERSION) if SCYLLA_VERSION is not None else '0.0.0')
+    if current_version > Version("2018.1"):
+        lt_scylla_version = Version(ent_scylla_version)
+    else:
+        lt_scylla_version = Version(oss_scylla_version)
+    return pytest.mark.xfail(current_version < lt_scylla_version,
+                             reason=reason, *args, **kwargs)
+
 incorrect_test = lambda reason='This test seems to be incorrect and should be fixed', *args, **kwargs: pytest.mark.xfail(reason=reason, *args, **kwargs)
 
 pypy = unittest.skipUnless(platform.python_implementation() == "PyPy", "Test is skipped unless it's on PyPy")

--- a/tests/integration/cqlengine/management/test_compaction_settings.py
+++ b/tests/integration/cqlengine/management/test_compaction_settings.py
@@ -61,7 +61,7 @@ class AlterTableTest(BaseCassEngTestCase):
 
             __options__ = {'compaction': {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy',
                                           'bucket_high': '20',
-                                          'bucket_low': '10',
+                                          'bucket_low': '0.5',
                                           'max_threshold': '200',
                                           'min_threshold': '100',
                                           'min_sstable_size': '1000',

--- a/tests/integration/cqlengine/query/test_queryset.py
+++ b/tests/integration/cqlengine/query/test_queryset.py
@@ -39,7 +39,7 @@ from cassandra.cqlengine import operators
 from cassandra.util import uuid_from_time
 from cassandra.cqlengine.connection import get_session
 from tests.integration import PROTOCOL_VERSION, CASSANDRA_VERSION, greaterthancass20, greaterthancass21, \
-    greaterthanorequalcass30, TestCluster, requires_collection_indexes
+    greaterthanorequalcass30, TestCluster, requires_collection_indexes, xfail_scylla
 from tests.integration.cqlengine import execute_count, DEFAULT_KEYSPACE
 
 
@@ -599,6 +599,7 @@ class TestQuerySetDistinct(BaseQuerySetUsage):
 
 @requires_collection_indexes
 class TestQuerySetOrdering(BaseQuerySetUsage):
+    @xfail_scylla(reason="Scylla does not support ordering on non-primary key columns: https://github.com/scylladb/python-driver/issues/343")
     @execute_count(2)
     def test_order_by_success_case(self):
         q = TestModel.objects(test_id=0).order_by('attempt_id')

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -42,7 +42,7 @@ from tests import notwindows, notasyncio
 from tests.integration import use_cluster, get_server_versions, CASSANDRA_VERSION, \
     execute_until_pass, execute_with_long_wait_retry, get_node, MockLoggingHandler, get_unsupported_lower_protocol, \
     get_unsupported_upper_protocol, lessthanprotocolv3, protocolv6, local, CASSANDRA_IP, greaterthanorequalcass30, \
-    lessthanorequalcass40, DSE_VERSION, TestCluster, PROTOCOL_VERSION, xfail_scylla, incorrect_test
+    lessthanorequalcass40, DSE_VERSION, TestCluster, PROTOCOL_VERSION, xfail_scylla_version, incorrect_test
 from tests.integration.util import assert_quiescent_pool_state
 import sys
 
@@ -288,7 +288,8 @@ class ClusterTests(unittest.TestCase):
 
         cluster.shutdown()
 
-    @xfail_scylla("Failing with scylla because there is option to create a cluster with 'lower bound' protocol")
+    @xfail_scylla_version("Failing with scylla because there is option to create a cluster with 'lower bound' protocol",
+                          oss_scylla_version="5.2", ent_scylla_version="2023.1")
     def test_invalid_protocol_negotation(self):
         """
         Test for protocol negotiation when explicit versions are set

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -41,7 +41,7 @@ from tests.integration import (get_cluster, use_singledc, PROTOCOL_VERSION, exec
                                greaterthancass21, assert_startswith, greaterthanorequalcass40,
                                greaterthanorequaldse67, lessthancass40,
                                TestCluster, DSE_VERSION, requires_java_udf, requires_composite_type,
-                               requires_collection_indexes, xfail_scylla)
+                               requires_collection_indexes, xfail_scylla, xfail_scylla_version)
 
 from tests.util import wait_until
 
@@ -502,7 +502,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.assertIn('CREATE INDEX e_index', statement)
 
     @greaterthancass21
-    @requires_collection_indexes
+    @xfail_scylla_version('failing cause of scylladb/scylladb#19278', oss_scylla_version='6.1', ent_scylla_version='2025.1')
     def test_collection_indexes(self):
 
         self.session.execute("CREATE TABLE %s.%s (a int PRIMARY KEY, b map<text, text>)"
@@ -1210,7 +1210,8 @@ CREATE TABLE export_udts.users (
         cluster.shutdown()
 
     @greaterthancass21
-    @pytest.mark.xfail(reason='Column name in CREATE INDEX is not quoted. It\'s a bug in driver or in Scylla')
+    @xfail_scylla_version(reason='Column name in CREATE INDEX is not quoted. It\'s a bug in driver or in Scylla',
+                          oss_scylla_version="5.2", ent_scylla_version="2023.1")
     def test_case_sensitivity(self):
         """
         Test that names that need to be escaped in CREATE statements are


### PR DESCRIPTION
since we want to start test the alpha/beta version of python refactoring a bit the integration test workflow

the action for pyenv we are using isn't really getting updates too much, and trying to switch back to the offical use python action that can now have prerelease python versions

also move to test newer scylla version which are not depended on python2 anymore, which was the main reason for using pyenv