### PR TITLE
Cleanup tablet implementation

### DIFF
--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -254,8 +254,8 @@ class Statement(object):
     table = None
     """
     The string name of the table this query acts on. This is used when the tablet
-    experimental feature is enabled and in the same time :class`~.TokenAwarePolicy`
-    is configured in the profile load balancing policy.
+    feature is enabled and in the same time :class`~.TokenAwarePolicy` is configured
+    in the profile load balancing policy.
     """
 
     custom_payload = None

--- a/cassandra/tablets.py
+++ b/cassandra/tablets.py
@@ -1,4 +1,3 @@
-# Experimental, this interface and use may change
 from threading import Lock
 
 
@@ -34,7 +33,6 @@ class Tablet(object):
         return None
 
 
-# Experimental, this interface and use may change
 class Tablets(object):
     _lock = None
     _tablets = {}

--- a/cassandra/tablets.py
+++ b/cassandra/tablets.py
@@ -4,7 +4,7 @@ from threading import Lock
 class Tablet(object):
     """
     Represents a single ScyllaDB tablet.
-    It stores information about each replica, its host and shard, 
+    It stores information about each replica, its host and shard,
     and the token interval in the format (first_token, last_token].
     """
     first_token = 0
@@ -40,12 +40,12 @@ class Tablets(object):
     def __init__(self, tablets):
         self._tablets = tablets
         self._lock = Lock()
-    
+
     def get_tablet_for_key(self, keyspace, table, t):
         tablet = self._tablets.get((keyspace, table), [])
         if not tablet:
             return None
-        
+
         id = bisect_left(tablet, t.value, key=lambda tablet: tablet.last_token)
         if id < len(tablet) and t.value > tablet[id].first_token:
             return tablet[id]

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -506,7 +506,7 @@ def start_cluster_wait_for_up(cluster):
 
 
 def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None, set_keyspace=True, ccm_options=None,
-                configuration_options=None, dse_options=None, use_single_interface=USE_SINGLE_INTERFACE, use_tablets=False):
+                configuration_options=None, dse_options=None, use_single_interface=USE_SINGLE_INTERFACE):
     configuration_options = configuration_options or {}
     dse_options = dse_options or {}
     workloads = workloads or []
@@ -616,10 +616,7 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None, 
                     # CDC is causing an issue (can't start cluster with multiple seeds)
                     # Selecting only features we need for tests, i.e. anything but CDC.
                     CCM_CLUSTER = CCMScyllaCluster(path, cluster_name, **ccm_options)
-                    if use_tablets:
-                        CCM_CLUSTER.set_configuration_options({'experimental_features': ['lwt', 'udf', 'consistent-topology-changes', 'tablets'], 'start_native_transport': True})
-                    else:
-                        CCM_CLUSTER.set_configuration_options({'experimental_features': ['lwt', 'udf'], 'start_native_transport': True})
+                    CCM_CLUSTER.set_configuration_options({'experimental_features': ['lwt', 'udf'], 'start_native_transport': True})
 
                     CCM_CLUSTER.set_configuration_options({'skip_wait_for_gossip_to_settle': 0})
                     # Permit IS NOT NULL restriction on non-primary key columns of a materialized view

--- a/tests/integration/experiments/test_tablets.py
+++ b/tests/integration/experiments/test_tablets.py
@@ -20,7 +20,7 @@ class TestTabletsIntegration(unittest.TestCase):
         cls.session = cls.cluster.connect()
         cls.create_ks_and_cf(cls)
         cls.create_data(cls.session)
-    
+
     @classmethod
     def teardown_class(cls):
         cls.cluster.shutdown()
@@ -32,7 +32,7 @@ class TestTabletsIntegration(unittest.TestCase):
         for event in events:
             LOGGER.info("TRACE EVENT: %s %s %s", event.source, event.thread_name, event.description)
             host_set.add(event.source)
-        
+
         self.assertEqual(len(host_set), 1)
         self.assertIn('locally', "\n".join([event.description for event in events]))
 
@@ -43,7 +43,7 @@ class TestTabletsIntegration(unittest.TestCase):
         for event in events:
             LOGGER.info("TRACE EVENT: %s %s", event.source, event.activity)
             host_set.add(event.source)
-        
+
         self.assertEqual(len(host_set), 1)
         self.assertIn('locally', "\n".join([event.activity for event in events]))
 
@@ -54,7 +54,7 @@ class TestTabletsIntegration(unittest.TestCase):
         for event in events:
             LOGGER.info("TRACE EVENT: %s %s %s", event.source, event.thread_name, event.description)
             shard_set.add(event.thread_name)
-            
+
         self.assertEqual(len(shard_set), 1)
         self.assertIn('locally', "\n".join([event.description for event in events]))
 
@@ -65,10 +65,10 @@ class TestTabletsIntegration(unittest.TestCase):
         for event in events:
             LOGGER.info("TRACE EVENT: %s %s", event.thread, event.activity)
             shard_set.add(event.thread)
-            
+
         self.assertEqual(len(shard_set), 1)
         self.assertIn('locally', "\n".join([event.activity for event in events]))
-    
+
     def create_ks_and_cf(self):
         self.session.execute(
             """
@@ -79,8 +79,8 @@ class TestTabletsIntegration(unittest.TestCase):
             """
             CREATE KEYSPACE test1
             WITH replication = {
-                'class': 'NetworkTopologyStrategy', 
-                'replication_factor': 1 
+                'class': 'NetworkTopologyStrategy',
+                'replication_factor': 1
             } AND tablets = {
                 'initial': 8
             }
@@ -90,14 +90,14 @@ class TestTabletsIntegration(unittest.TestCase):
             """
             CREATE TABLE test1.table1 (pk int, ck int, v int, PRIMARY KEY (pk, ck));
             """)
-        
+
     @staticmethod
     def create_data(session):
         prepared = session.prepare(
             """
             INSERT INTO test1.table1 (pk, ck, v) VALUES (?, ?, ?)
             """)
-        
+
         for i in range(50):
             bound = prepared.bind((i, i%5, i%2))
             session.execute(bound)

--- a/tests/integration/experiments/test_tablets.py
+++ b/tests/integration/experiments/test_tablets.py
@@ -9,7 +9,7 @@ from tests.integration import PROTOCOL_VERSION, use_cluster
 from tests.unit.test_host_connection_pool import LOGGER
 
 def setup_module():
-    use_cluster('tablets', [3], start=True, use_tablets=True)
+    use_cluster('tablets', [3], start=True)
 
 class TestTabletsIntegration(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
Previously there was a need for different cluster configuration for tablet specific test. Now to test tablets we use scylladb version that has it as a default, so there is no need to specify so additional `experimental_features`

This PR addresses that problem, also it removes comments stating that tablets are experimental and fixes some inconsistencies with indentations and white spaces. 