### PR TITLE
fix extensions building

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Build wheels
         env:
-          CIBW_BUILD: "cp39* cp310* cp311* cp312*" # limit to specific version since it take much more time than jobs limit
+          CIBW_BUILD: "cp39* cp310* cp311* cp312* cp313*" # limit to specific version since it take much more time than jobs limit
         run: |
           python -m cibuildwheel --archs  ${{ matrix.archs }} --output-dir wheelhouse
 

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -34,7 +34,7 @@ jobs:
           - os: ubuntu-24.04
             platform: PyPy
 
-          - os: windows-latest
+          - os: windows-2022
             platform: win64
 
           - os: windows-latest
@@ -100,6 +100,7 @@ jobs:
         if: runner.os == 'Windows' && matrix.platform == 'win64'
         run: |
           echo "CIBW_BUILD=cp*win_amd64" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo "CIBW_ENVIRONMENT_WINDOWS= CC=clang CXX=clang++" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
       - name: Overwrite for Windows PyPY
         if: runner.os == 'Windows' && matrix.platform == 'PyPy'

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -168,6 +168,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+          image: 'docker.io/tonistiigi/binfmt:desktop-v8.1.5'
         if: runner.os == 'Linux'
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -12,7 +12,7 @@ env:
  CIBW_TEST_COMMAND_WINDOWS: "pytest {project}/tests/unit  -k \"not (test_deserialize_date_range_year or test_datetype or test_libevreactor)\" "
  CIBW_BEFORE_TEST: "pip install -r {project}/test-requirements.txt"
  CIBW_BEFORE_BUILD_LINUX: "rm -rf ~/.pyxbld && rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux && yum install -y libffi-devel libev libev-devel openssl openssl-devel"
- CIBW_ENVIRONMENT: "CASS_DRIVER_BUILD_CONCURRENCY=2 CFLAGS='-g0 -O3'"
+ CIBW_ENVIRONMENT: "CASS_DRIVER_BUILD_CONCURRENCY=2 CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST=yes CFLAGS='-g0 -O3'"
  CIBW_SKIP: cp36* cp37* pp*i686 *musllinux*
  CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
  CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux_2_28

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -40,7 +40,7 @@ jobs:
           - os: windows-latest
             platform: PyPy
 
-          - os: macos-latest
+          - os: macos-14
             platform: all
 
           - os: macos-13
@@ -112,8 +112,15 @@ jobs:
         run: |
           echo "CIBW_BUILD=cp39* cp310* cp311* cp312* cp313*" >> $GITHUB_ENV
           echo "CIBW_BEFORE_TEST_MACOS=pip install -r {project}/test-requirements.txt pytest" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
-
+          if [ "${{ matrix.os }}" == "macos-13" ]; then
+            echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV;
+            echo "Enforcing target deployment for 13.0"
+          elif [ "${{ matrix.os }}" == "macos-14" ]; then
+            echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV;
+            echo "Enforcing target deployment for 14.0"
+          else
+            echo "Unknown macos version" && false;
+          fi
       - name: Overwrite for MacOs PyPy
         if: runner.os == 'MacOs' && matrix.platform == 'PyPy'
         run: |

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -28,10 +28,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             platform: x86_64
 
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             platform: PyPy
 
           - os: windows-latest
@@ -133,7 +133,7 @@ jobs:
   build_sdist:
     name: Build source distribution
     if: "(!contains(github.event.pull_request.labels.*.name, 'disable-test-build'))|| github.event_name == 'push' && endsWith(github.event.ref, 'scylla')"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -153,7 +153,7 @@ jobs:
   build_wheels_extra_arch:
     if: "(!contains(github.event.pull_request.labels.*.name, 'disable-test-build'))|| github.event_name == 'push' && endsWith(github.event.ref, 'scylla')"
     # The host should always be linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Build extra arch ${{ matrix.archs }} wheels
     strategy:
       fail-fast: false
@@ -193,7 +193,7 @@ jobs:
 
   upload_pypi:
     needs: [build_wheels, build_wheels_extra_arch, build_sdist]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
 

--- a/cassandra/io/libevwrapper.c
+++ b/cassandra/io/libevwrapper.c
@@ -667,9 +667,6 @@ initlibevwrapper(void)
     if (PyModule_AddObject(module, "Timer", (PyObject *)&libevwrapper_TimerType) == -1)
         INITERROR;
 
-    if (!PyEval_ThreadsInitialized()) {
-        PyEval_InitThreads();
-    }
 
 #if PY_MAJOR_VERSION >= 3
     return module;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,81 @@
