### PR TITLE
(improvement) log a warning when importing of lz4 or snappy packages …

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -64,6 +64,7 @@ locally_supported_compressions = OrderedDict()
 try:
     import lz4
 except ImportError:
+    log.debug("lz4 package could not be imported. LZ4 Compression will not be available")
     pass
 else:
     # The compress and decompress functions we need were moved from the lz4 to
@@ -102,6 +103,7 @@ else:
 try:
     import snappy
 except ImportError:
+    log.debug("snappy package could not be imported. Snappy Compression will not be available")
     pass
 else:
     # work around apparently buggy snappy decompress
@@ -1408,7 +1410,7 @@ class Connection(object):
             overlap = (set(locally_supported_compressions.keys()) &
                        set(remote_supported_compressions))
             if len(overlap) == 0:
-                log.debug("No available compression types supported on both ends."
+                log.error("No available compression types supported on both ends."
                           " locally supported: %r. remotely supported: %r",
                           locally_supported_compressions.keys(),
                           remote_supported_compressions)


### PR DESCRIPTION
…fails.

If it is not available, the driver will silently not use compression. Not very very silently, as you will see in debug level only something like: "No available compression types supported on both ends. locally supported: odict_keys([]). remotely supported: ['lz4', 'snappy']"

Make it a warning. I think it wouldn't be too noisy and is clear enough for the developer.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.