### PR TITLE
Make MAPPED_SCYLLA_VERSION a soft requirement

### DIFF
--- a/ci/run_integration_test.sh
+++ b/ci/run_integration_test.sh
@@ -36,6 +36,5 @@ ccm remove
 
 # run test
 
-export MAPPED_SCYLLA_VERSION=3.11.4
 PROTOCOL_VERSION=4  pytest -rf --import-mode append $*
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -185,10 +185,10 @@ if os.getenv('DSE_VERSION', None):  # we are testing against DSE
     DSE_CRED = os.getenv('DSE_CREDS', None)
     CASSANDRA_VERSION = _get_cass_version_from_dse(DSE_VERSION.base_version)
     CCM_VERSION = DSE_VERSION.base_version
-else:  # we are testing against Cassandra or DDAC
+else:  # we are testing against Cassandra,DDAC or Scylla
     if SCYLLA_VERSION:
         cv_string = SCYLLA_VERSION
-        mcv_string = os.getenv('MAPPED_SCYLLA_VERSION', None)
+        mcv_string = os.getenv('MAPPED_SCYLLA_VERSION', '3.11.4') # Assume that scylla matches cassandra `3.11.4` behavior
     else:
         cv_string = os.getenv('CASSANDRA_VERSION', None)
         mcv_string = os.getenv('MAPPED_CASSANDRA_VERSION', None)


### PR DESCRIPTION
It is going to ease development and test process.
From now on if you want to run it on release you can just run it as such:
```
SCYLLA_VERSION="6.0.2" pytest ....
```