### PR TITLE
Invalidate tablets when table or keyspace is deleted

### DIFF
--- a/tests/integration/experiments/test_tablets.py
+++ b/tests/integration/experiments/test_tablets.py
@@ -1,7 +1,3 @@
-import time
-import unittest
-import pytest
-import os
 from cassandra.cluster import Cluster
 from cassandra.policies import ConstantReconnectionPolicy, RoundRobinPolicy, TokenAwarePolicy
 
@@ -11,7 +7,7 @@ from tests.unit.test_host_connection_pool import LOGGER
 def setup_module():
     use_cluster('tablets', [3], start=True)
 
-class TestTabletsIntegration(unittest.TestCase):
+class TestTabletsIntegration:
     @classmethod
     def setup_class(cls):
         cls.cluster = Cluster(contact_points=["127.0.0.1", "127.0.0.2", "127.0.0.3"], protocol_version=PROTOCOL_VERSION,
@@ -33,8 +29,8 @@ class TestTabletsIntegration(unittest.TestCase):
             LOGGER.info("TRACE EVENT: %s %s %s", event.source, event.thread_name, event.description)
             host_set.add(event.source)
 
-        self.assertEqual(len(host_set), 1)
-        self.assertIn('locally', "\n".join([event.description for event in events]))
+        assert len(host_set) == 1
+        assert 'locally' in "\n".join([event.description for event in events])
 
         trace_id = results.response_future.get_query_trace_ids()[0]
         traces = self.session.execute("SELECT * FROM system_traces.events WHERE session_id = %s", (trace_id,))
@@ -44,8 +40,8 @@ class TestTabletsIntegration(unittest.TestCase):
             LOGGER.info("TRACE EVENT: %s %s", event.source, event.activity)
             host_set.add(event.source)
 
-        self.assertEqual(len(host_set), 1)
-        self.assertIn('locally', "\n".join([event.activity for event in events]))
+        assert len(host_set) == 1
+        assert 'locally' in "\n".join([event.activity for event in events])
 
     def verify_same_shard_in_tracing(self, results):
         traces = results.get_query_trace()
@@ -55,8 +51,8 @@ class TestTabletsIntegration(unittest.TestCase):
             LOGGER.info("TRACE EVENT: %s %s %s", event.source, event.thread_name, event.description)
             shard_set.add(event.thread_name)
 
-        self.assertEqual(len(shard_set), 1)
-        self.assertIn('locally', "\n".join([event.description for event in events]))
+        assert len(shard_set) == 1
+        assert 'locally' in "\n".join([event.description for event in events])
 
         trace_id = results.response_future.get_query_trace_ids()[0]
         traces = self.session.execute("SELECT * FROM system_traces.events WHERE session_id = %s", (trace_id,))
@@ -66,8 +62,8 @@ class TestTabletsIntegration(unittest.TestCase):
             LOGGER.info("TRACE EVENT: %s %s", event.thread, event.activity)
             shard_set.add(event.thread)
 
-        self.assertEqual(len(shard_set), 1)
-        self.assertIn('locally', "\n".join([event.activity for event in events]))
+        assert len(shard_set) == 1
+        assert 'locally' in "\n".join([event.activity for event in events])
 
     def create_ks_and_cf(self):
         self.session.execute(
@@ -110,7 +106,7 @@ class TestTabletsIntegration(unittest.TestCase):
 
         bound = prepared.bind([(2)])
         results = session.execute(bound, trace=True)
-        self.assertEqual(results, [(2, 2, 0)])
+        assert results == [(2, 2, 0)]
         if verify_in_tracing:
             self.verify_same_shard_in_tracing(results)
 
@@ -122,7 +118,7 @@ class TestTabletsIntegration(unittest.TestCase):
 
         bound = prepared.bind([(2)])
         results = session.execute(bound, trace=True)
-        self.assertEqual(results, [(2, 2, 0)])
+        assert results == [(2, 2, 0)]
         if verify_in_tracing:
             self.verify_same_host_in_tracing(results)
 

--- a/tests/integration/experiments/test_tablets.py
+++ b/tests/integration/experiments/test_tablets.py
@@ -1,11 +1,20 @@
+import time
+
+import pytest
+
 from cassandra.cluster import Cluster
 from cassandra.policies import ConstantReconnectionPolicy, RoundRobinPolicy, TokenAwarePolicy
 
 from tests.integration import PROTOCOL_VERSION, use_cluster
 from tests.unit.test_host_connection_pool import LOGGER
 
+CCM_CLUSTER = None
+
 def setup_module():
-    use_cluster('tablets', [3], start=True)
+    global CCM_CLUSTER
+
+    CCM_CLUSTER = use_cluster('tablets', [3], start=True)
+
 
 class TestTabletsIntegration:
     @classmethod
@@ -14,14 +23,14 @@ class TestTabletsIntegration:
                               load_balancing_policy=TokenAwarePolicy(RoundRobinPolicy()),
                               reconnection_policy=ConstantReconnectionPolicy(1))
         cls.session = cls.cluster.connect()
-        cls.create_ks_and_cf(cls)
+        cls.create_ks_and_cf(cls.session)
         cls.create_data(cls.session)
 
     @classmethod
     def teardown_class(cls):
         cls.cluster.shutdown()
 
-    def verify_same_host_in_tracing(self, results):
+    def verify_hosts_in_tracing(self, results, expected):
         traces = results.get_query_trace()
         events = traces.events
         host_set = set()
@@ -29,7 +38,7 @@ class TestTabletsIntegration:
             LOGGER.info("TRACE EVENT: %s %s %s", event.source, event.thread_name, event.description)
             host_set.add(event.source)
 
-        assert len(host_set) == 1
+        assert len(host_set) == expected
         assert 'locally' in "\n".join([event.description for event in events])
 
         trace_id = results.response_future.get_query_trace_ids()[0]
@@ -40,8 +49,12 @@ class TestTabletsIntegration:
             LOGGER.info("TRACE EVENT: %s %s", event.source, event.activity)
             host_set.add(event.source)
 
-        assert len(host_set) == 1
+        assert len(host_set) == expected
         assert 'locally' in "\n".join([event.activity for event in events])
+
+    def get_tablet_record(self, query):
+        metadata = self.session.cluster.metadata
+        return metadata._tablets.get_tablet_for_key(query.keyspace, query.table, metadata.token_map.token_class.from_key(query.routing_key))
 
     def verify_same_shard_in_tracing(self, results):
         traces = results.get_query_trace()
@@ -65,24 +78,25 @@ class TestTabletsIntegration:
         assert len(shard_set) == 1
         assert 'locally' in "\n".join([event.activity for event in events])
 
-    def create_ks_and_cf(self):
-        self.session.execute(
+    @classmethod
+    def create_ks_and_cf(cls, session):
+        session.execute(
             """
             DROP KEYSPACE IF EXISTS test1
             """
         )
-        self.session.execute(
+        session.execute(
             """
             CREATE KEYSPACE test1
             WITH replication = {
                 'class': 'NetworkTopologyStrategy',
-                'replication_factor': 1
+                'replication_factor': 2
             } AND tablets = {
                 'initial': 8
             }
             """)
 
-        self.session.execute(
+        session.execute(
             """
             CREATE TABLE test1.table1 (pk int, ck int, v int, PRIMARY KEY (pk, ck));
             """)
@@ -120,7 +134,7 @@ class TestTabletsIntegration:
         results = session.execute(bound, trace=True)
         assert results == [(2, 2, 0)]
         if verify_in_tracing:
-            self.verify_same_host_in_tracing(results)
+            self.verify_hosts_in_tracing(results, 1)
 
     def query_data_shard_insert(self, session, verify_in_tracing=True):
         prepared = session.prepare(
@@ -142,7 +156,7 @@ class TestTabletsIntegration:
         bound = prepared.bind([(52), (1), (2)])
         results = session.execute(bound, trace=True)
         if verify_in_tracing:
-            self.verify_same_host_in_tracing(results)
+            self.verify_hosts_in_tracing(results, 2)
 
     def test_tablets(self):
         self.query_data_host_select(self.session)
@@ -151,3 +165,70 @@ class TestTabletsIntegration:
     def test_tablets_shard_awareness(self):
         self.query_data_shard_select(self.session)
         self.query_data_shard_insert(self.session)
+
+    def test_tablets_invalidation_drop_ks_while_reconnecting(self):
+        def recreate_while_reconnecting(_):
+            # Kill control connection
+            conn = self.session.cluster.control_connection._connection
+            self.session.cluster.control_connection._connection = None
+            conn.close()
+
+            # Drop and recreate ks and table to trigger tablets invalidation
+            self.create_ks_and_cf(self.cluster.connect())
+
+            # Start control connection
+            self.session.cluster.control_connection._reconnect()
+
+        self.run_tablets_invalidation_test(recreate_while_reconnecting)
+
+    def test_tablets_invalidation_drop_ks(self):
+        def drop_ks(_):
+            # Drop and recreate ks and table to trigger tablets invalidation
+            self.create_ks_and_cf(self.cluster.connect())
+            time.sleep(3)
+
+        self.run_tablets_invalidation_test(drop_ks)
+
+    @pytest.mark.last
+    def test_tablets_invalidation_decommission_non_cc_node(self):
+        def decommission_non_cc_node(rec):
+            # Drop and recreate ks and table to trigger tablets invalidation
+            for node in CCM_CLUSTER.nodes.values():
+                if self.cluster.control_connection._connection.endpoint.address == node.network_interfaces["storage"][0]:
+                    # Ignore node that control connection is connected to
+                    continue
+                for replica in rec.replicas:
+                    if str(replica[0]) == str(node.node_hostid):
+                        node.decommission()
+                        break
+                else:
+                    continue
+                break
+            else:
+                assert False, "failed to find node to decommission"
+            time.sleep(10)
+
+        self.run_tablets_invalidation_test(decommission_non_cc_node)
+
+
+    def run_tablets_invalidation_test(self, invalidate):
+        # Make sure driver holds tablet info
+        # By landing query to the host that is not in replica set
+        bound = self.session.prepare(
+            """
+            SELECT pk, ck, v FROM test1.table1 WHERE pk = ?
+            """).bind([(2)])
+
+        rec = None
+        for host in self.cluster.metadata.all_hosts():
+            self.session.execute(bound, host=host)
+            rec = self.get_tablet_record(bound)
+            if rec is not None:
+                break
+
+        assert rec is not None, "failed to find tablet record"
+
+        invalidate(rec)
+
+        # Check if tablets information was purged
+        assert self.get_tablet_record(bound) is None, "tablet was not deleted, invalidation did not work"


### PR DESCRIPTION
Delete tablets for table or keyspace when one is deleted.
When host is removed from cluster delete all tablets that have this host in it.
Ensure that if it happens when control connection is reconnection.

Fixes https://github.com/scylladb/python-driver/issues/388

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.