### PR TITLE
Make any query to system.local use WHERE clause

### DIFF
--- a/examples/request_init_listener.py
+++ b/examples/request_init_listener.py
@@ -68,8 +68,8 @@ session = Cluster().connect()
 # attach a listener to this session
 ra = RequestAnalyzer(session)
 
-session.execute("SELECT release_version FROM system.local")
-session.execute("SELECT release_version FROM system.local")
+session.execute("SELECT release_version FROM system.local WHERE key='local'")
+session.execute("SELECT release_version FROM system.local WHERE key='local'")
 
 print(ra)
 # 2 requests (0 errors)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -87,7 +87,7 @@ def get_server_versions():
 
     c = TestCluster()
     s = c.connect()
-    row = s.execute('SELECT cql_version, release_version FROM system.local').one()
+    row = s.execute("SELECT cql_version, release_version FROM system.local WHERE key='local'").one()
 
     cass_version = _tuple_version(row.release_version)
     cql_version = _tuple_version(row.cql_version)

--- a/tests/integration/advanced/test_auth.py
+++ b/tests/integration/advanced/test_auth.py
@@ -157,7 +157,7 @@ class BasicDseAuthTest(unittest.TestCase):
         os.environ['KRB5_CONFIG'] = self.krb_conf
         self.cluster = TestCluster(auth_provider=auth_provider)
         self.session = self.cluster.connect()
-        query = query if query else "SELECT * FROM system.local"
+        query = query if query else "SELECT * FROM system.local WHERE key='local'"
         statement = SimpleStatement(query)
         rs = self.session.execute(statement)
         return rs
@@ -529,4 +529,4 @@ class DseProxyAuthTest(BaseDseProxyAuthTest):
         @expected_result connect and query should be allowed
         """
         auth_provider = TransitionalModePlainTextAuthProvider()
-        self.assertIsNotNone(self.connect_and_query(auth_provider, query="SELECT * from system.local"))
+        self.assertIsNotNone(self.connect_and_query(auth_provider, query="SELECT * from system.local WHERE key='local'"))

--- a/tests/integration/advanced/test_unixsocketendpoint.py
+++ b/tests/integration/advanced/test_unixsocketendpoint.py
@@ -71,4 +71,4 @@ class UnixSocketTest(unittest.TestCase):
 
     def test_unix_socket_connection(self):
         s = self.cluster.connect()
-        s.execute('select * from system.local')
+        s.execute("select * from system.local where key='local'")

--- a/tests/integration/cloud/test_cloud.py
+++ b/tests/integration/cloud/test_cloud.py
@@ -62,7 +62,7 @@ class CloudTests(CloudProxyCluster):
 
         self.assertEqual(len(self.hosts_up()), 3)
         for host in self.cluster.metadata.all_hosts():
-            row = self.session.execute('SELECT * FROM system.local', host=host).one()
+            row = self.session.execute("SELECT * FROM system.local WHERE key='local'", host=host).one()
             self.assertEqual(row.host_id, host.host_id)
             self.assertEqual(row.rpc_address, host.broadcast_rpc_address)
 

--- a/tests/integration/long/test_consistency.py
+++ b/tests/integration/long/test_consistency.py
@@ -354,7 +354,7 @@ class ConnectivityTest(unittest.TestCase):
             # Attempt a query against that node. It should complete
             cluster2 = TestCluster(contact_points=all_contact_points)
             session2 = cluster2.connect()
-            session2.execute("SELECT * FROM system.local")
+            session2.execute("SELECT * FROM system.local WHERE key='local'")
         finally:
             cluster2.shutdown()
             start(node_to_stop)

--- a/tests/integration/long/test_ipv6.py
+++ b/tests/integration/long/test_ipv6.py
@@ -80,7 +80,7 @@ class IPV6ConnectionTest(object):
     def test_connect(self):
         cluster = TestCluster(connection_class=self.connection_class, contact_points=['::1'], connect_timeout=10)
         session = cluster.connect()
-        future = session.execute_async("SELECT * FROM system.local")
+        future = session.execute_async("SELECT * FROM system.local WHERE key='local'")
         future.result()
         self.assertEqual(future._current_host.address, '::1')
         cluster.shutdown()

--- a/tests/integration/long/test_ssl.py
+++ b/tests/integration/long/test_ssl.py
@@ -193,7 +193,7 @@ class SSLConnectionTests(unittest.TestCase):
         # attempt a few simple commands.
 
         for i in range(8):
-            rs = session.execute("SELECT * FROM system.local")
+            rs = session.execute("SELECT * FROM system.local WHERE key='local'")
             time.sleep(10)
 
         cluster.shutdown()

--- a/tests/integration/simulacron/test_connection.py
+++ b/tests/integration/simulacron/test_connection.py
@@ -464,14 +464,14 @@ class ConnectionTests(SimulacronBase):
         for host in cluster.metadata.all_hosts():
             self.assertIn(host, listener.hosts_marked_down)
 
-        self.assertRaises(NoHostAvailable, session.execute, "SELECT * from system.local")
+        self.assertRaises(NoHostAvailable, session.execute, "SELECT * from system.local WHERE key='local'")
 
         clear_queries()
         prime_request(AcceptConnections())
 
         time.sleep(idle_heartbeat_timeout + idle_heartbeat_interval + 2)
 
-        self.assertIsNotNone(session.execute("SELECT * from system.local"))
+        self.assertIsNotNone(session.execute("SELECT * from system.local WHERE key='local'"))
 
     def test_max_in_flight(self):
         """ Verify we don't exceed max_in_flight when borrowing connections or sending heartbeats """

