### PR TITLE
Fix test connections

### DIFF
--- a/tests/integration/standard/test_connection.py
+++ b/tests/integration/standard/test_connection.py
@@ -213,7 +213,7 @@ class ConnectionTests(object):
         automated testing edge-case.
         """
         conn = None
-        e = None
+        err = None
         for i in range(5):
             try:
                 contact_point = CASSANDRA_IP
@@ -225,12 +225,14 @@ class ConnectionTests(object):
                 )
                 break
             except (OperationTimedOut, NoHostAvailable, ConnectionShutdown) as e:
+                err = e
                 continue
 
         if conn:
             return conn
-        else:
-            raise e
+        if err:
+            raise err
+        raise RuntimeError("Unexpected state, nor conn neither err is populated, most likely self.klass.factory returned None")
 
     def test_single_connection(self):
         """


### PR DESCRIPTION
Outer variable `e` is not populate properly, as result when all retries
are exhausted you endup with following error:
```
        else:
>           raise e
E           UnboundLocalError: cannot access local variable 'e' where it is not associated with a value
```

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~`I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~