### PR TITLE
Bring python 3.13 into integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,14 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [8]
-        python-version: ["3.8.17", "3.11.4", "3.12.0b4"]
+        python-version: ["3.8", "3.11", "3.12", "3.13"]
         event_loop_manager: ["libev", "asyncio", "asyncore"]
         exclude:
-          - python-version: "3.12.0b4"
+          - python-version: "3.12"
+            event_loop_manager: "asyncore"
+          - python-version: "3.13"
             event_loop_manager: "asyncore"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v4
@@ -32,11 +34,12 @@ jobs:
         java-version: ${{ matrix.java-version }}
         distribution: 'adopt'
 
-    - name: setup pyenv ${{ matrix.python-version }}
-      uses: "gabrielfalcao/pyenv-action@v16"
+    - uses: actions/setup-python@v5
+      name: Install Python ${{ matrix.python-version }}
       with:
-        default: 2.7.14
-        versions: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+
     - name: Test with pytest
       run: |
         export EVENT_LOOP_MANAGER=${{ matrix.event_loop_manager }}

--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -254,7 +254,7 @@ class TablePropertiesTests(BaseCassEngTestCase):
 
         table_options = management._get_table_metadata(ModelWithTableProperties).options
 
-        self.assertDictContainsSubset(ModelWithTableProperties.__options__, table_options)
+        self.assertTrue(set(ModelWithTableProperties.__options__) <= set(table_options))
 
     def test_bogus_option_update(self):
         sync_table(ModelWithTableProperties)

--- a/tests/integration/long/test_ipv6.py
+++ b/tests/integration/long/test_ipv6.py
@@ -16,19 +16,25 @@ import os, socket, errno
 from ccmlib import common
 
 from cassandra.cluster import NoHostAvailable
-from cassandra.io.asyncorereactor import AsyncoreConnection
+
+try:
+    from cassandra.io.asyncorereactor import AsyncoreConnection
+except ImportError:
+    AsyncoreConnection = None
 
 from tests import is_monkey_patched
 from tests.integration import use_cluster, remove_cluster, TestCluster
 
+try:
+    from cassandra.io.libevreactor import LibevConnection
+except ImportError:
+    LibevConnection = None
+
+
 if is_monkey_patched():
-    LibevConnection = -1
-    AsyncoreConnection = -1
-else:
-    try:
-        from cassandra.io.libevreactor import LibevConnection
-    except ImportError:
-        LibevConnection = None
+    LibevConnection = None
+    AsyncoreConnection = None
+
 
 import unittest
 
@@ -102,7 +108,7 @@ class LibevConnectionTests(IPV6ConnectionTest, unittest.TestCase):
         if os.name == "nt":
             raise unittest.SkipTest("IPv6 is currently not supported under Windows")
 
-        if LibevConnection == -1:
+        if LibevConnection is None:
             raise unittest.SkipTest("Can't test libev with monkey patching")
         elif LibevConnection is None:
             raise unittest.SkipTest("Libev does not appear to be installed properly")
@@ -116,5 +122,5 @@ class AsyncoreConnectionTests(IPV6ConnectionTest, unittest.TestCase):
         if os.name == "nt":
             raise unittest.SkipTest("IPv6 is currently not supported under Windows")
 
-        if AsyncoreConnection == -1:
+        if AsyncoreConnection is None:
             raise unittest.SkipTest("Can't test asyncore with monkey patching")

--- a/tests/integration/standard/test_connection.py
+++ b/tests/integration/standard/test_connection.py
@@ -446,6 +446,9 @@ class AsyncoreConnectionTests(ConnectionTests, unittest.TestCase):
     def setUp(self):
         if is_monkey_patched():
             raise unittest.SkipTest("Can't test asyncore with monkey patching")
+        if AsyncoreConnection is None:
+            raise unittest.SkipTest(
+                'asyncore does not appear to be installed properly')
         ConnectionTests.setUp(self)
 
     def clean_global_loop(self):

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -133,7 +133,7 @@ class MetaDataRemovalTest(unittest.TestCase):
 
         # verify the un-existing host was filtered
         for host in self.cluster.metadata.all_hosts():
-            self.assertNotEquals(host.endpoint.address, '126.0.0.186')
+            self.assertNotEqual(host.endpoint.address, '126.0.0.186')
 
 
 class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):


### PR DESCRIPTION
It is resurrection of https://github.com/scylladb/python-driver/pull/336
Brings python `3.13` to the integration tests.
Updates scylla to `5.4` and switches from `gabrielfalcao/pyenv-action@v16` to `actions/setup-python@v5`
