### PR TITLE
Stop pytest from picking up non-test classes

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1060,6 +1060,8 @@ def assert_startswith(s, prefix):
 
 
 class TestCluster(object):
+    __test__ = False
+
     DEFAULT_PROTOCOL_VERSION = default_protocol_version
     DEFAULT_CASSANDRA_IP = CASSANDRA_IP
     DEFAULT_ALLOW_BETA = ALLOW_BETA_PROTOCOL

--- a/tests/integration/cqlengine/advanced/test_cont_paging.py
+++ b/tests/integration/cqlengine/advanced/test_cont_paging.py
@@ -28,6 +28,8 @@ from tests.integration import (DSE_VERSION, greaterthanorequaldse51,
 
 
 class TestMultiKeyModel(models.Model):
+    __test__ = False
+
     partition = columns.Integer(primary_key=True)
     cluster = columns.Integer(primary_key=True)
     count = columns.Integer(required=False)

--- a/tests/integration/cqlengine/base.py
+++ b/tests/integration/cqlengine/base.py
@@ -22,6 +22,7 @@ from cassandra.cqlengine import columns
 from uuid import uuid4
 
 class TestQueryUpdateModel(Model):
+    __test__ = False
 
     partition = columns.UUID(primary_key=True, default=uuid4)
     cluster = columns.Integer(primary_key=True)

--- a/tests/integration/cqlengine/columns/test_container_columns.py
+++ b/tests/integration/cqlengine/columns/test_container_columns.py
@@ -35,6 +35,8 @@ log = logging.getLogger(__name__)
 
 
 class TestSetModel(Model):
+    __test__ = False
+
     partition = columns.UUID(primary_key=True, default=uuid4)
     int_set = columns.Set(columns.Integer, required=False)
     text_set = columns.Set(columns.Text, required=False)
@@ -193,6 +195,7 @@ class TestSetColumn(BaseCassEngTestCase):
 
 
 class TestListModel(Model):
+    __test__ = False
 
     partition = columns.UUID(primary_key=True, default=uuid4)
     int_list = columns.List(columns.Integer, required=False)
@@ -347,6 +350,8 @@ class TestListColumn(BaseCassEngTestCase):
 
 
 class TestMapModel(Model):
+    __test__ = False
+
     partition = columns.UUID(primary_key=True, default=uuid4)
     int_map = columns.Map(columns.Integer, columns.UUID, required=False)
     text_map = columns.Map(columns.Text, columns.DateTime, required=False)
@@ -525,6 +530,7 @@ class TestMapColumn(BaseCassEngTestCase):
 
 
 class TestCamelMapModel(Model):
+    __test__ = False
 
     partition = columns.UUID(primary_key=True, default=uuid4)
     camelMap = columns.Map(columns.Text, columns.Integer, required=False)
@@ -546,6 +552,7 @@ class TestCamelMapColumn(BaseCassEngTestCase):
 
 
 class TestTupleModel(Model):
+    __test__ = False
 
     partition = columns.UUID(primary_key=True, default=uuid4)
     int_tuple = columns.Tuple(columns.Integer, columns.Integer, columns.Integer, required=False)
@@ -746,6 +753,7 @@ class TestTupleColumn(BaseCassEngTestCase):
 
 
 class TestNestedModel(Model):
+    __test__ = False
 
     partition = columns.UUID(primary_key=True, default=uuid4)
     list_list = columns.List(columns.List(columns.Integer), required=False)

--- a/tests/integration/cqlengine/columns/test_counter_column.py
+++ b/tests/integration/cqlengine/columns/test_counter_column.py
@@ -21,6 +21,7 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 
 
 class TestCounterModel(Model):
+    __test__ = False
 
     partition = columns.UUID(primary_key=True, default=uuid4)
     cluster = columns.UUID(primary_key=True, default=uuid4)

--- a/tests/integration/cqlengine/columns/test_static_column.py
+++ b/tests/integration/cqlengine/columns/test_static_column.py
@@ -28,6 +28,8 @@ from tests.integration import PROTOCOL_VERSION
 STATIC_SUPPORTED = PROTOCOL_VERSION >= 2
 
 class TestStaticModel(Model):
+    __test__ = False
+
     partition = columns.UUID(primary_key=True, default=uuid4)
     cluster = columns.UUID(primary_key=True, default=uuid4)
     static = columns.Text(static=True)

--- a/tests/integration/cqlengine/connections/test_connection.py
+++ b/tests/integration/cqlengine/connections/test_connection.py
@@ -29,6 +29,7 @@ from tests.integration.cqlengine import DEFAULT_KEYSPACE, setup_connection
 
 
 class TestConnectModel(Model):
+    __test__ = False
 
     id = columns.Integer(primary_key=True)
     keyspace = columns.Text()

--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -372,6 +372,8 @@ class InconsistentTable(BaseCassEngTestCase):
 
 
 class TestIndexSetModel(Model):
+    __test__ = False
+
     partition = columns.UUID(primary_key=True)
     int_set = columns.Set(columns.Integer, index=True)
     int_list = columns.List(columns.Integer, index=True)

--- a/tests/integration/cqlengine/model/test_equality_operations.py
+++ b/tests/integration/cqlengine/model/test_equality_operations.py
@@ -21,6 +21,7 @@ from cassandra.cqlengine.models import Model
 from cassandra.cqlengine import columns
 
 class TestModel(Model):
+    __test__ = False
 
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()

--- a/tests/integration/cqlengine/model/test_model_io.py
+++ b/tests/integration/cqlengine/model/test_model_io.py
@@ -36,6 +36,7 @@ from tests.integration.cqlengine import DEFAULT_KEYSPACE
 
 
 class TestModel(Model):
+    __test__ = False
 
     id = columns.UUID(primary_key=True, default=lambda: uuid4())
     count = columns.Integer()
@@ -44,6 +45,8 @@ class TestModel(Model):
 
 
 class TestModelSave(Model):
+    __test__ = False
+
     partition = columns.UUID(primary_key=True, default=uuid4)
     cluster = columns.Integer(primary_key=True)
     count = columns.Integer(required=False)
@@ -302,6 +305,7 @@ class TestModelIO(BaseCassEngTestCase):
 
 
 class TestMultiKeyModel(Model):
+    __test__ = False
 
     partition = columns.Integer(primary_key=True)
     cluster = columns.Integer(primary_key=True)
@@ -658,6 +662,7 @@ class TestQueryQuoting(BaseCassEngTestCase):
 
 
 class TestQueryModel(Model):
+    __test__ = False
 
     test_id = columns.UUID(primary_key=True, default=uuid4)
     date = columns.Date(primary_key=True)

--- a/tests/integration/cqlengine/model/test_updates.py
+++ b/tests/integration/cqlengine/model/test_updates.py
@@ -25,6 +25,7 @@ from cassandra.cqlengine.management import sync_table, drop_table
 from cassandra.cqlengine.usertype import UserType
 
 class TestUpdateModel(Model):
+    __test__ = False
 
     partition   = columns.UUID(primary_key=True, default=uuid4)
     cluster     = columns.UUID(primary_key=True, default=uuid4)

--- a/tests/integration/cqlengine/model/test_value_lists.py
+++ b/tests/integration/cqlengine/model/test_value_lists.py
@@ -22,11 +22,13 @@ from cassandra.cqlengine import columns
 
 
 class TestModel(Model):
+    __test__ = False
 
     id = columns.Integer(primary_key=True)
     clustering_key = columns.Integer(primary_key=True, clustering_order='desc')
 
 class TestClusteringComplexModel(Model):
+    __test__ = False
 
     id = columns.Integer(primary_key=True)
     clustering_key = columns.Integer(primary_key=True, clustering_order='desc')

--- a/tests/integration/cqlengine/query/test_batch_query.py
+++ b/tests/integration/cqlengine/query/test_batch_query.py
@@ -27,6 +27,7 @@ from cassandra.cqlengine.query import BatchType as cqlengine_BatchType
 
 
 class TestMultiKeyModel(Model):
+    __test__ = False
 
     partition = columns.Integer(primary_key=True)
     cluster = columns.Integer(primary_key=True)

--- a/tests/integration/cqlengine/query/test_queryset.py
+++ b/tests/integration/cqlengine/query/test_queryset.py
@@ -62,6 +62,7 @@ class TzOffset(tzinfo):
 
 
 class TestModel(Model):
+    __test__ = False
 
     test_id = columns.Integer(primary_key=True)
     attempt_id = columns.Integer(primary_key=True)
@@ -104,6 +105,7 @@ class IndexedCollectionsTestModel(Model):
 
 
 class TestMultiClusteringModel(Model):
+    __test__ = False
 
     one = columns.Integer(primary_key=True)
     two = columns.Integer(primary_key=True)
@@ -1346,6 +1348,7 @@ class TestModelQueryWithDBField(BaseCassEngTestCase):
         list(DBFieldModel.objects.filter(c0=0, k0=0, k1=0).values_list('c0', 'v0'))
 
 class TestModelSmall(Model):
+    __test__ = False
 
     test_id = columns.Integer(primary_key=True)
 

--- a/tests/integration/cqlengine/test_batch_query.py
+++ b/tests/integration/cqlengine/test_batch_query.py
@@ -22,6 +22,8 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 from mock import patch
 
 class TestMultiKeyModel(Model):
+    __test__ = False
+
     partition   = columns.Integer(primary_key=True)
     cluster     = columns.Integer(primary_key=True)
     count       = columns.Integer(required=False)

--- a/tests/integration/cqlengine/test_connections.py
+++ b/tests/integration/cqlengine/test_connections.py
@@ -26,7 +26,7 @@ from tests.integration import local, CASSANDRA_IP, TestCluster
 
 
 class TestModel(Model):
-
+    __test__ = False
     __keyspace__ = 'ks1'
 
     partition = columns.Integer(primary_key=True)

--- a/tests/integration/cqlengine/test_consistency.py
+++ b/tests/integration/cqlengine/test_consistency.py
@@ -26,6 +26,7 @@ from cassandra.cqlengine.query import BatchQuery
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 
 class TestConsistencyModel(Model):
+    __test__ = False
 
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()

--- a/tests/integration/cqlengine/test_context_query.py
+++ b/tests/integration/cqlengine/test_context_query.py
@@ -20,7 +20,7 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 
 
 class TestModel(Model):
-
+    __test__ = False
     __keyspace__ = 'ks1'
 
     partition = columns.Integer(primary_key=True)

--- a/tests/integration/cqlengine/test_ifexists.py
+++ b/tests/integration/cqlengine/test_ifexists.py
@@ -26,6 +26,7 @@ from tests.integration import PROTOCOL_VERSION
 
 
 class TestIfExistsModel(Model):
+    __test__ = False
 
     id = columns.UUID(primary_key=True, default=lambda: uuid4())
     count = columns.Integer()
@@ -33,6 +34,7 @@ class TestIfExistsModel(Model):
 
 
 class TestIfExistsModel2(Model):
+    __test__ = False
 
     id = columns.Integer(primary_key=True)
     count = columns.Integer(primary_key=True, required=False)
@@ -40,6 +42,7 @@ class TestIfExistsModel2(Model):
 
 
 class TestIfExistsWithCounterModel(Model):
+    __test__ = False
 
     id = columns.UUID(primary_key=True, default=lambda: uuid4())
     likes = columns.Counter()

--- a/tests/integration/cqlengine/test_ifnotexists.py
+++ b/tests/integration/cqlengine/test_ifnotexists.py
@@ -25,6 +25,7 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration import PROTOCOL_VERSION
 
 class TestIfNotExistsModel(Model):
+    __test__ = False
 
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()
@@ -32,6 +33,7 @@ class TestIfNotExistsModel(Model):
 
 
 class TestIfNotExistsWithCounterModel(Model):
+    __test__ = False
 
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     likes   = columns.Counter()

--- a/tests/integration/cqlengine/test_lwt_conditional.py
+++ b/tests/integration/cqlengine/test_lwt_conditional.py
@@ -27,12 +27,16 @@ from tests.integration import greaterthancass20
 
 
 class TestConditionalModel(Model):
+    __test__ = False
+
     id = columns.UUID(primary_key=True, default=uuid4)
     count = columns.Integer()
     text = columns.Text(required=False)
 
 
 class TestUpdateModel(Model):
+    __test__ = False
+
     partition = columns.Integer(primary_key=True)
     cluster = columns.Integer(primary_key=True)
     value = columns.Integer(required=False)

--- a/tests/integration/cqlengine/test_timestamp.py
+++ b/tests/integration/cqlengine/test_timestamp.py
@@ -25,6 +25,8 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 
 
 class TestTimestampModel(Model):
+    __test__ = False
+
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()
 

--- a/tests/integration/cqlengine/test_ttl.py
+++ b/tests/integration/cqlengine/test_ttl.py
@@ -29,6 +29,8 @@ from tests.integration import CASSANDRA_VERSION, greaterthancass20
 
 
 class TestTTLModel(Model):
+    __test__ = False
+
     id = columns.UUID(primary_key=True, default=lambda: uuid4())
     count = columns.Integer()
     text = columns.Text(required=False)
@@ -48,6 +50,8 @@ class BaseTTLTest(BaseCassEngTestCase):
 
 
 class TestDefaultTTLModel(Model):
+    __test__ = False
+
     __options__ = {'default_time_to_live': 20}
     id = columns.UUID(primary_key=True, default=lambda:uuid4())
     count = columns.Integer()

--- a/tests/integration/standard/test_connection.py
+++ b/tests/integration/standard/test_connection.py
@@ -95,6 +95,8 @@ class ConnectionTimeoutTest(unittest.TestCase):
 
 
 class TestHostListener(HostStateListener):
+    __test__ = False
+
     host_down = None
 
     def on_down(self, host):


### PR DESCRIPTION
Some classes are not meant to be picked up.
But pytest does it and throw warning message when something goes wrong. One example of this issue:
```
PytestCollectionWarning: cannot collect test class 'TestCluster' because it has a __new__ constructor (from: tests/integration/standard/column_encryption/test_policies.py)
    class TestCluster(object):
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.