### PR TITLE
Do not throw a warning for zero-token node

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -4088,8 +4088,8 @@ class ControlConnection(object):
             return False
 
         if "tokens" in row and not row.get("tokens"):
-            log.warning(
-                "Found an invalid row for peer - tokens is None (broadcast_rpc: %s, host_id: %s). Ignoring host." %
+            log.debug(
+                "Found a zero-token node - tokens is None (broadcast_rpc: %s, host_id: %s). Ignoring host." %
                 (broadcast_rpc, host_id))
             return False
 


### PR DESCRIPTION
Zero-token nodes do not handle any queries and should be excluded from query routing, so it is ok to consider them invalid, but the warning should not be logged as having them is not a bug now.

Refs: #352 