+[project]
+name = "scylla-driver"
+description = "Scylla Driver for Apache Cassandra"
+authors = [
+    {name = "ScyllaDB"},
+]
+keywords = ["cassandra", "cql", "orm", "dse", "graph"]
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: Apache Software License',
+    'Natural Language :: English',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: Implementation :: CPython',
+    'Programming Language :: Python :: Implementation :: PyPy',
+    'Topic :: Software Development :: Libraries :: Python Modules'
+]
+dependencies = [
+    'geomet>=0.1,<0.3',
+    'pyyaml > 5.0'
+]
+dynamic = ["version", "readme"]
+
+[project.urls]
+"Homepage" = "https://github.com/scylladb/python-driver"
+"Documentation" = "https://scylladb.github.io/python-driver/"
+"Source" = "https://github.com/scylladb/python-driver/"
+"Issues" = "https://github.com/scylladb/python-driver/issues"
+
+[project.optional-dependencies]
+graph =  ['gremlinpython==3.4.6']
+cle = ['cryptography>=35.0']
+test = [
+    "pytest",
+    "mock>=2.0.0",
+    "PyYAML",
+    "pytz",
+    "sure",
+    "scales",
+    "pure-sasl",
+    "twisted[tls]; python_version >= '3.5'",
+    "twisted[tls]==19.2.1; python_version < '3.5'",
+    "gevent>=1.0; python_version < '3.13' and platform_machine != 'i686' and platform_machine != 'win32'",
+    "gevent==23.9.0; python_version < '3.13' and (platform_machine == 'i686' or platform_machine == 'win32')",
+    "eventlet>=0.33.3; python_version < '3.13'",
+    "cython",
+    "packaging",
+    "futurist; python_version >= '3.7'",
+    "asynctest; python_version >= '3.5'",
+    "pyyaml",
+]
+
+[tool.setuptools]
+include-package-data = true
+packages=[
+    'cassandra', 'cassandra.io', 'cassandra.cqlengine', 'cassandra.graph',
+    'cassandra.datastax', 'cassandra.datastax.insights', 'cassandra.datastax.graph',
+    'cassandra.datastax.graph.fluent', 'cassandra.datastax.cloud', 'cassandra.scylla',
+    'cassandra.column_encryption'
+]
+
+[tool.setuptools.dynamic]
+version = {attr = "cassandra.__version__"}  # any module attribute compatible with ast.literal_eval
+readme = {file = "README.rst", content-type = "text/x-rst"}
+
+[build-system]
+requires = [
+    "setuptools>=42",
+    "Cython",
+]
+
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,6 @@ try:
 except ImportError:
     has_subprocess = False
 
-from cassandra import __version__
-
-long_description = ""
-with open("README.rst") as f:
-    long_description = f.read()
-
-
 try:
     from nose.commands import nosetests
 except ImportError:
@@ -94,6 +87,7 @@ class DocCommand(Command):
             path = "docs/_build/doctest"
             mode = "doctest"
         else:
+            from cassandra import __version__
             path = "docs/_build/%s" % __version__
             mode = "html"
 
@@ -434,59 +428,8 @@ def run_setup(extensions):
         else:
             sys.stderr.write("Bypassing Cython setup requirement\n")
 
-    dependencies = [
-        'geomet>=0.1,<0.3',
-        'pyyaml > 5.0'
-    ]
-
-    _EXTRAS_REQUIRE = {
-        'graph': ['gremlinpython==3.4.6'],
-        'cle': ['cryptography>=35.0']
-    }
-
     setup(
-        name='scylla-driver',
-        version=__version__,
-        description='Scylla Driver for Apache Cassandra',
-        long_description=long_description,
-        long_description_content_type='text/x-rst',
-        url='https://github.com/scylladb/python-driver',
-        project_urls={
-            'Documentation': 'https://scylladb.github.io/python-driver/',
-            'Source': 'https://github.com/scylladb/python-driver/',
-            'Issues': 'https://github.com/scylladb/python-driver/issues',
-        },
-        author='ScyllaDB',
-        packages=[
-            'cassandra', 'cassandra.io', 'cassandra.cqlengine', 'cassandra.graph',
-            'cassandra.datastax', 'cassandra.datastax.insights', 'cassandra.datastax.graph',
-            'cassandra.datastax.graph.fluent', 'cassandra.datastax.cloud', 'cassandra.scylla',
-            'cassandra.column_encryption'
-        ],
-        keywords='cassandra,cql,orm,dse,graph',
-        include_package_data=True,
-        install_requires=dependencies,
-        extras_require=_EXTRAS_REQUIRE,
         tests_require=['nose', 'mock>=2.0.0', 'PyYAML', 'pytz', 'sure'],
-        classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'Intended Audience :: Developers',
-            'License :: OSI Approved :: Apache Software License',
-            'Natural Language :: English',
-            'Operating System :: OS Independent',
-            'Programming Language :: Python',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.7',
-            'Programming Language :: Python :: 3.8',
-            'Programming Language :: Python :: 3.9',
-            'Programming Language :: Python :: 3.10',
-            'Programming Language :: Python :: 3.11',
-            'Programming Language :: Python :: 3.12',
-            'Programming Language :: Python :: 3.13',
-            'Programming Language :: Python :: Implementation :: CPython',
-            'Programming Language :: Python :: Implementation :: PyPy',
-            'Topic :: Software Development :: Libraries :: Python Modules'
-        ],
         **kw)
 
 

