### PR TITLE
Update openssl for windows

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install OpenSSL for Windows
         if: runner.os == 'Windows'
         run: |
-          choco install openssl --version=3.3.1 -f -y
+          choco install openssl --version=3.3.2 -f -y
 
       - name: Install Conan
         if: runner.os == 'Windows'


### PR DESCRIPTION
3.3.1 was removed from the hosting, we need to update to 3.3.2 to keep CICD running