### PR TITLE
Optimise shard port allocator

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -672,13 +672,21 @@ class ShardAwarePortGenerator:
         self.start_port = start_port
         self.end_port = end_port
 
+    @staticmethod
+    def _align(value: int, total_shards: int):
+        shift = value % total_shards
+        if shift == 0:
+            return value
+        return value + total_shards - shift
+
     def generate(self, shard_id: int, total_shards: int):
-        start = random.randrange(self.start_port, self.end_port)
-        available_ports = itertools.chain(range(start, self.end_port), range(self.start_port, start))
+        start = self._align(random.randrange(self.start_port, self.end_port), total_shards) + shard_id
+        beginning = self._align(self.start_port, total_shards) + shard_id
+        available_ports = itertools.chain(range(start, self.end_port, total_shards),
+                                          range(beginning, start, total_shards))
 
         for port in available_ports:
-            if port % total_shards == shard_id:
-                yield port
+            yield port
 
 
 DefaultShardAwarePortGenerator = ShardAwarePortGenerator(DEFAULT_LOCAL_PORT_LOW, DEFAULT_LOCAL_PORT_HIGH)


### PR DESCRIPTION
While I was working on other issue, I have found that code of `ShardawarePortGenerator` is suboptimal in regards of performance.

So, this PR:
1. Makes  `ShardawarePortGenerator` testable
2. Adds unit test for `ShardawarePortGenerator`
3. Optimise `ShardawarePortGenerator`

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~