### PR TITLE
pool: Handle non-shard-aware endpoints in logging

### DIFF
--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -731,7 +731,11 @@ class HostConnection(object):
         else:
             conn = self._session.cluster.connection_factory(self.host.endpoint, host_conn=self, on_orphaned_stream_released=self.on_orphaned_stream_released)
 
-        log.debug("Received a connection %s for shard_id=%i on host %s", id(conn), conn.features.shard_id, self.host)
+        log.debug(
+            "Received a connection %s for shard_id=%i on host %s",
+            id(conn),
+            conn.features.shard_id if conn.features.shard_id is not None else -1,
+            self.host)
         if self.is_shutdown:
             log.debug("Pool for host %s is in shutdown, closing the new connection (%s)", self.host, id(conn))
             conn.close()


### PR DESCRIPTION
When connecting to non-shard-aware endpoints, conn.features.shard_id is None. Previously, this would cause a TypeError when logging with %i format specifier.

```
  Traceback (most recent call last):
    File "/usr/lib64/python3.12/logging/__init__.py", line 1160, in emit
      msg = self.format(record)
            ^^^^^^^^^^^^^^^^^^^
    File "/usr/lib64/python3.12/logging/__init__.py", line 999, in format
      return fmt.format(record)
             ^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.12/site-packages/_pytest/logging.py", line 136, in format
      return super().format(record)
             ^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib64/python3.12/logging/__init__.py", line 703, in format
      record.message = record.getMessage()
                       ^^^^^^^^^^^^^^^^^^^
    File "/usr/lib64/python3.12/logging/__init__.py", line 392, in getMessage
      msg = msg % self.args
            ~~~~^~~~~~~~~~~
  TypeError: %i format: a real number is required, not NoneType
  Call stack:
    File "/usr/lib64/python3.12/threading.py", line 1032, in _bootstrap
      self._bootstrap_inner()
    File "/usr/lib64/python3.12/threading.py", line 1075, in _bootstrap_inner
      self.run()
    File "/usr/lib64/python3.12/threading.py", line 1012, in run
      self._target(*self._args, **self._kwargs)
    File "/usr/lib64/python3.12/concurrent/futures/thread.py", line 92, in _worker
      work_item.run()
    File "/usr/lib64/python3.12/concurrent/futures/thread.py", line 58, in run
      result = self.fn(*self.args, **self.kwargs)
  Message: 'Received a connection %s for shard_id=%i on host %s'
  Arguments: (140333813254336, None, <Host: 127.67.173.34:9042 dc2>)
```

Now prints -1 as a fallback value instead of raising an exception.

This fixes logging failures that occurred when:
- Connecting to non-shard-aware endpoints
- Debug logging level was enabled

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.