### PR TITLE
Make guard to have only one pending reconnect on control connection

### DIFF
--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -326,6 +326,61 @@ class ClusterTests(unittest.TestCase):
                 cluster.connect()
             cluster.shutdown()
 
+    def test_control_connection_reconnect(self):
+        """
+        Ensure clusters that connect on a keyspace, do
+        """
+        cassandra.cluster.log.setLevel(logging.DEBUG)
+
+        cluster = TestCluster()
+        _ = cluster.connect()
+
+        cluster.control_connection._reconnect_internal = Mock(wraps=cluster.control_connection._reconnect_internal)
+
+        cluster.control_connection.reconnect()
+        cluster.control_connection.reconnect()
+        cluster.control_connection.reconnect()
+        cluster.control_connection.reconnect()
+
+        while cluster.control_connection._reconnection_pending:
+            time.sleep(0.1)
+
+        self.assertFalse(cluster.control_connection._connection.is_closed)
+        self.assertFalse(cluster.control_connection._connection.is_defunct)
+        self.assertTrue(cluster.control_connection.refresh_schema())
+        cluster.control_connection._reconnect_internal.assert_called_once()
+
+    def test_control_connection_reconnect_rescheduled(self):
+        """
+        Ensure clusters that connect on a keyspace, do
+        """
+        cassandra.cluster.log.setLevel(logging.DEBUG)
+
+        cluster = TestCluster()
+        _ = cluster.connect()
+
+        original_reconnect_internal = cluster.control_connection._reconnect_internal
+        def _throw(*args):
+            cluster.control_connection._reconnect_internal = Mock(wraps=original_reconnect_internal)
+            raise NoHostAvailable("Unable to connect to any servers")
+
+        cluster.scheduler.schedule = Mock(wraps=cluster.scheduler.schedule)
+        cluster.control_connection._reconnect_internal = _throw
+
+        cluster.control_connection.reconnect()
+        cluster.control_connection.reconnect()
+        cluster.control_connection.reconnect()
+        cluster.control_connection.reconnect()
+
+        while cluster.control_connection._reconnection_pending:
+            time.sleep(0.1)
+
+        self.assertFalse(cluster.control_connection._connection.is_closed)
+        self.assertFalse(cluster.control_connection._connection.is_defunct)
+        self.assertTrue(cluster.control_connection.refresh_schema())
+        cluster.control_connection._reconnect_internal.assert_called_once()
+        cluster.scheduler.schedule.assert_called_once()
+
     def test_connect_on_keyspace(self):
         """
         Ensure clusters that connect on a keyspace, do


### PR DESCRIPTION
`ControlConnection.reconnect` could be called from many places in parallel. When it happens you get to see streak for reconnects happning one by one and, in some cases, even in parallel.
This commit adds guard that makes sure there is only one pending control connection reconnect.

Old implementation via `_ControlReconnectionHandler` had following problems:
1. Did not rewind schedule, effectively stoping reconnection attempts when schedule is exhausted.
2. Did not provide good API to rewind schedule when it is exhausted. 
3. Did not allow tight control when reconnection stops.
3. Had convoluted code with no benefits

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~