### PR TITLE
Deprecate `metadata_request_timeout`

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1082,6 +1082,8 @@ class Cluster(object):
 
     metadata_request_timeout = datetime.timedelta(seconds=2)
     """
+    Deprecated: use control_connection_timeout instead.
+
     Timeout for all queries used by driver it self.
     Supported only by Scylla clusters.
     """
@@ -1300,6 +1302,7 @@ class Cluster(object):
 
         self.auth_provider = auth_provider
         if metadata_request_timeout is not None:
+            warn("metadata_request_timeout is deprecated: use control_connection_timeout instead", DeprecationWarning)
             self.metadata_request_timeout = metadata_request_timeout
 
         if load_balancing_policy is not None:


### PR DESCRIPTION
When I was testing https://github.com/scylladb/python-driver/commit/e4a000fdf6548b1cfde477567304b667fcb4cb96, I have figure that out there is another option that controls system queries timeout - `Cluster.control_connection_timeout`, switch to use that it instead of `Cluster.metadata_request_timeout`, but did not remove `Cluster.metadata_request_timeout`.

Effectively `Cluster.metadata_request_timeout` is not working, what is working is `Cluster.control_connection_timeout`.
To address that let's mark `Cluster.metadata_request_timeout` it as deprecated in favor of `Cluster.control_connection_timeout`, to be removed in next minor release.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.