### PR TITLE
docs: update ResultSet.current_rows wrt empty pages

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5405,8 +5405,8 @@ class ResultSet(object):
     @property
     def current_rows(self):
         """
-        The list of current page rows. May be empty if the result was empty,
-        or this is the last page.
+        The list of current page rows. May be empty; this does not mean
+        there is no more data. Use `has_more_pages()` for that.
         """
         return self._current_rows or []
 


### PR DESCRIPTION
ScyllaDB may send empty pages when processing long spans of tombstones to avoid timing out; adjust the documentation not to imply that an empty page means there is no more data.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.