### PR TITLE
Update Scylla version in CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -68,6 +68,6 @@ jobs:
     - name: Test with pytest
       run: |
         export EVENT_LOOP_MANAGER=${{ matrix.event_loop_manager }}
-        export SCYLLA_VERSION='release:6.2'
+        export SCYLLA_VERSION='release:2025.2'
         export PROTOCOL_VERSION=4
         uv run pytest tests/integration/standard/ tests/integration/cqlengine/

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -42,7 +42,8 @@ from tests.integration import (get_cluster, use_singledc, PROTOCOL_VERSION, exec
                                greaterthancass21, assert_startswith, greaterthanorequalcass40,
                                lessthancass40,
                                TestCluster, requires_java_udf, requires_composite_type,
-                               requires_collection_indexes, SCYLLA_VERSION, xfail_scylla, xfail_scylla_version_lt)
+                               requires_collection_indexes, SCYLLA_VERSION, xfail_scylla, xfail_scylla_version_lt,
+                               requirescompactstorage)
 
 from tests.util import wait_until
 
@@ -428,6 +429,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.check_create_statement(tablemeta, create_statement)
 
     @lessthancass40
+    @requirescompactstorage
     def test_compact_storage(self):
         create_statement = self.make_create_statement(["a"], [], ["b"])
         create_statement += " WITH COMPACT STORAGE"
@@ -437,6 +439,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.check_create_statement(tablemeta, create_statement)
 
     @lessthancass40
+    @requirescompactstorage
     def test_dense_compact_storage(self):
         create_statement = self.make_create_statement(["a"], ["b"], ["c"])
         create_statement += " WITH COMPACT STORAGE"
@@ -456,6 +459,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.check_create_statement(tablemeta, create_statement)
 
     @lessthancass40
+    @requirescompactstorage
     def test_counter_with_compact_storage(self):
         """ PYTHON-1100 """
         create_statement = (
@@ -468,6 +472,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.check_create_statement(tablemeta, create_statement)
 
     @lessthancass40
+    @requirescompactstorage
     def test_counter_with_dense_compact_storage(self):
         create_statement = (
             "CREATE TABLE {keyspace}.{table} ("

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -2126,7 +2126,8 @@ class MaterializedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
         self.session.execute("CREATE TABLE {0}.{1} (pk int PRIMARY KEY, c int)".format(self.keyspace_name, self.function_table_name))
         self.session.execute(
             "CREATE MATERIALIZED VIEW {0}.mv1 AS SELECT pk, c FROM {0}.{1} "
-            "WHERE pk IS NOT NULL AND c IS NOT NULL PRIMARY KEY (pk, c)".format(
+            "WHERE pk IS NOT NULL AND c IS NOT NULL PRIMARY KEY (pk, c) "
+            "WITH compaction = {{ 'class' : 'SizeTieredCompactionStrategy' }}".format(
                 self.keyspace_name, self.function_table_name)
         )
 


### PR DESCRIPTION
This PR fixes the tests failures that started to appear in 2025.1 / 2025.2.
There were 2 breaking Scylla changes that needed fixing:
- Compact storage was deprecacted, and disabled by default
- Default compaction strategy changed

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~