### PR TITLE
CICD: Make it possible to publish prior tags

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,7 +17,6 @@ on:
      - LICENSE
      - .github/dependabot.yml
      - .github/pull_request_template.md
-  workflow_dispatch:
 
 jobs:
   build-and-publish:
@@ -25,4 +24,3 @@ jobs:
     uses: ./.github/workflows/lib-build-and-push.yml
     with:
       upload: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch'  ) && endsWith(github.event.ref, 'scylla') }}
-      python-version: '3.13'

--- a/.github/workflows/lib-build-and-push.yml
+++ b/.github/workflows/lib-build-and-push.yml
@@ -12,14 +12,26 @@ on:
       python-version:
         description: 'Python version to run on'
         type: string
-        required: true
+        required: false
         default: "3.13"
 
       target:
-        description: "target os to build for: linux,macos,windows"
+        description: "Target os to build for: linux,macos,windows"
         type: string
         required: false
         default: "linux,macos-x86,macos-arm,windows,linux-aarch64"
+
+      target_tag:
+        description: "Publish particular tag"
+        type: string
+        required: false
+        default: ""
+
+      ignore_tests:
+        description: "Don't run tests"
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   prepare-matrix:
@@ -72,6 +84,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Checkout tag ${{ inputs.target_tag }}
+        if: inputs.target_tag != ''
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_tag }}
+
+      - name: Disable tests
+        if: inputs.ignore_tests
+        shell: bash
+        run: |
+          echo "CIBW_TEST_COMMAND=\"\"" >> $GITHUB_ENV;
+          echo "CIBW_TEST_SKIP=*" >> $GITHUB_ENV;
+          echo "CIBW_SKIP=\"cp2* cp36* pp36* cp37* pp37* *i686 *musllinux*\"" >> $GITHUB_ENV;
+          echo "CIBW_BUILD=\"cp3* pp3*\"" >> $GITHUB_ENV;
+          echo "CIBW_BEFORE_TEST=\"\"" >> $GITHUB_ENV;
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -1,0 +1,44 @@
+name: Build and upload to PyPi manually
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload:
+        description: 'Upload to PyPI'
+        type: boolean
+        required: false
+        default: false
+
+      python-version:
+        description: 'Python version to run on'
+        type: string
+        required: false
+        default: "3.13"
+
+      target:
+        description: "Target os to build for: linux,macos,windows"
+        type: string
+        required: false
+        default: "linux,macos-x86,macos-arm,windows,linux-aarch64"
+
+      target_tag:
+        description: "Publish particular tag"
+        type: string
+        required: false
+        default: ""
+
+      ignore_tests:
+        description: "Don't run tests"
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  build-and-publish:
+    uses: ./.github/workflows/lib-build-and-push.yml
+    with:
+      upload: ${{ inputs.upload }}
+      python-version: ${{ inputs.python-version }}
+      ignore_tests: ${{ inputs.ignore_tests }}
+      target_tag: ${{ inputs.target_tag }}
+      target: ${{ inputs.target }}


### PR DESCRIPTION
Make publishing work for older tags.
Problem is that workflow definition is also pulled from the same ref.
In this PR I make it do additional pull of target branch while workflow is pulled from original ref. 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~