### PR TITLE
(improvement) set monitor_reporting_enabled False

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1036,7 +1036,7 @@ class Cluster(object):
     documentation for :meth:`Session.timestamp_generator`.
     """
 
-    monitor_reporting_enabled = True
+    monitor_reporting_enabled = False
     """
     A boolean indicating if monitor reporting, which sends gathered data to
     Insights when running against DSE 6.8 and higher.


### PR DESCRIPTION
monitor_reporting_enabled is a DSE feature. ScyllaDB doesn't support it, so we can set the default to False.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.