### PR TITLE
Revert "ci: enable pytest run debug"

### DIFF
--- a/ci/run_integration_test.sh
+++ b/ci/run_integration_test.sh
@@ -37,5 +37,5 @@ ccm remove
 # run test
 
 export MAPPED_SCYLLA_VERSION=3.11.4
-PROTOCOL_VERSION=4  pytest -vv -s --log-cli-level=debug  -rf --import-mode append $*
+PROTOCOL_VERSION=4  pytest -rf --import-mode append $*
 


### PR DESCRIPTION
We have some flakiness in CI, but debugging this is much harder because CI started to output logs from all tests, not only failed tests - because of commit https://github.com/scylladb/python-driver/commit/cdd125adbc7b0af1a9e5a1deaa5fc3d03a2b03f4
This PR reverts that, so we may have the chance to use CI logs.