### PR TITLE
cicd: switch to arm runners for linux-aarch64

### DIFF
--- a/.github/workflows/lib-build-and-push.yml
+++ b/.github/workflows/lib-build-and-push.yml
@@ -41,7 +41,7 @@ jobs:
              was_added=1
            elif [[ "${target}" == "linux-aarch64" ]]; then
              [ -n "$was_added" ] && echo -n ","  >> /tmp/matrix.json
-             echo -n  '{"os":"ubuntu-20.04", "target": "linux-aarch64"}' >> /tmp/matrix.json
+             echo -n  '{"os":"ubuntu-24.04-arm", "target": "linux-aarch64"}' >> /tmp/matrix.json
              was_added=1
            elif [[ "${target}" == "windows" ]]; then
              [ -n "$was_added" ] && echo -n ","  >> /tmp/matrix.json
@@ -92,13 +92,6 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           choco install openssl --version=3.4.1 -f -y --no-progress
-
-      - name: Set up QEMU
-        if: matrix.target == 'linux-aarch64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-          image: 'docker.io/tonistiigi/binfmt:desktop-v8.1.5'
 
       - name: Install Conan
         if: runner.os == 'Windows'


### PR DESCRIPTION
Github actions support arm runners, switching to them should speedup linux-aarch64 wheels building.
Currently it takes `85 minutes` to just build one arm wheel, switching to arm runner dropped the time to `4 minutes`.
 
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~