### PR TITLE
test_metadata: skip extensions test on new Scylla versions

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -392,6 +392,9 @@ requires_custom_payload = pytest.mark.skipif(SCYLLA_VERSION is not None or PROTO
 xfail_scylla = lambda reason, *args, **kwargs: pytest.mark.xfail(SCYLLA_VERSION is not None, reason=reason, *args, **kwargs)
 incorrect_test = lambda reason='This test seems to be incorrect and should be fixed', *args, **kwargs: pytest.mark.xfail(reason=reason, *args, **kwargs)
 
+lessthanscylla55 = pytest.mark.skipif(SCYLLA_VERSION is not None and Version(get_scylla_version(SCYLLA_VERSION)) < Version('5.5'),
+                                      reason="Scylla version less than 5.5 required for this test")
+
 pypy = unittest.skipUnless(platform.python_implementation() == "PyPy", "Test is skipped unless it's on PyPy")
 notpy3 = unittest.skipIf(sys.version_info >= (3, 0), "Test not applicable for Python 3.x runtime")
 requiresmallclockgranularity = unittest.skipIf("Windows" in platform.system() or "asyncore" in EVENT_LOOP_MANAGER,

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -41,7 +41,7 @@ from tests.integration import (get_cluster, use_singledc, PROTOCOL_VERSION, exec
                                greaterthancass21, assert_startswith, greaterthanorequalcass40,
                                greaterthanorequaldse67, lessthancass40,
                                TestCluster, DSE_VERSION, requires_java_udf, requires_composite_type,
-                               requires_collection_indexes, xfail_scylla)
+                               requires_collection_indexes, xfail_scylla, lessthanscylla55)
 
 from tests.util import wait_until
 
@@ -956,6 +956,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.assertEqual(index_2.keyspace_name, "schemametadatatests")
 
     @greaterthanorequalcass30
+    @lessthanscylla55 # New Scylla versions enable some extensions by default
     def test_table_extensions(self):
         s = self.session
         ks = self.keyspace_name


### PR DESCRIPTION
New Scylla versions may enable some extensions by default, which breaks this test.

Fixes: https://github.com/scylladb/scylladb/issues/18501