### PR TITLE
CI: download libev via conan, for windows builds to have it

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -10,7 +10,7 @@ env:
  CIBW_BEFORE_TEST: "pip install -r {project}/test-requirements.txt"
  CIBW_BEFORE_BUILD_LINUX: "rm -rf ~/.pyxbld && rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux && yum install -y libffi-devel libev libev-devel openssl openssl-devel"
  CIBW_ENVIRONMENT: "CASS_DRIVER_BUILD_CONCURRENCY=2 CFLAGS='-g0 -O3'"
- CIBW_SKIP: cp35* cp36* pp*i686 *musllinux*
+ CIBW_SKIP: cp35* cp36* cp37* pp*i686 *musllinux*
  CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
  CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux_2_28
  CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
@@ -62,6 +62,16 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           choco install openssl --version=3.3.1 -f -y
+
+      - name: Install Conan
+        if: runner.os == 'Windows'
+        uses: turtlebrowser/get-conan@main
+
+      - name: configure libev for Windows
+        if: runner.os == 'Windows'
+        run: |
+          conan profile detect
+          conan install conanfile.py
 
       - name: Install OpenSSL for MacOS
         if: runner.os == 'MacOs'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include cassandra/io/libevwrapper.c
 include cassandra/*.pyx
 include cassandra/*.pxd
 include cassandra/*.h
+graft build-release

--- a/cassandra/io/libevwrapper.c
+++ b/cassandra/io/libevwrapper.c
@@ -1,3 +1,5 @@
+#pragma comment(lib, "Ws2_32.Lib")
+
 #include <Python.h>
 #include <ev.h>
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+
+from conan import ConanFile
+from conan.tools.layout import basic_layout
+from conan.internal import check_duplicated_generator
+from conan.tools.files import save
+
+
+CONAN_COMMANDLINE_FILENAME = "conandeps.env"
+
+class CommandlineDeps:
+    def __init__(self, conanfile):
+        """
+        :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
+        """
+        self._conanfile = conanfile
+
+    def generate(self) -> None:
+        """
+        Collects all dependencies and components, then, generating a Makefile
+        """
+        check_duplicated_generator(self, self._conanfile)
+
+        host_req = self._conanfile.dependencies.host
+        build_req = self._conanfile.dependencies.build  # tool_requires
+        test_req = self._conanfile.dependencies.test
+
+        content_buffer = ""
+
+        # Filter the build_requires not activated for any requirement
+        dependencies = [tup for tup in list(host_req.items()) + list(build_req.items()) + list(test_req.items()) if not tup[0].build]
+
+        for require, dep in dependencies:
+            # Require is not used at the moment, but its information could be used, and will be used in Conan 2.0
+            if require.build:
+                continue
+            include_dir = Path(dep.package_folder) / 'include'
+            package_dir = Path(dep.package_folder) / 'lib'
+            content_buffer += json.dumps(dict(include_dirs=str(include_dir), library_dirs=str(package_dir)))
+
+        save(self._conanfile, CONAN_COMMANDLINE_FILENAME, content_buffer)
+        self._conanfile.output.info(f"Generated {CONAN_COMMANDLINE_FILENAME}")
+
+
+class python_driverConan(ConanFile):
+    win_bash = False
+
+    settings = "os", "compiler", "build_type", "arch"
+    requires = "libev/4.33"
+
+    def layout(self):
+        basic_layout(self)
+
+    def generate(self):
+        pc = CommandlineDeps(self)
+        pc.generate()


### PR DESCRIPTION
windows builds so far was running with having libev available and until this sync the fallback for python 3.12 was asyncio eventloop, but now we fail and not fall back to asyncio. so all unittest on windows are failing on any import from cassandra.connection.

in this change we use conan to download libev, and using it to compile the driver with libev

Ref: https://conan.io/center/recipes/libev