### PR TITLE
cicd: make openssl installation step stable

### DIFF
--- a/.github/workflows/lib-build-and-push.yml
+++ b/.github/workflows/lib-build-and-push.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install OpenSSL for Windows
         if: runner.os == 'Windows'
         run: |
-          choco install openssl --version=3.5.3 -f -y --no-progress
+          choco install openssl.light --no-progress -y
 
       - name: Install Conan
         if: runner.os == 'Windows'


### PR DESCRIPTION
It always getting broken due to the version being removed from the server.
If we drop version it will pull newest version, which should work just fine.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~