--- a/setup.py
+++ b/setup.py
@@ -325,10 +325,14 @@ On OSX, via homebrew:
                                extra_compile_args=compile_args)
                         for m in cython_candidates],
                     nthreads=build_concurrency,
-                    exclude_failures=True))
+                    compiler_directives={'language_level': 3},
+                ))
 
-                self.extensions.extend(cythonize(NoPatchExtension("*", ["cassandra/*.pyx"], extra_compile_args=compile_args),
-                                                 nthreads=build_concurrency))
+                self.extensions.extend(cythonize(
+                    NoPatchExtension("*", ["cassandra/*.pyx"], extra_compile_args=compile_args),
+                    nthreads=build_concurrency,
+                    compiler_directives={'language_level': 3},
+                ))
             except Exception:
                 sys.stderr.write("Failed to cythonize one or more modules. These will not be compiled as extensions (optional).\n")
 


### PR DESCRIPTION
By accident @avikivity has found that `cassandra.io.libevwrapper` is not built properly for `fedora:41`.
Later @fruch  has discovered that on other systems we have similar problems that we failed to spot becasuse `setup.py` ignores when extension building fails.
To address that this PR introduces `CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST` which is `False` by default.
When it is set, `setup.py` fails when extension build is failed.

`CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST=yes` is added to the CICD, to make it fail, so that we see problem right away.
This PR also addresses all the problems that `CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST` uncovered with failed extensions.

`pyproject.toml` is also introduced to fix building for `aarch64` and `python 3.13`, by some reason `cibuildwheel` fails to pull all the dependancies in such case.

Fixes following problems:
1. `PyEval_InitThreads` got [depricated](https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads) and does not exists in python 3.13:
```
building 'cassandra.io.libevwrapper' extension
gcc -fno-strict-overflow -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -fcf-protection -fexceptions -fcf-protection -fexceptions -fcf-protection -fexceptions -O3 -fPIC -I/usr/include/libev -I/usr/local/include -I/opt/local/include -I/usr/include/python3.13 -c cassandra/io/libevwrapper.c -o build/temp.linux-x86_64-cpython-313/cassandra/io/libevwrapper.o
cassandra/io/libevwrapper.c: In function ‘PyInit_libevwrapper’:
cassandra/io/libevwrapper.c:668:10: error: implicit declaration of function ‘PyEval_ThreadsInitialized’ [-Wimplicit-function-declaration]
  668 |     if (!PyEval_ThreadsInitialized()) {
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
cassandra/io/libevwrapper.c:669:9: warning: ‘PyEval_InitThreads’ is deprecated [-Wdeprecated-declarations]
  669 |         PyEval_InitThreads();
      |         ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/python3.13/Python.h:124,
                 from cassandra/io/libevwrapper.c:1:
/usr/include/python3.13/ceval.h:114:37: note: declared here
  114 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
      |                                     ^~~~~~~~~~~~~~~~~~
command '/usr/lib64/ccache/gcc' failed with exit code 1
/home/avi/python-driver/setup.py:291: UserWarning: 
```
2. Cython fails to convert unicode to 'str':
```
Error compiling Cython file:
------------------------------------------------------------
...
if metadata_request_timeout is None:
    return stmt
ms = int(metadata_request_timeout / datetime.timedelta(milliseconds=1))
if ms == 0:
    return stmt
return f"{stmt} USING TIMEOUT {ms}ms"
               ^
------------------------------------------------------------
    
cassandra/util.py:1813:11: Cannot convert Unicode string to 'str' implicitly. This is not portable and requires explicit encoding.
```
3. Windows builds failures:
```
    cassandra\c_shard_info.c(3083): error C2065: '__uint128_t': undeclared identifier
    cassandra\c_shard_info.c(3083): error C2146: syntax error: missing ')' before identifier '__pyx_v_biased_token'
    cassandra\c_shard_info.c(3083): error C2059: syntax error: ')'
    cassandra\c_shard_info.c(3083): error C2059: syntax error: ')'
    cassandra\c_shard_info.c(3083): error C2059: syntax error: ')'
```
4. Varios macos build failures, one of which:
```
  ERROR: scylla_driver-3.28.0-cp39-cp39-macosx_14_0_x86_64.whl is not a supported wheel on this platform.
```
5. Random crashes, failures or hangups during `aarch64` builds

Fixes: https://github.com/scylladb/python-driver/issues/409
## Tested

Localy on `fedora:41` image

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [ ] ~~All commits compile, pass static checks and pass test.~~
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.