### PR TITLE
fix removing key/value in map_column__remove query

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -972,7 +972,7 @@ class Map(BaseContainerColumn):
     def to_database(self, value):
         if value is None:
             return None
-        return dict((self.key_col.to_database(k), self.value_col.to_database(v)) for k, v in value.items())
+        return dict((self.key_col.to_database(k), v and self.value_col.to_database(v)) for k, v in value.items())
 
 
 class UDTValueManager(BaseValueManager):


### PR DESCRIPTION
when requesting map_column__remove, in the ModalQuerySet object, in the update function, when requesting a delete operation, the set object is converted to a dict with all values None, which causes an error when calling the to_database function

## Pre-review checklist
- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.