### PR TITLE
cibuildwheel: move configuration to pyproject.toml

### DIFF
--- a/.github/workflows/build-pre-release.yml
+++ b/.github/workflows/build-pre-release.yml
@@ -3,13 +3,8 @@ name: Build pre release python versions
 on: [push, pull_request]
 
 env:
- CIBW_TEST_COMMAND_LINUX: "pytest {project}/tests/unit"
- CIBW_BEFORE_TEST: "pip install -r {project}/test-requirements.txt"
- CIBW_BEFORE_BUILD_LINUX: "rm -rf ~/.pyxbld && rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux && yum install -y libffi-devel libev libev-devel openssl openssl-devel"
- CIBW_ENVIRONMENT: "CASS_DRIVER_BUILD_CONCURRENCY=2 CFLAGS='-g0 -O3'"
- CIBW_PRERELEASE_PYTHONS: True
- CIBW_SKIP: cp35* cp36* *musllinux*
- CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+ CIBW_ENABLE: cpython-prerelease
+ CIBW_ALLOW_EMPTY: True
 
 jobs:
   build_wheels:
@@ -32,12 +27,12 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.22.0
+          python3 -m pip install cibuildwheel==2.22.0 uv==0.5.23
 
       - name: Overwrite for Linux 64
         if: runner.os == 'Linux' && matrix.platform == 'x86_64'
         run: |
-          echo "CIBW_BUILD=cp313*_x86_64" >> $GITHUB_ENV
+          echo "CIBW_BUILD=cp314*" >> $GITHUB_ENV
 
       - name: Build wheels
         run: |

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -2,23 +2,6 @@ name: Build and upload to PyPi
 
 on: [push, pull_request]
 
-
-env:
- CIBW_TEST_COMMAND_LINUX: > 
-    pytest {project}/tests/unit && 
-    EVENT_LOOP_MANAGER=gevent pytest {project}/tests/unit/io/test_geventreactor.py
-   
- CIBW_TEST_COMMAND_MACOS: "pytest {project}/tests/unit -k 'not (test_multi_timer_validation or test_empty_connections or test_timer_cancellation)' "
- CIBW_TEST_COMMAND_WINDOWS: "pytest {project}/tests/unit  -k \"not (test_deserialize_date_range_year or test_datetype or test_libevreactor)\" "
- CIBW_BEFORE_TEST: "pip install -r {project}/test-requirements.txt"
- CIBW_BEFORE_BUILD_LINUX: "rm -rf ~/.pyxbld && rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux && yum install -y libffi-devel libev libev-devel openssl openssl-devel"
- CIBW_ENVIRONMENT: "CASS_DRIVER_BUILD_CONCURRENCY=2 CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST=yes CFLAGS='-g0 -O3'"
- CIBW_SKIP: cp36* cp37* pp*i686 *musllinux*
- CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
- CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux_2_28
- CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
- CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: manylinux_2_28
-
 jobs:
   build_wheels:
     name: Build wheels ${{ matrix.os }} (${{ matrix.platform }})
@@ -63,7 +46,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.22.0
+          python3 -m pip install cibuildwheel==2.22.0 uv==0.5.23
 
       - name: Install OpenSSL for Windows
         if: runner.os == 'Windows'
@@ -85,49 +68,30 @@ jobs:
         run: |
           brew install libev
 
-      - name: Overwrite for Linux 64
-        if: runner.os == 'Linux' && matrix.platform == 'x86_64'
-        run: |
-          echo "CIBW_BUILD=cp3*_x86_64" >> $GITHUB_ENV
-
       - name: Overwrite for Linux PyPy
         if: runner.os == 'Linux' && matrix.platform == 'PyPy'
         run: |
           echo "CIBW_BUILD=pp*" >> $GITHUB_ENV
-          echo "CIBW_TEST_COMMAND_LINUX=" >> $GITHUB_ENV
-
-      - name: Overwrite for Windows 64
-        if: runner.os == 'Windows' && matrix.platform == 'win64'
-        run: |
-          echo "CIBW_BUILD=cp*win_amd64" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          echo "CIBW_ENVIRONMENT_WINDOWS= CC=clang CXX=clang++" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
       - name: Overwrite for Windows PyPY
         if: runner.os == 'Windows' && matrix.platform == 'PyPy'
         run: |
           echo "CIBW_BUILD=pp*" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          echo "CIBW_TEST_COMMAND_WINDOWS=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
-      - name: Overwrite for MacOs
-        if: runner.os == 'MacOs' && matrix.platform == 'all'
-        run: |
-          echo "CIBW_BUILD=cp39* cp310* cp311* cp312* cp313*" >> $GITHUB_ENV
-          echo "CIBW_BEFORE_TEST_MACOS=pip install -r {project}/test-requirements.txt pytest" >> $GITHUB_ENV
-          if [ "${{ matrix.os }}" == "macos-13" ]; then
-            echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV;
-            echo "Enforcing target deployment for 13.0"
-          elif [ "${{ matrix.os }}" == "macos-14" ]; then
-            echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV;
-            echo "Enforcing target deployment for 14.0"
-          else
-            echo "Unknown macos version" && false;
-          fi
       - name: Overwrite for MacOs PyPy
         if: runner.os == 'MacOs' && matrix.platform == 'PyPy'
         run: |
           echo "CIBW_BUILD=pp*" >> $GITHUB_ENV
