### PR TITLE
Start using 6.0.2 for tablets tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,5 +38,5 @@ jobs:
     - name: Test tablets
       run: |
         export EVENT_LOOP_MANAGER=${{ matrix.event_loop_manager }}
-        export SCYLLA_VERSION='unstable/master:2024-01-17T17:56:00Z'
+        export SCYLLA_VERSION='release:6.0.2'
         ./ci/run_integration_test.sh tests/integration/experiments/


### PR DESCRIPTION
Tablets are released to `6.0.0`, instead of targeting unstable master let's target release.