### PR TITLE
Fix double execution after concurrent node bootstraps

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1015,7 +1015,7 @@ class Cluster(object):
     cloud = None
     """
     A dict of the cloud configuration. Example::
-        
+
         {
             # path to the secure connect bundle
             'secure_connect_bundle': '/path/to/secure-connect-dbname.zip',
@@ -1779,7 +1779,7 @@ class Cluster(object):
                           self.contact_points, self.protocol_version)
                 self.connection_class.initialize_reactor()
                 _register_cluster_shutdown(self)
-                
+
                 self._add_resolved_hosts()
 
                 try:
@@ -3628,7 +3628,7 @@ class ControlConnection(object):
         if old:
             log.debug("[control connection] Closing old connection %r, replacing with %r", old, conn)
             old.close()
-    
+
     def _connect_host_in_lbp(self):
         errors = {}
         lbp = (
@@ -3649,7 +3649,7 @@ class ControlConnection(object):
                 log.warning("[control connection] Error connecting to %s:", host, exc_info=True)
             if self._is_shutdown:
                 raise DriverException("[control connection] Reconnection in progress during shutdown")
-        
+
         return (None, errors)
 
     def _reconnect_internal(self):
@@ -3673,7 +3673,7 @@ class ControlConnection(object):
         (conn, errors) = self._connect_host_in_lbp()
         if conn is not None:
             return conn
-        
+
         raise NoHostAvailable("Unable to connect to any servers", errors)
 
     def _try_connect(self, host):


### PR DESCRIPTION
In some cases we want to only update the pool if previous do not exist or is shutdown. This commit adds additional validation to `add_or_renew_pool` to make sure this condition is met.

Problematic scenario:

> We boot 2 Scylla nodes concurrently into existing cluster.
> Python driver obtains two `on_add` notifications, one for each node.
> Each notification calls `add_or_renew_pool`, which creates connection pool to each node.
> 
>But then, for some reason, one of the `on_add`s (let's say it is for node 1) may cause another `add_or_renew_pool` to be called for the other server  (let's call it node 2). This happens from _finalize_add -> update_created_pools.

The reason `add_or_renew_pool` was executed second time is:
https://github.com/scylladb/python-driver/blob/d768d74148a8053844ea276c305ae5e86e9fabac/cassandra/cluster.py#L3359-L3364 in this place `pool` for the node 2 is `None`. That is because `add_or_renew_pool` was called, but it does not finished yet (https://github.com/scylladb/python-driver/blob/d768d74148a8053844ea276c305ae5e86e9fabac/cassandra/cluster.py#L3324), new pool was created but not assigned to `self._pools[host]`.  This is why adding sleep before that line make the issue easier to reproduce (https://github.com/scylladb/python-driver/commit/022a3aa77c470f14f50567ec191c087874f53896)

> This may cause a second pool to be created for the other server and the initially established pool to that server to be closed.
> There could be a statement running on the initially established pool. The statement may have already been executed on Scylla side, but the driver didn't get a response yet.
> The pool is closed before response arrives. This causes driver to retry the statement on the new pool, leading to double execution.

So in that specific case we only want to create new pool if there was no pool before or it was shutdown. But the case might be that the pool was created but not assigned yet, so before assigning second one we want to check if previous met the conditions. 

Fixes: https://github.com/scylladb/python-driver/issues/317