### PR TITLE
management.py: fail sync_table on adding partition_key 

### DIFF
--- a/cassandra/cqlengine/management.py
+++ b/cassandra/cqlengine/management.py
@@ -256,7 +256,7 @@ def _sync_table(model, connection=None):
 
                 continue
 
-            if col.primary_key or col.primary_key:
+            if col.primary_key or col.partition_key:
                 msg = format_log_context("Cannot add primary key '{0}' (with db_field '{1}') to existing table {2}", keyspace=ks_name, connection=connection)
                 raise CQLEngineException(msg.format(model_name, db_name, cf_name))
 


### PR DESCRIPTION
Replace `if col.primary_key or col.primary_key:` statement. with ``if col.primary_key or col.partition_key:``
It was introduced with this mistake 9 years ago.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~