### PR TITLE
Dk/fix publishing issue

### DIFF
--- a/.github/workflows/lib-build-and-push.yml
+++ b/.github/workflows/lib-build-and-push.yml
@@ -152,13 +152,14 @@ jobs:
 
       - name: Build wheels
         if: matrix.target != 'linux-aarch64'
+        shell: bash
         run: |
-          python3 -m cibuildwheel --output-dir wheelhouse
+          GITHUB_WORKFLOW_REF="scylladb/python-driver/.github/workflows/lib-build-and-push.yml@refs/heads/master" python3 -m cibuildwheel --output-dir wheelhouse
 
       - name: Build wheels for linux aarch64
         if: matrix.target == 'linux-aarch64'
         run: |
-          CIBW_BUILD='cp3*' python -m cibuildwheel --archs aarch64 --output-dir wheelhouse
+          GITHUB_WORKFLOW_REF="scylladb/python-driver/.github/workflows/lib-build-and-push.yml@refs/heads/master" CIBW_BUILD="cp3*" python -m cibuildwheel --archs aarch64 --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
There is bug https://github.com/pypa/gh-action-pypi-publish/issues/166
that does not allow to publish from reusable workflows, this is workaround for it.

Source of the issue is that whl being signed based on original workflow.
While attestation is done against reusable workflow.
As result publishing fails with:
```
WARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Invalid attestations supplied during upload: Could not verify the      
         uploaded artifact using the included attestation: Verification failed: 
         Certificate's Build Config URI                                         
         (<Extension(oid=<ObjectIdentifier(oid=1.3.6.1.4.1.57264.1.18,          
         name=Unknown OID)>, critical=False,                                    
         value=<UnrecognizedExtension(oid=<ObjectIdentifier(oid=1.3.6.1.4.1.5726
         4.1.18, name=Unknown OID)>,                                            
         value=b'\x0cbhttps://github.com/scylladb/python-driver/.github/workflow
         s/publish-manually.yml@refs/heads/master')>)>) does not match expected 
         Trusted Publisher (lib-build-and-push.yml @ scylladb/python-driver)  
``` 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~