### PR TITLE
cassandra/query: use timezone specific API to avoid deprecated warning

### DIFF
--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -19,7 +19,7 @@ queries.
 """
 
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import re
 import struct
 import time
@@ -1086,7 +1086,7 @@ class TraceEvent(object):
 
     def __init__(self, description, timeuuid, source, source_elapsed, thread_name):
         self.description = description
-        self.datetime = datetime.utcfromtimestamp(unix_time_from_uuid1(timeuuid))
+        self.datetime = datetime.fromtimestamp(unix_time_from_uuid1(timeuuid), tz=timezone.utc)
         self.source = source
         if source_elapsed is not None:
             self.source_elapsed = timedelta(microseconds=source_elapsed)


### PR DESCRIPTION
before this change, when testing with cqlsh using some dtest based tests, we have failures like:

```
------------------------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------------------------
15:10:02,963 ccm             DEBUG cluster.py     :754  | node1: (EE) /home/kefu/dev/scylladb/tools/cqlsh/bin/cqlsh.py:1063: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future vers
ion. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
15:10:02,963 cqlsh_tests.cqlsh_tests ERROR cqlsh_tests.py :534  | /home/kefu/dev/scylladb/tools/cqlsh/bin/cqlsh.py:1063: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.
 Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
----------------------------------------------------------------------------------------------- Captured log teardown ------------------------------------------------------------------------------------------------                        15:10:05,989 dtest_setup     DEBUG dtest_setup.py :629  | exclude_errors: []
15:10:05,993 dtest_setup     DEBUG dtest_setup.py :718  | removing ccm cluster test at: /home/kefu/.dtest/dtest-kguqevx3
15:10:06,002 dtest_setup     DEBUG dtest_setup.py :721  | clearing ssl stores from [/home/kefu/.dtest/dtest-kguqevx3] directory
15:10:06,002 dtest_setup     DEBUG dtest_setup.py :85   | Freeing cluster ID 20: link /home/kefu/.dtest/20
================================================================================================== warnings summary ==================================================================================================                        <frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtim
estamp(timestamp, datetime.UTC).

cqlsh_tests/cqlsh_tests.py::TestCqlshWithSSL::test_tracing[require_client_auth=true]
cqlsh_tests/cqlsh_tests.py::TestCqlshWithSSL::test_tracing[require_client_auth=false]
  /home/kefu/.local/lib/python3.12/site-packages/pytest_elk_reporter.py:281: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in
UTC: datetime.datetime.now(datetime.UTC).
    timestamp=datetime.datetime.utcnow().isoformat(),

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================== short test summary info ===============================================================================================
FAILED cqlsh_tests/cqlsh_tests.py::TestCqlshWithSSL::test_tracing[require_client_auth=true] - AssertionError: Failed to execute cqlsh
FAILED cqlsh_tests/cqlsh_tests.py::TestCqlshWithSSL::test_tracing[require_client_auth=false]
- AssertionError: Failed to execute cqlsh
````

this happens because the warnings are printed to stderr, and we take non-empty output in stderr as an indication of test failure.

in this change, we replace the deprecated API with timezone-aware API, to avoid this warning.

and the tests passed.