### PR TITLE
(cleanup) remove code related to v1,v2 protocols

### DIFF
--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -33,13 +33,7 @@ def execute_concurrent(session, statements_and_parameters, concurrency=100, rais
     ``parameters`` item must be a sequence or :const:`None`.
 
     The `concurrency` parameter controls how many statements will be executed
-    concurrently.  When :attr:`.Cluster.protocol_version` is set to 1 or 2,
-    it is recommended that this be kept below 100 times the number of
-    core connections per host times the number of connected hosts (see
-    :meth:`.Cluster.set_core_connections_per_host`).  If that amount is exceeded,
-    the event loop thread may attempt to block on new connection creation,
-    substantially impacting throughput.  If :attr:`~.Cluster.protocol_version`
-    is 3 or higher, you can safely experiment with higher levels of concurrency.
+    concurrently.
 
     If `raise_on_first_error` is left as :const:`True`, execution will stop
     after the first failed statement and the corresponding exception will be

--- a/docs/api/cassandra/cluster.rst
+++ b/docs/api/cassandra/cluster.rst
@@ -86,14 +86,6 @@
 
    .. automethod:: add_execution_profile
 
-   .. automethod:: get_core_connections_per_host
-
-   .. automethod:: set_core_connections_per_host
-
-   .. automethod:: get_max_connections_per_host
-
-   .. automethod:: set_max_connections_per_host
-
    .. automethod:: get_control_connection_host
 
    .. automethod:: refresh_schema_metadata

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -729,8 +729,6 @@ class ClusterTests(unittest.TestCase):
         interval = 2
         cluster = TestCluster(idle_heartbeat_interval=interval,
                               monitor_reporting_enabled=False)
-        if PROTOCOL_VERSION < 3:
-            cluster.set_core_connections_per_host(HostDistance.LOCAL, 1)
         session = cluster.connect(wait_for_all_pools=True)
 
         # This test relies on impl details of connection req id management to see if heartbeats

--- a/tests/integration/standard/test_concurrent.py
+++ b/tests/integration/standard/test_concurrent.py
@@ -46,8 +46,6 @@ class ClusterTests(unittest.TestCase):
                 EXEC_PROFILE_DICT: ExecutionProfile(row_factory=dict_factory)
             }
         )
-        if PROTOCOL_VERSION < 3:
-            cls.cluster.set_core_connections_per_host(HostDistance.LOCAL, 1)
         cls.session = cls.cluster.connect()
 
     @classmethod

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -664,8 +664,6 @@ class BatchStatementTests(BasicSharedKeyspaceUnitTestCase):
                 % (PROTOCOL_VERSION,))
 
         self.cluster = TestCluster()
-        if PROTOCOL_VERSION < 3:
-            self.cluster.set_core_connections_per_host(HostDistance.LOCAL, 1)
         self.session = self.cluster.connect(wait_for_all_pools=True)
 
     def tearDown(self):
@@ -800,8 +798,6 @@ class SerialConsistencyTests(unittest.TestCase):
                 % (PROTOCOL_VERSION,))
 
         self.cluster = TestCluster()
-        if PROTOCOL_VERSION < 3:
-            self.cluster.set_core_connections_per_host(HostDistance.LOCAL, 1)
         self.session = self.cluster.connect()
 
     def tearDown(self):

--- a/tests/integration/standard/test_query_paging.py
+++ b/tests/integration/standard/test_query_paging.py
@@ -46,8 +46,6 @@ class QueryPagingTests(unittest.TestCase):
         self.cluster = TestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(consistency_level=ConsistencyLevel.LOCAL_QUORUM)}
         )
-        if PROTOCOL_VERSION < 3:
-            self.cluster.set_core_connections_per_host(HostDistance.LOCAL, 1)
         self.session = self.cluster.connect(wait_for_all_pools=True)
         self.session.execute("TRUNCATE test3rf.test")
 

--- a/tests/unit/test_host_connection_pool.py
+++ b/tests/unit/test_host_connection_pool.py
@@ -39,8 +39,6 @@ class _PoolTests(unittest.TestCase):
 
     def make_session(self):
         session = NonCallableMagicMock(spec=Session, keyspace='foobarkeyspace')
-        session.cluster.get_core_connections_per_host.return_value = 1
-        session.cluster.get_max_connections_per_host.return_value = 1
         return session
 
     def test_borrow_and_return(self):
@@ -112,9 +110,6 @@ class _PoolTests(unittest.TestCase):
         conn = NonCallableMagicMock(spec=Connection, in_flight=0, is_defunct=False, is_closed=False, max_request_id=100)
         conn.max_request_id = 100
         session.cluster.connection_factory.return_value = conn
-
-        # core conns = 1, max conns = 2
-        session.cluster.get_max_connections_per_host.return_value = 2
 
         pool = self.PoolImpl(host, HostDistance.LOCAL, session)
         session.cluster.connection_factory.assert_called_once_with(host.endpoint, on_orphaned_stream_released=pool.on_orphaned_stream_released)


### PR DESCRIPTION
I'm not sure why I did not remove it as part of https://github.com/scylladb/python-driver/pull/493

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.