### PR TITLE
(minor improvement): small refactoring in make_token_replica_map()

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -569,10 +569,11 @@ class SimpleStrategy(ReplicationStrategy):
 
     def make_token_replica_map(self, token_to_host_owner, ring):
         replica_map = {}
-        for i in range(len(ring)):
+        ring_len = len(ring)
+        for i in range(ring_len):
             j, hosts = 0, list()
-            while len(hosts) < self.replication_factor and j < len(ring):
-                token = ring[(i + j) % len(ring)]
+            while len(hosts) < self.replication_factor and j < ring_len:
+                token = ring[(i + j) % ring_len]
                 host = token_to_host_owner[token]
                 if host not in hosts:
                     hosts.append(host)


### PR DESCRIPTION
While trying to look at some random (flaky?) test (https://github.com/scylladb/python-driver/pull/510#issuecomment-3162760630 ) I saw some (minor) improvements that can be made to `make_token_replica_map()`:
1. Remove some redundant len() calls to outside the loop(s)
2. Align some variable names, start with num_ ... for them.
3. Move token_offset and host assignment within the loop to closer to where it's used.
4. Only add hosts that are in the dc_rf_map to begin with.

item 1 above was also implemented for SimpleStrategy's `make_token_replica_map()`

All those are probably very very minor improvements, perhaps in a large cluster it'll be noticable.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.