### PR TITLE
github actions: user newer cython versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -406,7 +406,7 @@ def run_setup(extensions):
         # 1.) build_ext eats errors at compile time, letting the install complete while producing useful feedback
         # 2.) there could be a case where the python environment has cython installed but the system doesn't have build tools
         if pre_build_check():
-            cython_dep = 'Cython>=0.20,!=0.25,<0.30'
+            cython_dep = 'Cython>=3.0.11,<4'
             user_specified_cython_version = os.environ.get('CASS_DRIVER_ALLOWED_CYTHON_VERSION')
             if user_specified_cython_version is not None:
                 cython_dep = 'Cython==%s' % (user_specified_cython_version,)


### PR DESCRIPTION
`setup.py` is pinning to use `Cython>=0.20,!=0.25,<0.30` code generated form those old versions is not compiling anymore with python3.13

in turn it cause libev part to be missing in the driver, which surface other issue with asyncio eventloop we currently use as default

in this chnage we pin to newer version of cython when we build the wheel

Fixes: #409

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.