### PR TITLE
cicd: enforce ccm version

### DIFF
--- a/scripts/run_integration_test.sh
+++ b/scripts/run_integration_test.sh
@@ -28,7 +28,7 @@ pip install -e .
 pip install awscli
 
 # install scylla-ccm
-pip install https://github.com/scylladb/scylla-ccm/archive/master.zip
+pip install https://github.com/scylladb/scylla-ccm/archive/a0696fe532bf99ff8f7b7db0ed32672c34f103be.zip
 
 # download version
 


### PR DESCRIPTION
Recently new ccm version broke CICD.
For sake of CICD stability we need to enforce CCM version.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~