### PR TITLE
Prevent starting null read watcher

### DIFF
--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -165,6 +165,10 @@ class LibevLoop(object):
 
     def connection_destroyed(self, conn):
         with self._conn_set_lock:
+            new_conns = self._new_conns.copy()
+            new_conns.discard(conn)
+            self._new_conns = new_conns
+
             new_live_conns = self._live_conns.copy()
             new_live_conns.discard(conn)
             self._live_conns = new_live_conns

--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -194,7 +194,8 @@ class LibevLoop(object):
                 self._new_conns = set()
 
             for conn in to_start:
-                conn._read_watcher.start()
+                if conn._read_watcher:
+                    conn._read_watcher.start()
 
             changed = True
 


### PR DESCRIPTION
Fix: https://github.com/scylladb/python-driver/issues/503

This issue happens when connection is opened and closed right away.
`_loop_will_run` calls `conn.close` on it, which removes `self._read_watcher` from the `connection` and since connection stays in `self._new_conns` on next iteration it will pick it up and try to start `self._read_watcher` on it.
Solution is to remove closed connection from `self._new_conns` and check if `self._read_watcher` is not None before starting it.

Two fixes for follwing problem:
```
Exception ignored in: <bound method LibevLoop._loop_will_run of <cassandra.io.libevreactor.LibevLoop object at 0x7343276afc10>>
Traceback (most recent call last):
  File "/123/cassandra/io/libevreactor.py", line 197, in _loop_will_run
    conn._read_watcher.start()
AttributeError: 'NoneType' object has no attribute 'start'
```
1. Check if `self._read_watcher` is not `None` before starting it
2. Remove connection from `self._new_conns` when it is destroyed

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.