--- a/tests/integration/simulacron/utils.py
+++ b/tests/integration/simulacron/utils.py
@@ -125,7 +125,7 @@ class SimulacronClient(object):
         if DSE_VERSION:
             system_local_row["dse_version"] = DSE_VERSION.base_version
         column_types = {"cql_version": "ascii", "release_version": "ascii"}
-        system_local = PrimeQuery("SELECT cql_version, release_version FROM system.local",
+        system_local = PrimeQuery("SELECT cql_version, release_version FROM system.local WHERE key='local'",
                                   rows=[system_local_row],
                                   column_types=column_types)
 

--- a/tests/integration/standard/test_authentication.py
+++ b/tests/integration/standard/test_authentication.py
@@ -105,7 +105,7 @@ class AuthenticationTests(unittest.TestCase):
             cluster = self.cluster_as(user, passwd)
             session = cluster.connect(wait_for_all_pools=True)
             try:
-                self.assertTrue(session.execute('SELECT release_version FROM system.local'))
+                self.assertTrue(session.execute("SELECT release_version FROM system.local WHERE key='local'"))
                 assert_quiescent_pool_state(self, cluster, wait=1)
                 for pool in session.get_pools():
                     connection, _ = pool.borrow_connection(timeout=0)

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -589,15 +589,15 @@ class ClusterTests(unittest.TestCase):
         cluster = TestCluster()
         session = cluster.connect()
 
-        result = session.execute( "SELECT * FROM system.local", trace=True)
+        result = session.execute( "SELECT * FROM system.local WHERE key='local'", trace=True)
         self._check_trace(result.get_query_trace())
 
-        query = "SELECT * FROM system.local"
+        query = "SELECT * FROM system.local WHERE key='local'"
         statement = SimpleStatement(query)
         result = session.execute(statement, trace=True)
         self._check_trace(result.get_query_trace())
 
-        query = "SELECT * FROM system.local"
+        query = "SELECT * FROM system.local WHERE key='local'"
         statement = SimpleStatement(query)
         result = session.execute(statement)
         self.assertIsNone(result.get_query_trace())
@@ -612,7 +612,7 @@ class ClusterTests(unittest.TestCase):
         future.result()
         self.assertIsNone(future.get_query_trace())
 
-        prepared = session.prepare("SELECT * FROM system.local")
+        prepared = session.prepare("SELECT * FROM system.local WHERE key='local'")
         future = session.execute_async(prepared, parameters=(), trace=True)
         future.result()
         self._check_trace(future.get_query_trace())
@@ -636,7 +636,7 @@ class ClusterTests(unittest.TestCase):
         self.addCleanup(cluster.shutdown)
         session = cluster.connect()
 
-        query = "SELECT * FROM system.local"
+        query = "SELECT * FROM system.local WHERE key='local'"
         statement = SimpleStatement(query)
 
         max_retry_count = 10
@@ -686,7 +686,7 @@ class ClusterTests(unittest.TestCase):
         cluster = TestCluster()
         session = cluster.connect()
 
-        query = "SELECT * FROM system.local"
+        query = "SELECT * FROM system.local WHERE key='local'"
         statement = SimpleStatement(query)
         future = session.execute_async(statement)
 
@@ -742,7 +742,7 @@ class ClusterTests(unittest.TestCase):
         with MockLoggingHandler().set_module_name(connection.__name__) as mock_handler:
             with TestCluster(auth_provider=auth_provider) as cluster:
                 session = cluster.connect()
-                self.assertIsNotNone(session.execute("SELECT * from system.local"))
+                self.assertIsNotNone(session.execute("SELECT * from system.local WHERE key='local'"))
 
             # Three conenctions to nodes plus the control connection
             auth_warning = mock_handler.get_message_count('warning', "An authentication challenge was not sent")
@@ -786,7 +786,7 @@ class ClusterTests(unittest.TestCase):
         self.assertTrue(all(c.is_idle for c in connections))
 
         # send messages on all connections
-        statements_and_params = [("SELECT release_version FROM system.local", ())] * len(cluster.metadata.all_hosts())
+        statements_and_params = [("SELECT release_version FROM system.local WHERE key='local'", ())] * len(cluster.metadata.all_hosts())
         results = execute_concurrent(session, statements_and_params)
         for success, result in results:
             self.assertTrue(success)
@@ -871,7 +871,7 @@ class ClusterTests(unittest.TestCase):
 
         @test_category config_profiles
         """
-        query = "select release_version from system.local"
+        query = "select release_version from system.local where key='local'"
         node1 = ExecutionProfile(
             load_balancing_policy=HostFilterPolicy(
                 RoundRobinPolicy(), lambda host: host.address == CASSANDRA_IP
@@ -942,7 +942,7 @@ class ClusterTests(unittest.TestCase):
 
         @test_category config_profiles
         """
-        query = "select release_version from system.local"
+        query = "select release_version from system.local where key='local'"
         rr1 = ExecutionProfile(load_balancing_policy=RoundRobinPolicy())
         rr2 = ExecutionProfile(load_balancing_policy=RoundRobinPolicy())
         exec_profiles = {'rr1': rr1, 'rr2': rr2}
@@ -971,7 +971,7 @@ class ClusterTests(unittest.TestCase):
 
         @test_category config_profiles
         """
-        query = "select release_version from system.local"
+        query = "select release_version from system.local where key='local'"
         ta1 = ExecutionProfile()
         with TestCluster() as cluster:
             session = cluster.connect()
@@ -991,7 +991,7 @@ class ClusterTests(unittest.TestCase):
 
         @test_category config_profiles
         """
-        query = "select release_version from system.local"
+        query = "select release_version from system.local where key='local'"
         rr1 = ExecutionProfile(load_balancing_policy=RoundRobinPolicy())
         exec_profiles = {'rr1': rr1}
         with TestCluster(execution_profiles=exec_profiles) as cluster:
@@ -1018,7 +1018,7 @@ class ClusterTests(unittest.TestCase):
 
         @test_category config_profiles
         """
-        query = "select release_version from system.local"
+        query = "select release_version from system.local where key='local'"
         rr1 = ExecutionProfile(load_balancing_policy=RoundRobinPolicy())
         rr2 = ExecutionProfile(load_balancing_policy=RoundRobinPolicy())
         exec_profiles = {'rr1': rr1, 'rr2': rr2}

--- a/tests/integration/standard/test_connection.py
+++ b/tests/integration/standard/test_connection.py
@@ -86,7 +86,7 @@ class ConnectionTimeoutTest(unittest.TestCase):
         @test_category connection timeout
         """
         futures = []
-        query = '''SELECT * FROM system.local'''
+        query = "SELECT * FROM system.local WHERE key='local'"
         for _ in range(100):
             futures.append(self.session.execute_async(query))
 
@@ -151,7 +151,7 @@ class HeartbeatTest(unittest.TestCase):
         current_host = ""
         count = 0
         while current_host != host and count < 100:
-            rs = self.session.execute_async("SELECT * FROM system.local", trace=False)
+            rs = self.session.execute_async("SELECT * FROM system.local WHERE key='local'", trace=False)
             rs.result()
             current_host = str(rs._current_host)
             count += 1

--- a/tests/integration/standard/test_custom_cluster.py
+++ b/tests/integration/standard/test_custom_cluster.py
@@ -53,4 +53,4 @@ class CustomClusterTests(unittest.TestCase):
         wait_until(lambda: len(cluster.metadata.all_hosts()) == 3, 1, 5)
         for host in cluster.metadata.all_hosts():
             self.assertTrue(host.is_up)
-            session.execute("select * from system.local", host=host)
+            session.execute("select * from system.local where key='local'", host=host)

--- a/tests/integration/standard/test_custom_payload.py
+++ b/tests/integration/standard/test_custom_payload.py
@@ -56,7 +56,7 @@ class CustomPayloadTests(unittest.TestCase):
         """
 
         # Create a simple query statement a
-        query = "SELECT * FROM system.local"
+        query = "SELECT * FROM system.local WHERE key='local'"
         statement = SimpleStatement(query)
         # Validate that various types of custom payloads are sent and received okay
         self.validate_various_custom_payloads(statement=statement)

--- a/tests/integration/standard/test_custom_protocol_handler.py
+++ b/tests/integration/standard/test_custom_protocol_handler.py
@@ -69,20 +69,20 @@ class CustomProtocolHandlerTest(unittest.TestCase):
         )
         session = cluster.connect(keyspace="custserdes")
 
-        result = session.execute("SELECT schema_version FROM system.local")
+        result = session.execute("SELECT schema_version FROM system.local WHERE key='local'")
         uuid_type = result.one()[0]
         self.assertEqual(type(uuid_type), uuid.UUID)
 
         # use our custom protocol handlder
         session.client_protocol_handler = CustomTestRawRowType
-        result_set = session.execute("SELECT schema_version FROM system.local")
+        result_set = session.execute("SELECT schema_version FROM system.local WHERE key='local'")
         raw_value = result_set.one()[0]
         self.assertTrue(isinstance(raw_value, bytes))
         self.assertEqual(len(raw_value), 16)
 
         # Ensure that we get normal uuid back when we re-connect
         session.client_protocol_handler = ProtocolHandler
-        result_set = session.execute("SELECT schema_version FROM system.local")
+        result_set = session.execute("SELECT schema_version FROM system.local WHERE key='local'")
         uuid_type = result_set.one()[0]
         self.assertEqual(type(uuid_type), uuid.UUID)
         cluster.shutdown()

--- a/tests/integration/standard/test_ip_change.py
+++ b/tests/integration/standard/test_ip_change.py
@@ -52,7 +52,7 @@ class TestIpAddressChange(unittest.TestCase):
 
         def new_node_connectable():
             LOGGER.info(self.cluster.shard_aware_stats())
-            local_info = self.session.execute("SELECT * FROM system.local", execution_profile="new_node").one()
+            local_info = self.session.execute("SELECT * FROM system.local WHERE key='local'", execution_profile="new_node").one()
             LOGGER.debug(local_info._asdict())
             assert local_info.broadcast_address == new_ip
 

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -160,7 +160,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.assertEqual(len(no_token.metadata.token_map.token_to_host_owner), 0)
 
         # Do a simple query to ensure queries are working
-        query = "SELECT * FROM system.local"
+        query = "SELECT * FROM system.local WHERE key='local'"
         no_schema_rs = no_schema_session.execute(query)
         no_token_rs = no_token_session.execute(query)
         self.assertIsNotNone(no_schema_rs.one())
@@ -1357,11 +1357,11 @@ class MetadataTimeoutTest(unittest.TestCase):
 
         cluster.connection_class = ConnectionWrapper
         s = cluster.connect()
-        s.execute('SELECT now() FROM system.local')
+        s.execute("SELECT now() FROM system.local WHERE key='local'")
         s.shutdown()
 
         for stmt in stmts:
-            if "SELECT now() FROM system.local" in stmt:
+            if "SELECT now() FROM system.local WHERE key='local'" in stmt:
                 continue
             if "USING TIMEOUT 2000ms" not in stmt:
                 self.fail(f"query `{stmt}` does not contain `USING TIMEOUT 2000ms`")

--- a/tests/integration/standard/test_metrics.py
+++ b/tests/integration/standard/test_metrics.py
@@ -377,7 +377,7 @@ class MetricsRequestSize(BasicExistingKeyspaceUnitTestCase):
 
         ra = RequestAnalyzer(self.session)
         for _ in range(10):
-            self.session.execute("SELECT release_version FROM system.local")
+            self.session.execute("SELECT release_version FROM system.local WHERE key='local'")
 
         for _ in range(3):
             try:
@@ -392,7 +392,7 @@ class MetricsRequestSize(BasicExistingKeyspaceUnitTestCase):
 
         # Make sure a poorly coded RA doesn't cause issues
         ra = RequestAnalyzer(self.session, throw_on_success=False, throw_on_fail=True)
-        self.session.execute("SELECT release_version FROM system.local")
+        self.session.execute("SELECT release_version FROM system.local WHERE key='local'")
         
         ra.remove_ra(self.session)
 

--- a/tests/integration/standard/test_policies.py
+++ b/tests/integration/standard/test_policies.py
@@ -59,7 +59,7 @@ class HostFilterPolicyTests(unittest.TestCase):
 
         queried_hosts = set()
         for _ in range(10):
-            response = session.execute("SELECT * from system.local")
+            response = session.execute("SELECT * from system.local WHERE key='local'")
             queried_hosts.update(response.response_future.attempted_hosts)
 
         self.assertEqual(queried_hosts, single_host)
@@ -70,7 +70,7 @@ class HostFilterPolicyTests(unittest.TestCase):
 
         queried_hosts = set()
         for _ in range(10):
-            response = session.execute("SELECT * from system.local")
+            response = session.execute("SELECT * from system.local WHERE key='local'")
             queried_hosts.update(response.response_future.attempted_hosts)
         self.assertEqual(queried_hosts, all_hosts)
 
@@ -86,7 +86,7 @@ class WhiteListRoundRobinPolicyTests(unittest.TestCase):
         session = cluster.connect(wait_for_all_pools=True)
         queried_hosts = set()
         for _ in range(10):
-            response = session.execute('SELECT * from system.local', execution_profile="white_list")
+            response = session.execute("SELECT * from system.local WHERE key='local'", execution_profile="white_list")
             queried_hosts.update(response.response_future.attempted_hosts)
         queried_hosts = set(host.address for host in queried_hosts)
         self.assertEqual(queried_hosts, only_connect_hosts)

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -75,7 +75,7 @@ class QueryTests(BasicSharedKeyspaceUnitTestCase):
         Code coverage to ensure trace prints to string without error
         """
 
-        query = "SELECT * FROM system.local"
+        query = "SELECT * FROM system.local WHERE key='local'"
         statement = SimpleStatement(query)
         rs = self.session.execute(statement, trace=True)
 
@@ -104,7 +104,7 @@ class QueryTests(BasicSharedKeyspaceUnitTestCase):
 
     def test_trace_id_to_resultset(self):
 
-        future = self.session.execute_async("SELECT * FROM system.local", trace=True)
+        future = self.session.execute_async("SELECT * FROM system.local WHERE key='local'", trace=True)
 
         # future should have the current trace
         rs = future.result()
@@ -123,7 +123,7 @@ class QueryTests(BasicSharedKeyspaceUnitTestCase):
                 execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
         ) as cluster:
             s = cluster.connect()
