### PR TITLE
Fix publishing issue

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -5,22 +5,10 @@ on:
     branches:
       - master
       - 'branch-**'
-  pull_request:
-    branches:
-      - master
-    paths-ignore:
-     - docs/*
-     - examples/*
-     - .gitignore
-     - '*.rst'
-     - '*.ini'
-     - LICENSE
-     - .github/dependabot.yml
-     - .github/pull_request_template.md
+  workflow_dispatch:
 
 jobs:
   build-and-publish:
-    if: "(!contains(github.event.pull_request.labels.*.name, 'disable-test-build')) || github.event_name == 'push' && endsWith(github.event.ref, 'scylla')"
     uses: ./.github/workflows/lib-build-and-push.yml
     with:
-      upload: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch'  ) && endsWith(github.event.ref, 'scylla') }}
+      upload: ${{ endsWith(github.event.ref, 'scylla') }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -9,6 +9,25 @@ on:
 
 jobs:
   build-and-publish:
+    name: "Build wheels"
     uses: ./.github/workflows/lib-build-and-push.yml
     with:
-      upload: ${{ endsWith(github.event.ref, 'scylla') }}
+      upload: false
+
+  # TODO: Remove when https://github.com/pypa/gh-action-pypi-publish/issues/166 is fixed and update build-and-publish.with.upload to ${{ endsWith(github.event.ref, 'scylla') }}
+  publish:
+    name: "Publish wheels to PyPi"
+    if: ${{ endsWith(github.event.ref, 'scylla') }}
+    needs: build-and-publish
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,23 @@
+name: Test wheels building
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+     - docs/*
+     - examples/*
+     - .gitignore
+     - '*.rst'
+     - '*.ini'
+     - LICENSE
+     - .github/dependabot.yml
+     - .github/pull_request_template.md
+
+jobs:
+  test-wheels-build:
+    name: "Test wheels building"
+    if: "!contains(github.event.pull_request.labels.*.name, 'disable-test-build')"
+    uses: ./.github/workflows/lib-build-and-push.yml
+    with:
+      upload: false

--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -35,10 +35,29 @@ on:
 
 jobs:
   build-and-publish:
+    name: "Build wheels"
     uses: ./.github/workflows/lib-build-and-push.yml
     with:
-      upload: ${{ inputs.upload }}
+      upload: false
       python-version: ${{ inputs.python-version }}
       ignore_tests: ${{ inputs.ignore_tests }}
       target_tag: ${{ inputs.target_tag }}
       target: ${{ inputs.target }}
+
+  # TODO: Remove when https://github.com/pypa/gh-action-pypi-publish/issues/166 is fixed and update build-and-publish.with.upload to ${{ inputs.upload }}
+  publish:
+    name: "Publish wheels to PyPi"
+    needs: build-and-publish
+    if: inputs.upload
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
## Pre-review checklist

Does the following:
1. Moves out build test part from `build-push.yml` to `build-push.yml`
2. Extracts publishing step from `lib-build-and-push.yml` since it is not working due to https://github.com/pypa/gh-action-pypi-publish/issues/166

Fixes: https://github.com/scylladb/python-driver/issues/440

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.