### PR TITLE
Sync with 3.29.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,19 @@
+3.29.0
+======
+December 19, 2023
+
+Features
+--------
+* Add support for Python 3.9 through 3.12, drop support for 3.7 (PYTHON-1283)
+* Removal of dependency on six module (PR 1172)
+* Raise explicit exception when deserializing a vector with a subtype that isn’t a constant size (PYTHON-1371)
+
+Others
+------
+* Remove outdated Python pre-3.7 references (PR 1186)
+* Remove backup(.bak) files (PR 1185)
+* Fix doc typo in add_callbacks (PR 1177)
+
 3.28.0
 ======
 June 5, 2023

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -54,7 +54,7 @@ try:
     from cassandra.io.libevreactor import LibevConnection
     have_libev = True
     supported_reactors.append(LibevConnection)
-except ImportError as exc:
+except cassandra.DependencyException as exc:
     pass
 
 have_asyncio = False

--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -763,7 +763,7 @@ class DependencyException(Exception):
     def __init__(self, msg, excs=[]):
         complete_msg = msg
         if excs:
-            complete_msg += ("The following exceptions were observed: \n" + '\n'.join(str(e) for e in excs))
+            complete_msg += ("\nThe following exceptions were observed: \n - " + '\n - '.join(str(e) for e in excs))
         Exception.__init__(self, complete_msg)
 
 class VectorDeserializationFailure(DriverException):

--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -735,6 +735,7 @@ class OperationType(Enum):
     Read = 0
     Write = 1
 
