### PR TITLE
enforce gevent version for aarch64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ test = [
     "pure-sasl",
     "twisted[tls]; python_version >= '3.5'",
     "twisted[tls]==19.2.1; python_version < '3.5'",
-    "gevent>=1.0; python_version < '3.13' and platform_machine != 'i686' and platform_machine != 'win32'",
+    "gevent>=1.0; python_version < '3.13' and platform_machine != 'i686' and platform_machine != 'win32' and platform_machine != 'aarch64'",
+    "gevent==24.11.1; platform_machine == 'aarch64'", # fix for broken gevent build https://github.com/scylladb/python-driver/issues/479
     "gevent==23.9.0; python_version < '3.13' and (platform_machine == 'i686' or platform_machine == 'win32')",
     "eventlet>=0.33.3; python_version < '3.13'",
     "cython",


### PR DESCRIPTION
On aarch64 gevent build is broken:
  src/gevent/libev/corecext.pyx:69:26: undeclared name not builtin: long

Enforcing version will help to keep it compilable

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.