-          echo "CIBW_BEFORE_TEST_MACOS=pip install -r {project}/test-requirements.txt pytest" >> $GITHUB_ENV
-          echo "CIBW_TEST_COMMAND_MACOS=" >> $GITHUB_ENV
+
+      - name: Overwrite for macos-13
+        if: matrix.os == 'macos-13' && matrix.platform == 'all'
+        run: |
+          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
+
+      - name: Overwrite for macos-14
+        if: matrix.os == 'macos-14' && matrix.platform == 'all'
+        run: |
+          echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
 
       - name: Build wheels
         run: |

--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -23,7 +23,7 @@ class NullHandler(logging.Handler):
 
 logging.getLogger('cassandra').addHandler(NullHandler())
 
-__version_info__ = (3, 28, 0)
+__version_info__ = (3, 28, 2)
 __version__ = '.'.join(map(str, __version_info__))
 
 

--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -14,7 +14,7 @@
 
 from enum import Enum
 import logging
-
+from cassandra._version import __version__, __version_tuple__ as __version_info__
 
 class NullHandler(logging.Handler):
 
@@ -22,9 +22,6 @@ class NullHandler(logging.Handler):
         pass
 
 logging.getLogger('cassandra').addHandler(NullHandler())
-
-__version_info__ = (3, 28, 2)
-__version__ = '.'.join(map(str, __version_info__))
 
 
 class ConsistencyLevel(object):

--- a/cassandra/c_shard_info.pyx
+++ b/cassandra/c_shard_info.pyx
@@ -15,6 +15,15 @@
 from libc.stdint cimport INT64_MIN, UINT32_MAX, uint64_t, int64_t
 
 cdef extern from *:
+    """
+    #include <stdint.h>
+
+    // windows doesn't have __uint128_t, do we need to define ourself
+    #if defined(_WIN32) || defined(MS_WINDOWS) || defined(_MSC_VER)
+        #define __uint128_t unsigned long long
+    #endif
+
+    """
     ctypedef unsigned int __uint128_t
 
 cdef class ShardingInfo():

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,14 +10,14 @@ import cassandra
 # -- Global variables
 
 # Build documentation for the following tags and branches
-TAGS = ['3.21.0-scylla', '3.22.3-scylla', '3.24.8-scylla', '3.25.4-scylla', '3.25.11-scylla', '3.26.9-scylla', '3.28.0-scylla', '3.28.1-scylla']
+TAGS = ['3.21.0-scylla', '3.22.3-scylla', '3.24.8-scylla', '3.25.4-scylla', '3.25.11-scylla', '3.26.9-scylla', '3.28.0-scylla', '3.28.1-scylla', '3.28.2-scylla']
 BRANCHES = ['master']
 # Set the latest version.
-LATEST_VERSION = '3.28.1-scylla'
+LATEST_VERSION = '3.28.2-scylla'
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ['master']
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = ['3.21.0-scylla', '3.22.3-scylla', '3.24.8-scylla', '3.25.4-scylla', '3.25.11-scylla', '3.26.9-scylla', ]
+DEPRECATED_VERSIONS = ['3.21.0-scylla', '3.22.3-scylla', '3.24.8-scylla', '3.25.4-scylla', '3.25.11-scylla', '3.26.9-scylla', '3.28.1-scylla']
 
 # -- General configuration 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,41 @@ requires = [
 ]
 
 build-backend = "setuptools.build_meta"
+
+#### CI BUILDWHEEL CONFIG ####
+
+[tool.cibuildwheel]
+
+build-frontend = "build[uv]"
+environment = { CASS_DRIVER_BUILD_CONCURRENCY = "2", CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST = "yes", CFLAGS = "-g0 -O3" }
+skip = ["cp36*", "cp37*", "pp37*", "pp*i686", "*musllinux*"]
+
+before-test = "pip install -r {project}/test-requirements.txt"
+
+[tool.cibuildwheel.linux]
+build = ["cp3*_x86_64"]
+
+before-build = "rm -rf ~/.pyxbld && rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux && yum install -y libffi-devel libev libev-devel openssl openssl-devel"
+test-command = [
+  "pytest {package}/tests/unit",
+  "EVENT_LOOP_MANAGER=gevent pytest {package}/tests/unit/io/test_geventreactor.py",
+]
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+
+[tool.cibuildwheel.macos]
+build = ["cp39*", "cp310*", "cp311*", "cp312*", "cp313*"]
+
+[tool.cibuildwheel.windows]
+build = ["cp3*_amd64"]
+build-frontend = "build" # build[uv] seems to be broken on Windows
+
+[[tool.cibuildwheel.overrides]]
+select = "pp*-manylinux*"
+test-command = []
+manylinux-pypy_x86_64-image = "manylinux_2_28"
+manylinux-pypy_aarch64-image = "manylinux_2_28"
+
+[[tool.cibuildwheel.overrides]]
+select = 'pp*win_amd64'
+test-command = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,11 +74,16 @@ readme = {file = "README.rst", content-type = "text/x-rst"}
 
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=64",
     "Cython",
+    "setuptools_scm>=8"
 ]
 
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+version_file = "cassandra/_version.py"
+tag_regex = '(?P<version>\d*?\.\d*?\.\d*?)-scylla'
 
 #### CI BUILDWHEEL CONFIG ####
 


### PR DESCRIPTION
move the configuration to pyproject.toml, that it would
be easier to use from multiple workflow and for local usage

for example:
```
uv pip install cibuildwheel
CIBW_FREE_THREADED_SUPPORT=True  cibuildwheel --only cp313-manylinux_x86_64
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.