+
 class RateLimitReached(ConfigurationException):
     '''
     Rate limit was exceeded for a partition affected by the request.
@@ -747,3 +748,20 @@ class RateLimitReached(ConfigurationException):
         self.rejected_by_coordinator = rejected_by_coordinator
         message = f"[request_error_rate_limit_reached OpType={op_type.name} RejectedByCoordinator={rejected_by_coordinator}]"
         Exception.__init__(self, message)
+
+
+class DependencyException(Exception):
+    """
+    Specific exception class for handling issues with driver dependencies
+    """
+
+    excs = []
+    """
+    A sequence of child exceptions
+    """
+
+    def __init__(self, msg, excs=[]):
+        complete_msg = msg
+        if excs:
+            complete_msg += ("The following exceptions were observed: \n" + '\n'.join(str(e) for e in excs))
+        Exception.__init__(self, complete_msg)

--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -23,7 +23,7 @@ class NullHandler(logging.Handler):
 
 logging.getLogger('cassandra').addHandler(NullHandler())
 
-__version_info__ = (3, 28, 2)
+__version_info__ = (3, 29, 0)
 __version__ = '.'.join(map(str, __version_info__))
 
 

--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -765,3 +765,9 @@ class DependencyException(Exception):
         if excs:
             complete_msg += ("The following exceptions were observed: \n" + '\n'.join(str(e) for e in excs))
         Exception.__init__(self, complete_msg)
+
+class VectorDeserializationFailure(DriverException):
+    """
+    The driver was unable to deserialize a given vector
+    """
+    pass

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -833,9 +833,9 @@ class Cluster(object):
     Using ssl_options without ssl_context is deprecated and will be removed in the
     next major release.
 
-    An optional dict which will be used as kwargs for ``ssl.SSLContext.wrap_socket`` (or
-    ``ssl.wrap_socket()`` if used without ssl_context) when new sockets are created.
-    This should be used when client encryption is enabled in Cassandra.
+    An optional dict which will be used as kwargs for ``ssl.SSLContext.wrap_socket`` 
+    when new sockets are created. This should be used when client encryption is enabled 
+    in Cassandra.
 
     The following documentation only applies when ssl_options is used without ssl_context.
 
@@ -851,6 +851,12 @@ class Cluster(object):
     should almost always require the option ``'cert_reqs': ssl.CERT_REQUIRED``. Note also that this functionality was not built into
     Python standard library until (2.7.9, 3.2). To enable this mechanism in earlier versions, patch ``ssl.match_hostname``
     with a custom or `back-ported function <https://pypi.org/project/backports.ssl_match_hostname/>`_.
+
+    .. versionchanged:: 3.29.0
+
+    ``ssl.match_hostname`` has been deprecated since Python 3.7 (and removed in Python 3.12).  This functionality is now implemented
+    via ``ssl.SSLContext.check_hostname``.  All options specified above (including ``check_hostname``) should continue to behave in a
+    way that is consistent with prior implementations.
     """
 
     ssl_context = None

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -127,8 +127,12 @@ def _is_eventlet_monkey_patched():
 def _is_gevent_monkey_patched():
     if 'gevent.monkey' not in sys.modules:
         return False
-    import gevent.socket
-    return socket.socket is gevent.socket.socket
+    try:
+        import eventlet.patcher
+        return eventlet.patcher.is_monkey_patched('socket')
+    # Another case related to PYTHON-1364
+    except AttributeError:
+        return False
 
 
 # default to gevent when we are monkey patched with gevent, eventlet when

--- a/cassandra/io/asyncorereactor.py
+++ b/cassandra/io/asyncorereactor.py
@@ -30,7 +30,15 @@ try:
 except ImportError:
     from cassandra.util import WeakSet  # noqa
 
-import asyncore
+from cassandra import DependencyException
+try:
+    import asyncore
+except ModuleNotFoundError:
+    raise DependencyException(
+        "Unable to import asyncore module.  Note that this module has been removed in Python 3.12 "
+        "so when using the driver with this version (or anything newer) you will need to use one of the "
+        "other event loop implementations."
+    )
 
 from cassandra.connection import Connection, ConnectionShutdown, NONBLOCKING, Timer, TimerManager
 

--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -21,13 +21,13 @@ import ssl
 from threading import Lock, Thread
 import time
 
-
+from cassandra import DependencyException
 from cassandra.connection import (Connection, ConnectionShutdown,
                                   NONBLOCKING, Timer, TimerManager)
 try:
     import cassandra.io.libevwrapper as libev
 except ImportError:
-    raise ImportError(
+    raise DependencyException(
         "The C extension needed to use libev was not found.  This "
         "probably means that you didn't have the required build dependencies "
         "when installing the driver.  See "

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ A Python client driver for `Scylla <https://docs.scylladb.com>`_.
 This driver works exclusively with the Cassandra Query Language v3 (CQL3)
 and Cassandra's native protocol.
 
-The driver supports Python 3.6-3.11.
+The driver supports Python 3.6-3.12.
 
 This driver is open source under the
 `Apache v2 License <http://www.apache.org/licenses/LICENSE-2.0.html>`_.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Supported Platforms
 -------------------
-Python versions 3.6-3.11 are supported. Both CPython (the standard Python
+Python versions 3.6-3.12 are supported. Both CPython (the standard Python
 implementation) and `PyPy <http://pypy.org>`_ are supported and tested.
 
 Linux, OSX, and Windows are supported.
@@ -26,7 +26,7 @@ To check if the installation was successful, you can run::
 
     python -c 'import cassandra; print cassandra.__version__'
 
-It should print something like "3.27.0".
+It should print something like "3.29.0".
 
 (*Optional*) Compression Support
 --------------------------------
@@ -182,12 +182,15 @@ dependencies, then use install-option::
     sudo pip install --install-option="--no-cython"
 
 
+Supported Event Loops
+^^^^^^^^^^^^^^^^^^^^^
+For Python versions before 3.12 the driver uses the ``asyncore`` module for its default
+event loop.  Other event loops such as ``libev``, ``gevent`` and ``eventlet`` are also
+available via Python modules or C extensions.  Python 3.12 has removed ``asyncore`` entirely
+so for this platform one of these other event loops must be used.
+
 libev support
 ^^^^^^^^^^^^^
-The driver currently uses Python's ``asyncore`` module for its default
-event loop.  For better performance, ``libev`` is also supported through
-a C extension.
-
 If you're on Linux, you should be able to install libev
 through a package manager.  For example, on Debian/Ubuntu::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,6 @@ classifiers = [
     'Natural Language :: English',
     'Operating System :: OS Independent',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,6 +11,6 @@ gevent==23.9.0; python_version < '3.13' and (platform_machine == 'i686' or platf
 eventlet>=0.33.3; python_version < '3.13'
 cython>=0.20,<0.30
 packaging
-futurist; python_version >= '3.7'
+futurist
 asynctest
 pyyaml

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,9 +6,9 @@ pytz
 sure
 pure-sasl
 twisted[tls]
-gevent>=1.0; python_version < '3.13' and platform_machine != 'i686' and platform_machine != 'win32'
-gevent==23.9.0; python_version < '3.13' and (platform_machine == 'i686' or platform_machine == 'win32')
-eventlet>=0.33.3; python_version < '3.13'
+gevent>=1.0; platform_machine != 'i686' and platform_machine != 'win32'
+gevent==23.9.0; platform_machine == 'i686' or platform_machine == 'win32'
+eventlet>=0.33.3;
 cython>=0.20,<0.30
 packaging
 futurist

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,13 +5,12 @@ mock>1.1
 pytz
 sure
 pure-sasl
-twisted[tls]; python_version >= '3.5'
-twisted[tls]==19.2.1; python_version < '3.5'
+twisted[tls]
 gevent>=1.0; python_version < '3.13' and platform_machine != 'i686' and platform_machine != 'win32'
 gevent==23.9.0; python_version < '3.13' and (platform_machine == 'i686' or platform_machine == 'win32')
 eventlet>=0.33.3; python_version < '3.13'
-cython
+cython>=0.20,<0.30
 packaging
 futurist; python_version >= '3.7'
-asynctest; python_version >= '3.5'
+asynctest
 pyyaml

--- a/tests/integration/long/test_ipv6.py
+++ b/tests/integration/long/test_ipv6.py
@@ -15,11 +15,12 @@
 import os, socket, errno
 from ccmlib import common
 
+from cassandra import DependencyException
 from cassandra.cluster import NoHostAvailable
 
 try:
     from cassandra.io.asyncorereactor import AsyncoreConnection
-except ImportError:
+except DependencyException:
     AsyncoreConnection = None
 
 from tests import is_monkey_patched
@@ -27,7 +28,7 @@ from tests.integration import use_cluster, remove_cluster, TestCluster
 
 try:
     from cassandra.io.libevreactor import LibevConnection
-except ImportError:
+except DependencyException:
     LibevConnection = None
 
 

--- a/tests/integration/long/test_ssl.py
+++ b/tests/integration/long/test_ssl.py
@@ -28,7 +28,7 @@ from tests.integration import (
 
 if not hasattr(ssl, 'match_hostname'):
     try:
-        from backports.ssl_match_hostname import match_hostname
+        from ssl import match_hostname
         ssl.match_hostname = match_hostname
     except ImportError:
         pass  # tests will fail

--- a/tests/integration/standard/test_connection.py
+++ b/tests/integration/standard/test_connection.py
@@ -23,16 +23,9 @@ from threading import Thread, Event
 import time
 from unittest import SkipTest
 
-from cassandra import ConsistencyLevel, OperationTimedOut
+from cassandra import ConsistencyLevel, OperationTimedOut, DependencyException
 from cassandra.cluster import NoHostAvailable, ConnectionShutdown, ExecutionProfile, EXEC_PROFILE_DEFAULT
-
-try:
-    from cassandra.io.asyncorereactor import AsyncoreConnection
-except ImportError:
-    AsyncoreConnection = None
-
 from cassandra.protocol import QueryMessage
-from cassandra.connection import Connection
 from cassandra.policies import HostFilterPolicy, RoundRobinPolicy, HostStateListener
 from cassandra.pool import HostConnectionPool
 
@@ -41,9 +34,15 @@ from tests.integration import use_singledc, get_node, CASSANDRA_IP, local, \
     requiresmallclockgranularity, greaterthancass20, TestCluster
 
 try:
+    import cassandra.io.asyncorereactor
+    from cassandra.io.asyncorereactor import AsyncoreConnection
+except DependencyException:
+    AsyncoreConnection = None
+
+try:
     from cassandra.io.libevreactor import LibevConnection
     import cassandra.io.libevreactor
-except ImportError:
+except DependencyException:
     LibevConnection = None
 
 
@@ -447,8 +446,7 @@ class AsyncoreConnectionTests(ConnectionTests, unittest.TestCase):
         if is_monkey_patched():
             raise unittest.SkipTest("Can't test asyncore with monkey patching")
         if AsyncoreConnection is None:
-            raise unittest.SkipTest(
-                'asyncore does not appear to be installed properly')
+            raise unittest.SkipTest('Unable to import asyncore module')
         ConnectionTests.setUp(self)
 
     def clean_global_loop(self):

--- a/tests/integration/standard/test_scylla_cloud.py
+++ b/tests/integration/standard/test_scylla_cloud.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from ccmlib.utils.ssl_utils import generate_ssl_stores
 from ccmlib.utils.sni_proxy import refresh_certs, start_sni_proxy, create_cloud_config, NodeInfo
 
+from cassandra import DependencyException
 from cassandra.policies import TokenAwarePolicy, RoundRobinPolicy, ConstantReconnectionPolicy
 from tests.integration import use_cluster, PROTOCOL_VERSION
 from cassandra.cluster import Cluster, TwistedConnection
@@ -15,14 +16,14 @@ supported_connection_classes = [TwistedConnection]
 try:
     from cassandra.io.libevreactor import LibevConnection
     supported_connection_classes += [LibevConnection]
-except ImportError:
+except DependencyException:
     pass
 
 
 try:
     from cassandra.io.asyncorereactor import AsyncoreConnection
     supported_connection_classes += [AsyncoreConnection]
-except ImportError:
+except DependencyException:
     pass
 
 #from cassandra.io.geventreactor import GeventConnection

--- a/tests/unit/io/test_asyncorereactor.py
+++ b/tests/unit/io/test_asyncorereactor.py
@@ -15,11 +15,14 @@ import unittest
 
 from mock import patch
 import socket
+
+from cassandra import DependencyException
+
 try:
     import cassandra.io.asyncorereactor as asyncorereactor
     from cassandra.io.asyncorereactor import AsyncoreConnection
     ASYNCCORE_AVAILABLE = True
-except ImportError:
+except (ImportError, DependencyException):
     ASYNCCORE_AVAILABLE = False
     AsyncoreConnection = None
 

--- a/tests/unit/io/test_libevreactor.py
+++ b/tests/unit/io/test_libevreactor.py
@@ -19,12 +19,12 @@ import socket
 
 from tests import is_monkey_patched
 from tests.unit.io.utils import ReactorTestMixin, TimerTestMixin, noop_if_monkey_patched
-
+from cassandra import DependencyException
 
 try:
     from cassandra.io.libevreactor import _cleanup as libev__cleanup
     from cassandra.io.libevreactor import LibevConnection
-except ImportError:
+except (ImportError, DependencyException):
     LibevConnection = None  # noqa
 
 

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -14,6 +14,7 @@
 import unittest
 
 import logging
+import socket
 
 from mock import patch, Mock
 
@@ -88,8 +89,9 @@ class ClusterTest(unittest.TestCase):
 
     def test_tuple_for_contact_points(self):
         cluster = Cluster(contact_points=[('localhost', 9045), ('127.0.0.2', 9046), '127.0.0.3'], port=9999)
+        localhost_addr = set([addr[0] for addr in [t for (_,_,_,_,t) in socket.getaddrinfo("localhost",80)]])
         for cp in cluster.endpoints_resolved:
-            if cp.address in ('::1', '127.0.0.1'):
+            if cp.address in localhost_addr:
                 self.assertEqual(cp.port, 9045)
             elif cp.address == '127.0.0.2':
                 self.assertEqual(cp.port, 9046)

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -16,10 +16,11 @@ import unittest
 import datetime
 import tempfile
 import time
+import uuid
 from binascii import unhexlify
 
 import cassandra
-from cassandra import util
+from cassandra import util, VectorDeserializationFailure
 from cassandra.cqltypes import (
     CassandraType, DateRangeType, DateType, DecimalType,
     EmptyValue, LongType, SetType, UTF8Type,
@@ -308,15 +309,67 @@ class TypeTests(unittest.TestCase):
         self.assertEqual(cql_quote('test'), "'test'")
         self.assertEqual(cql_quote(0), '0')
 
-    def test_vector_round_trip(self):
-        base = [3.4, 2.9, 41.6, 12.0]
-        ctype = parse_casstype_args("org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 4)")
-        base_bytes = ctype.serialize(base, 0)
-        self.assertEqual(16, len(base_bytes))
-        result = ctype.deserialize(base_bytes, 0)
-        self.assertEqual(len(base), len(result))
-        for idx in range(0,len(base)):
-            self.assertAlmostEqual(base[idx], result[idx], places=5)
+    def test_vector_round_trip_types_with_serialized_size(self):
+        # Test all the types which specify a serialized size... see PYTHON-1371 for details
+        self._round_trip_test([True, False, False, True], \
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.BooleanType, 4)")
+        self._round_trip_test([3.4, 2.9, 41.6, 12.0], \
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 4)")
+        self._round_trip_test([3.4, 2.9, 41.6, 12.0], \
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.DoubleType, 4)")
+        self._round_trip_test([3, 2, 41, 12], \
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.LongType, 4)")
+        self._round_trip_test([3, 2, 41, 12], \
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.Int32Type, 4)")
+        self._round_trip_test([uuid.uuid1(), uuid.uuid1(), uuid.uuid1(), uuid.uuid1()], \
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.TimeUUIDType, 4)")
+        self._round_trip_test([3, 2, 41, 12], \
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.ShortType, 4)")
+        self._round_trip_test([datetime.time(1,1,1), datetime.time(2,2,2), datetime.time(3,3,3)], \
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.TimeType, 3)")
+
+    def test_vector_round_trip_types_without_serialized_size(self):
+        # Test all the types which do not specify a serialized size... see PYTHON-1371 for details
+        # Varints
+        with self.assertRaises(VectorDeserializationFailure):
+            self._round_trip_test([3, 2, 41, 12], \
+                "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.IntegerType, 4)")
+        # ASCII text
+        with self.assertRaises(VectorDeserializationFailure):
+            self._round_trip_test(["abc", "def", "ghi", "jkl"], \
+                "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.AsciiType, 4)")
+        # UTF8 text
+        with self.assertRaises(VectorDeserializationFailure):
+            self._round_trip_test(["abc", "def", "ghi", "jkl"], \
+                "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.UTF8Type, 4)")
+        # Duration (containts varints)
+        with self.assertRaises(VectorDeserializationFailure):
+            self._round_trip_test([util.Duration(1,1,1), util.Duration(2,2,2), util.Duration(3,3,3)], \
+                "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.DurationType, 3)")
+        # List (of otherwise serializable type)
+        with self.assertRaises(VectorDeserializationFailure):
+            self._round_trip_test([[3.4], [2.9], [41.6], [12.0]], \
+                "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.FloatType), 4)")
+        # Set (of otherwise serializable type)
+        with self.assertRaises(VectorDeserializationFailure):
+            self._round_trip_test([set([3.4]), set([2.9]), set([41.6]), set([12.0])], \
+                "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.FloatType), 4)")
+        # Map (of otherwise serializable types)
+        with self.assertRaises(VectorDeserializationFailure):
+            self._round_trip_test([{1:3.4}, {2:2.9}, {3:41.6}, {4:12.0}], \
+                "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.MapType \
+                    (org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.FloatType), 4)")
+
+    def _round_trip_test(self, data, ctype_str):
+        ctype = parse_casstype_args(ctype_str)
+        data_bytes = ctype.serialize(data, 0)
+        serialized_size = getattr(ctype.subtype, "serial_size", None)
+        if serialized_size:
+            self.assertEqual(serialized_size * len(data), len(data_bytes))
+        result = ctype.deserialize(data_bytes, 0)
+        self.assertEqual(len(data), len(result))
+        for idx in range(0,len(data)):
+            self.assertAlmostEqual(data[idx], result[idx], places=5)
 
     def test_vector_cql_parameterized_type(self):
         ctype = parse_casstype_args("org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 4)")


### PR DESCRIPTION
Sync with 3.29.0 of the upstream

One significant refactor needed to make it work, after https://github.com/scylladb/python-driver/pull/406/commits/c44e264d2c44c087672bfe781d33ed8002063678 multiple test become broken, this commit introduced `DependencyException` for missing requirements for `asyncorereactor.py` and `libevreactor.py` and partially patched code that 
imports them, as result many tests where broken.
I have created following up commit that addresses all the problems: https://github.com/scylladb/python-driver/pull/406/commits/47d882d7ed630361e604d641abc21fb53cefd88d

## Pre-review checklist
<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~