### PR TITLE
cicd: update ubuntu runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -19,7 +19,7 @@ jobs:
     name: "Publish wheels to PyPi"
     if: ${{ endsWith(github.event.ref, 'scylla') }}
     needs: build-and-publish
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lib-build-and-push.yml
+++ b/.github/workflows/lib-build-and-push.yml
@@ -49,7 +49,7 @@ jobs:
           do
            if [[ "${target}" == "linux" ]]; then
              [ -n "$was_added" ] && echo -n ","  >> /tmp/matrix.json
-             echo -n '{"os":"ubuntu-20.04", "target": "linux"}' >> /tmp/matrix.json
+             echo -n '{"os":"ubuntu-24.04", "target": "linux"}' >> /tmp/matrix.json
              was_added=1
            elif [[ "${target}" == "linux-aarch64" ]]; then
              [ -n "$was_added" ] && echo -n ","  >> /tmp/matrix.json

--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -49,7 +49,7 @@ jobs:
     name: "Publish wheels to PyPi"
     needs: build-and-publish
     if: inputs.upload
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
According to https://github.com/actions/runner-images/issues/11101 `ubuntu-20.04` is going to be depricated soon, we need to move to modern version.

Fixes: https://github.com/scylladb/python-driver/issues/447

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.