### PR TITLE
Decouple schema fetch queries timeouts from server side timeouts

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -19,6 +19,7 @@ This module houses the main classes you will interact with,
 from __future__ import absolute_import
 
 import atexit
+import datetime
 from binascii import hexlify
 from collections import defaultdict
 from collections.abc import Mapping
@@ -1033,6 +1034,12 @@ class Cluster(object):
     or to disable the shardaware port (advanced shardaware)
     """
 
+    metadata_request_timeout = datetime.timedelta(seconds=2)
+    """
+    Timeout for all queries used by driver it self.
+    Supported only by Scylla clusters.
+    """
+
     @property
     def schema_metadata_enabled(self):
         """
@@ -1148,7 +1155,9 @@ class Cluster(object):
                  client_id=None,
                  cloud=None,
                  scylla_cloud=None,
-                 shard_aware_options=None):
+                 shard_aware_options=None,
+                 metadata_request_timeout=None,
+                 ):
         """
         ``executor_threads`` defines the number of threads in a pool for handling asynchronous tasks such as
         extablishing connection pools or refreshing metadata.
@@ -1240,6 +1249,8 @@ class Cluster(object):
         self.no_compact = no_compact
 
         self.auth_provider = auth_provider
+        if metadata_request_timeout is not None:
+            self.metadata_request_timeout = metadata_request_timeout
 
         if load_balancing_policy is not None:
             if isinstance(load_balancing_policy, type):
@@ -3549,6 +3560,7 @@ class ControlConnection(object):
     _is_shutdown = False
     _timeout = None
     _protocol_version = None
+    _metadata_request_timeout = None
 
     _schema_event_refresh_window = None
     _topology_event_refresh_window = None
@@ -3648,7 +3660,7 @@ class ControlConnection(object):
         (conn, _) = self._connect_host_in_lbp()
         if conn is not None:
             return conn
-        
+
         # Try to re-resolve hostnames as a fallback when all hosts are unreachable
         self._cluster._resolve_hostnames()
 
@@ -3693,7 +3705,10 @@ class ControlConnection(object):
         # If sharding information is available, it's a ScyllaDB cluster, so do not use peers_v2 table.
         if connection.features.sharding_info is not None:
             self._uses_peers_v2 = False
-        
+
+        # Cassandra does not support "USING TIMEOUT"
+        self._metadata_request_timeout = None if connection.features.sharding_info is None \
+            else datetime.timedelta(seconds=self._cluster.control_connection_timeout)
         self._tablets_routing_v1 = connection.features.tablets_routing_v1
 
         # use weak references in both directions
@@ -3830,7 +3845,12 @@ class ControlConnection(object):
             log.debug("Skipping schema refresh due to lack of schema agreement")
             return False
 
-        self._cluster.metadata.refresh(connection, self._timeout, fetch_size=self._schema_meta_page_size, **kwargs)
+        self._cluster.metadata.refresh(
+            connection,
+            self._timeout,
+            fetch_size=self._schema_meta_page_size,
+            metadata_request_timeout=self._metadata_request_timeout,
+            **kwargs)
 
         return True
 

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -29,6 +29,7 @@ import socket
 import sys
 import time
 import uuid
+from typing import Optional
 
 _HAS_GEOMET = True
 try:
@@ -1801,3 +1802,12 @@ class Version(object):
                 (is_major_ge and is_minor_ge and is_patch_ge and is_build_gt) or
                 (is_major_ge and is_minor_ge and is_patch_ge and is_build_ge and is_prerelease_gt)
                 )
+
+
+def maybe_add_timeout_to_query(stmt: str, metadata_request_timeout: Optional[datetime.timedelta]) -> str:
+    if metadata_request_timeout is None:
+        return stmt
+    ms = int(metadata_request_timeout / datetime.timedelta(milliseconds=1))
+    if ms == 0:
+        return stmt
+    return f"{stmt} USING TIMEOUT {ms}ms"

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -522,7 +522,7 @@ class ClusterTests(unittest.TestCase):
         def patched_wait_for_responses(*args, **kwargs):
             # When selecting schema version, replace the real schema UUID with an unexpected UUID
             response = original_wait_for_responses(*args, **kwargs)
-            if len(args) > 2 and hasattr(args[2], "query") and args[2].query == "SELECT schema_version FROM system.local WHERE key='local'":
+            if len(args) > 2 and hasattr(args[2], "query") and "SELECT schema_version FROM system.local WHERE key='local'" in args[2].query:
                 new_uuid = uuid4()
                 response[1].parsed_rows[0] = (new_uuid,)
             return response

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -243,7 +243,8 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
             cc,
             self.cluster.metadata.get_host(cc.host).release_version,
             self.cluster.metadata.get_host(cc.host).dse_version,
-            1
+            1,
+            None,
         )
 
         for option in tablemeta.options:
@@ -1968,7 +1969,8 @@ class BadMetaTest(unittest.TestCase):
             connection,
             cls.cluster.metadata.get_host(connection.host).release_version,
             cls.cluster.metadata.get_host(connection.host).dse_version,
-            timeout=20
+            20,
+            None,
         ).__class__
         cls.cluster.control_connection.reconnect = Mock()
 

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -618,7 +618,7 @@ class IndexTest(unittest.TestCase):
         column_meta.table.name = 'table_name_here'
         column_meta.table.keyspace_name = 'keyspace_name_here'
         column_meta.table.columns = {column_meta.name: column_meta}
-        parser = get_schema_parser(Mock(), '2.1.0', None, 0.1)
+        parser = get_schema_parser(Mock(), '2.1.0', None, 0.1, None)
 
         row = {'index_name': 'index_name_here', 'index_type': 'index_type_here'}
         index_meta = parser._build_index_metadata(column_meta, row)

--- a/tests/unit/test_util_types.py
+++ b/tests/unit/test_util_types.py
@@ -15,7 +15,7 @@ import unittest
 
 import datetime
 
-from cassandra.util import Date, Time, Duration, Version
+from cassandra.util import Date, Time, Duration, Version, maybe_add_timeout_to_query
 
 
 class DateTests(unittest.TestCase):
@@ -287,3 +287,15 @@ class VersionTests(unittest.TestCase):
         self.assertTrue(Version('4.0-SNAPSHOT2') > Version('4.0.0-SNAPSHOT1'))
 
         self.assertTrue(Version('4.0.0-alpha1-SNAPSHOT') > Version('4.0.0-SNAPSHOT'))
+
+
+class FunctionTests(unittest.TestCase):
+    def test_maybe_add_timeout_to_query(self):
+        self.assertEqual(
+            "SELECT * FROM HOSTS",
+            maybe_add_timeout_to_query("SELECT * FROM HOSTS", None)
+        )
+        self.assertEqual(
+            "SELECT * FROM HOSTS USING TIMEOUT 1000ms",
+            maybe_add_timeout_to_query("SELECT * FROM HOSTS", datetime.timedelta(seconds=1))
+        )


### PR DESCRIPTION
Scylla have an ability to override server timeout by appending `USING TIMEOUT <timeout>ms` to the query
Make driver add `USING TIMEOUT <control_connection_timeout*1000>ms` for scylla connections

Closes #320