### PR TITLE
Remove is <int>

### DIFF
--- a/tests/integration/cqlengine/__init__.py
+++ b/tests/integration/cqlengine/__init__.py
@@ -77,10 +77,10 @@ def execute_count(expected):
             # DeMonkey Patch our code
             cassandra.cqlengine.connection.execute = original_function
             # Check to see if we have a pre-existing test case to work from.
-            if len(args) is 0:
-                test_case = unittest.TestCase("__init__")
-            else:
+            if args:
                 test_case = args[0]
+            else:
+                test_case = unittest.TestCase("__init__")
             # Check to see if the count is what you expect
             test_case.assertEqual(count.get_counter(), expected, msg="Expected number of cassandra.cqlengine.connection.execute calls ({0}) doesn't match actual number invoked ({1})".format(expected, count.get_counter()))
             return to_return

--- a/tests/integration/cqlengine/query/test_queryoperators.py
+++ b/tests/integration/cqlengine/query/test_queryoperators.py
@@ -154,6 +154,6 @@ class TestTokenFunction(BaseCassEngTestCase):
         query = named.all().limit(1)
         first_page = list(query)
         last = first_page[-1]
-        self.assertTrue(len(first_page) is 1)
+        self.assertTrue(len(first_page) == 1)
         next_page = list(query.filter(pk__token__gt=functions.Token(last.key)))
-        self.assertTrue(len(next_page) is 1)
+        self.assertTrue(len(next_page) == 1)

--- a/tests/integration/standard/test_connection.py
+++ b/tests/integration/standard/test_connection.py
@@ -182,7 +182,7 @@ class HeartbeatTest(unittest.TestCase):
         while(retry < 300):
             retry += 1
             connections = self.fetch_connections(host, cluster)
-            if len(connections) is not 0:
+            if connections:
                 return connections
             time.sleep(.1)
         self.fail("No new connections found")
@@ -192,7 +192,7 @@ class HeartbeatTest(unittest.TestCase):
         while(retry < 100):
             retry += 1
             connections = self.fetch_connections(host, cluster)
-            if len(connections) is 0:
+            if not connections:
                 return
             time.sleep(.5)
         self.fail("Connections never cleared")


### PR DESCRIPTION
It does not match orthodox python style.
And trigger warnings:
```
  cqlengine/query/test_queryoperators.py:157: SyntaxWarning: "is" with 'int' literal. Did you mean "=="?
    self.assertTrue(len(first_page) is 1)
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.