### PR TITLE
CICD: Fix skip tests option

### DIFF
--- a/.github/workflows/lib-build-and-push.yml
+++ b/.github/workflows/lib-build-and-push.yml
@@ -95,11 +95,13 @@ jobs:
         if: inputs.ignore_tests
         shell: bash
         run: |
-          echo "CIBW_TEST_COMMAND=\"\"" >> $GITHUB_ENV;
+          echo "CIBW_TEST_COMMAND=true" >> $GITHUB_ENV;
+          echo "CIBW_TEST_COMMAND_WINDOWS=(exit 0)" >> $GITHUB_ENV;
           echo "CIBW_TEST_SKIP=*" >> $GITHUB_ENV;
-          echo "CIBW_SKIP=\"cp2* cp36* pp36* cp37* pp37* *i686 *musllinux*\"" >> $GITHUB_ENV;
-          echo "CIBW_BUILD=\"cp3* pp3*\"" >> $GITHUB_ENV;
-          echo "CIBW_BEFORE_TEST=\"\"" >> $GITHUB_ENV;
+          echo "CIBW_SKIP=cp2* cp36* pp36* cp37* pp37* *i686 *musllinux*" >> $GITHUB_ENV;
+          echo "CIBW_BUILD=cp3* pp3*" >> $GITHUB_ENV;
+          echo "CIBW_BEFORE_TEST=true" >> $GITHUB_ENV;
+          echo "CIBW_BEFORE_TEST_WINDOWS=(exit 0)" >> $GITHUB_ENV;
 
       - uses: actions/setup-python@v5
         name: Install Python


### PR DESCRIPTION
Workflow `.github/workflows/lib-build-and-push.yml` has `inputs.ignore_tests` option that does not work.
This PR to fix it.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~