### PR TITLE
Fix wrong escape sequences

### DIFF
--- a/cassandra/cqlengine/connection.py
+++ b/cassandra/cqlengine/connection.py
@@ -316,14 +316,14 @@ def setup(
         retry_connect=False,
         **kwargs):
     """
-    Setup a the driver connection used by the mapper
+    Setup the driver connection used by the mapper
 
     :param list hosts: list of hosts, (``contact_points`` for :class:`cassandra.cluster.Cluster`)
     :param str default_keyspace: The default keyspace to use
     :param int consistency: The global default :class:`~.ConsistencyLevel` - default is the same as :attr:`.Session.default_consistency_level`
     :param bool lazy_connect: True if should not connect until first use
     :param bool retry_connect: True if we should retry to connect even if there was a connection failure initially
-    :param \*\*kwargs: Pass-through keyword arguments for :class:`cassandra.cluster.Cluster`
+    :param kwargs: Pass-through keyword arguments for :class:`cassandra.cluster.Cluster`
     """
 
     from cassandra.cqlengine import models

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -205,8 +205,8 @@ class BatchQuery(object):
 
         :param fn: Callable object
         :type fn: callable
-        :param \*args: Positional arguments to be passed to the callback at the time of execution
-        :param \*\*kwargs: Named arguments to be passed to the callback at the time of execution
+        :param args: Positional arguments to be passed to the callback at the time of execution
+        :param kwargs: Named arguments to be passed to the callback at the time of execution
         """
         if not callable(fn):
             raise ValueError("Value for argument 'fn' is {0} and is not a callable object.".format(type(fn)))
@@ -276,8 +276,8 @@ class ContextQuery(object):
     A Context manager to allow a Model to switch context easily. Presently, the context only
     specifies a keyspace for model IO.
 
-    :param \*args: One or more models. A model should be a class type, not an instance.
-    :param \*\*kwargs: (optional) Context parameters: can be *keyspace* or *connection*
+    :param args: One or more models. A model should be a class type, not an instance.
+    :param kwargs: (optional) Context parameters: can be *keyspace* or *connection*
 
     For example:
 

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -150,7 +150,7 @@ class ClusterTests(unittest.TestCase):
         get_node(1).pause()
         cluster = TestCluster(contact_points=['127.0.0.1'], connect_timeout=1)
 
-        with self.assertRaisesRegex(NoHostAvailable, "OperationTimedOut\('errors=Timed out creating connection \(1 seconds\)"):
+        with self.assertRaisesRegex(NoHostAvailable, r"OperationTimedOut\('errors=Timed out creating connection \(1 seconds\)"):
             cluster.connect()
         cluster.shutdown()
 

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -1677,7 +1677,7 @@ class FunctionMetadata(FunctionTest):
 
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegex(fn_meta.as_cql_query(), "CREATE FUNCTION.*%s\(\) .*" % kwargs['name'])
+            self.assertRegex(fn_meta.as_cql_query(), r'CREATE FUNCTION.*%s\(\) .*' % kwargs['name'])
 
     def test_functions_follow_keyspace_alter(self):
         """
@@ -1725,12 +1725,12 @@ class FunctionMetadata(FunctionTest):
         kwargs['called_on_null_input'] = True
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegex(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) CALLED ON NULL INPUT RETURNS .*")
+            self.assertRegex(fn_meta.as_cql_query(), r'CREATE FUNCTION.*\) CALLED ON NULL INPUT RETURNS .*')
 
         kwargs['called_on_null_input'] = False
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegex(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) RETURNS NULL ON NULL INPUT RETURNS .*")
+            self.assertRegex(fn_meta.as_cql_query(), r'CREATE FUNCTION.*\) RETURNS NULL ON NULL INPUT RETURNS .*')
 
 
 @requires_java_udf

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -167,7 +167,7 @@ class QueryTests(BasicSharedKeyspaceUnitTestCase):
         client_ip = trace.client
 
         # Ip address should be in the local_host range
-        pat = re.compile("127.0.0.\d{1,3}")
+        pat = re.compile(r'127.0.0.\d{1,3}')
 
         # Ensure that ip is set
         self.assertIsNotNone(client_ip, "Client IP was not set in trace with C* >= 2.2")


### PR DESCRIPTION
Following warnings shows up all over the code:
```
SyntaxWarning: invalid escape sequence ...
```
Let's fix it.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.