### PR TITLE
cluster: add application_info

### DIFF
--- a/cassandra/application_info.py
+++ b/cassandra/application_info.py
@@ -1,0 +1,53 @@
+# Copyright 2025 ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Optional
+
+
+class ApplicationInfoBase:
+    """
+    A class that holds application information and adds it to startup message options
+    """
+    def add_startup_options(self, options: dict[str, str]):
+        raise NotImplementedError()
+
+
+class ApplicationInfo(ApplicationInfoBase):
+    application_name: Optional[str]
+    application_version: Optional[str]
+    client_id: Optional[str]
+
+    def __init__(
+            self,
+            application_name: Optional[str] = None,
+            application_version: Optional[str] = None,
+            client_id: Optional[str] = None
+    ):
+        if application_name and not isinstance(application_name, str):
+            raise TypeError('application_name must be a string')
+        if application_version and not isinstance(application_version, str):
+            raise TypeError('application_version must be a string')
+        if client_id and not isinstance(client_id, str):
+            raise TypeError('client_id must be a string')
+
+        self.application_name = application_name
+        self.application_version = application_version
+        self.client_id = client_id
+
+    def add_startup_options(self, options: dict[str, str]):
+        if self.application_name:
+            options['APPLICATION_NAME'] = self.application_name
+        if self.application_version:
+            options['APPLICATION_VERSION'] = self.application_version
+        if self.client_id:
+            options['CLIENT_ID'] = self.client_id

--- a/tests/integration/standard/test_application_info.py
+++ b/tests/integration/standard/test_application_info.py
@@ -1,0 +1,93 @@
+# Copyright 2025 ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from cassandra.application_info import ApplicationInfo
+from tests.integration import TestCluster, use_single_node, remove_cluster, xfail_scylla
+
+
+def setup_module():
+    use_single_node()
+
+
+def teardown_module():
+    remove_cluster()
+
+
+@xfail_scylla("#scylladb/scylla-enterprise#5467 - not released yet")
+class ApplicationInfoTest(unittest.TestCase):
+    attribute_to_startup_key = {
+        'application_name': 'APPLICATION_NAME',
+        'application_version': 'APPLICATION_VERSION',
+        'client_id': 'CLIENT_ID',
+    }
+
+    def test_create_session_and_check_system_views_clients(self):
+        """
+        Test to ensure that ApplicationInfo user provides endup in `client_options` of `system_views.clients` table
+        """
+
+        for application_info_args in [
+            {
+                'application_name': None,
+                'application_version': None,
+                'client_id': None,
+            },
+            {
+                'application_name': 'some-application-name',
+                'application_version': 'some-application-version',
+                'client_id': 'some-client-id',
+            },
+            {
+                'application_name': 'some-application-name',
+                'application_version': None,
+                'client_id': None,
+            },
+            {
+                'application_name': None,
+                'application_version': 'some-application-version',
+                'client_id': None,
+            },
+            {
+                'application_name': None,
+                'application_version': None,
+                'client_id': 'some-client-id',
+            },
+        ]:
+            with self.subTest(**application_info_args):
+                try:
+                    cluster = TestCluster(
+                        application_info=ApplicationInfo(
+                            **application_info_args
+                        ))
+
+                    found = False
+                    for row in cluster.connect().execute("select client_options from system_views.clients"):
+                        if not row[0]:
+                            continue
+                        for attribute_key, startup_key in self.attribute_to_startup_key.items():
+                            expected_value = application_info_args.get(attribute_key)
+                            if expected_value:
+                                if row[0].get(startup_key) != expected_value:
+                                    break
+                            else:
+                                # Check that it is absent
+                                if row[0].get(startup_key, None) is not None:
+                                    break
+                        else:
+                            found = True
+                    assert found
+                finally:
+                    cluster.shutdown()


### PR DESCRIPTION
Implement clustr.application_info to make driver send following startup options to server:
1. `APPLICATION_NAME` - ID what application is using driver, example: repo of the application
2. `APPLICATION_VERSION` - Version of the application, example: release version or commit id of the application
3. `CLIENT_ID` - unique id of the client instance, example: pod name

All strings.

Fix: https://github.com/scylladb/python-driver/issues/485

Results:
```
cqlsh> SELECT * FROM system_views.clients;

 address    | port  | client_options                                                                                                                                                                             | connection_stage | driver_name            | driver_version | hostname   | keyspace_name | protocol_version | request_count | ssl_cipher_suite | ssl_enabled | ssl_protocol | username
------------+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+------------------------+----------------+------------+---------------+------------------+---------------+------------------+-------------+--------------+-----------
 172.17.0.1 | 55756 | {'APPLICATION_NAME': 'app_name', 'APPLICATION_VERSION': '1.1.1', 'CLIENT_ID': 'my_client_id', 'CQL_VERSION': '3.4.7', 'DRIVER_NAME': 'ScyllaDB Python Driver', 'DRIVER_VERSION': '3.29.3'} |            ready | ScyllaDB Python Driver |         3.29.3 | 172.17.0.1 |          null |                5 |            16 |             null |       False |         null | anonymous
 172.17.0.1 | 55762 | {'APPLICATION_NAME': 'app_name', 'APPLICATION_VERSION': '1.1.1', 'CLIENT_ID': 'my_client_id', 'CQL_VERSION': '3.4.7', 'DRIVER_NAME': 'ScyllaDB Python Driver', 'DRIVER_VERSION': '3.29.3'} |            ready | ScyllaDB Python Driver |         3.29.3 | 172.17.0.1 |          null |                5 |             1 |             null |       False |         null | anonymous

(4 rows)
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
