### PR TITLE
cicd: make build-push workflow push changes on manual dispatch

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -24,5 +24,5 @@ jobs:
     if: "(!contains(github.event.pull_request.labels.*.name, 'disable-test-build')) || github.event_name == 'push' && endsWith(github.event.ref, 'scylla')"
     uses: ./.github/workflows/lib-build-and-push.yml
     with:
-      upload: ${{ github.event_name == 'push' && endsWith(github.event.ref, 'scylla') }}
+      upload: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch'  ) && endsWith(github.event.ref, 'scylla') }}
       python-version: '3.13'


### PR DESCRIPTION
Make it [build-push.yml](https://github.com/scylladb/python-driver/blob/master/.github/workflows/build-push.yml) publish to PyPI when triggered manually.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~