-            query = "SELECT * FROM system.local"
+            query = "SELECT * FROM system.local WHERE key='local'"
             statement = SimpleStatement(query)
             rs = s.execute(statement, trace=True)
 
@@ -157,7 +157,7 @@ class QueryTests(BasicSharedKeyspaceUnitTestCase):
         """
 
         # Make simple query with trace enabled
-        query = "SELECT * FROM system.local"
+        query = "SELECT * FROM system.local WHERE key='local'"
         statement = SimpleStatement(query)
         response_future = self.session.execute_async(statement, trace=True)
         response_future.result()
@@ -182,7 +182,7 @@ class QueryTests(BasicSharedKeyspaceUnitTestCase):
         @expected_result Consistency Levels set on get_query_trace should be honored
         """
         # Execute a query
-        query = "SELECT * FROM system.local"
+        query = "SELECT * FROM system.local WHERE key='local'"
         statement = SimpleStatement(query)
         response_future = self.session.execute_async(statement, trace=True)
         response_future.result()
@@ -488,7 +488,7 @@ class PreparedStatementMetdataTest(unittest.TestCase):
             cluster = Cluster(protocol_version=proto_version, allow_beta_protocol_version=beta_flag)
 
             session = cluster.connect()
-            select_statement = session.prepare("SELECT * FROM system.local")
+            select_statement = session.prepare("SELECT * FROM system.local WHERE key='local'")
             if proto_version == 1:
                 self.assertEqual(select_statement.result_metadata, None)
             else:

--- a/tests/integration/standard/test_scylla_cloud.py
+++ b/tests/integration/standard/test_scylla_cloud.py
@@ -67,7 +67,7 @@ class ScyllaCloudConfigTests(TestCase):
                 cluster = Cluster(scylla_cloud=config, connection_class=connection_class)
                 try:
                     with cluster.connect() as session:
-                        res = session.execute("SELECT * FROM system.local")
+                        res = session.execute("SELECT * FROM system.local WHERE key='local'")
                         assert res.all()
 
                         assert len(cluster.metadata._hosts) == 1
@@ -85,7 +85,7 @@ class ScyllaCloudConfigTests(TestCase):
                 cluster = Cluster(scylla_cloud=config, connection_class=connection_class)
                 try:
                     with cluster.connect() as session:
-                        res = session.execute("SELECT * FROM system.local")
+                        res = session.execute("SELECT * FROM system.local WHERE key='local'")
                         assert res.all()
                         assert len(cluster.metadata._hosts) == 3
                         assert len(cluster.metadata._host_id_by_endpoint) == 3

--- a/tests/integration/upgrade/test_upgrade.py
+++ b/tests/integration/upgrade/test_upgrade.py
@@ -78,7 +78,7 @@ class UpgradeTests(UpgradeBase):
             session = cluster.connect(wait_for_all_pools=True)
             queried_hosts = set()
             for _ in range(10):
-                results = session.execute("SELECT * from system.local")
+                results = session.execute("SELECT * from system.local WHERE key='local'")
                 self.assertGreater(len(results.current_rows), 0)
                 self.assertEqual(len(results.response_future.attempted_hosts), 1)
                 queried_hosts.add(results.response_future.attempted_hosts[0])
@@ -242,7 +242,7 @@ class UpgradeTestsAuthentication(UpgradeBaseAuth):
         session = cluster.connect(wait_for_all_pools=True)
         queried_hosts = set()
         for _ in range(10):
-            results = session.execute("SELECT * from system.local")
+            results = session.execute("SELECT * from system.local WHERE key='local'")
             self.assertGreater(len(results.current_rows), 0)
             self.assertEqual(len(results.response_future.attempted_hosts), 1)
             queried_hosts.add(results.response_future.attempted_hosts[0])


### PR DESCRIPTION
Full scan queries are slower even if there is only one record.

Fixes: https://github.com/scylladb/python-driver/issues/418
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.