### PR TITLE
Update cibuildwheel to 3.2.1

### DIFF
--- a/.github/workflows/lib-build-and-push.yml
+++ b/.github/workflows/lib-build-and-push.yml
@@ -98,8 +98,6 @@ jobs:
           echo "CIBW_TEST_COMMAND=true" >> $GITHUB_ENV;
           echo "CIBW_TEST_COMMAND_WINDOWS=(exit 0)" >> $GITHUB_ENV;
           echo "CIBW_TEST_SKIP=*" >> $GITHUB_ENV;
-          echo "CIBW_SKIP=cp2* cp36* pp36* cp37* pp37* cp38* pp38* cp39* pp39* *i686 *musllinux*" >> $GITHUB_ENV;
-          echo "CIBW_BUILD=cp3* pp3*" >> $GITHUB_ENV;
           echo "CIBW_BEFORE_TEST=true" >> $GITHUB_ENV;
           echo "CIBW_BEFORE_TEST_WINDOWS=(exit 0)" >> $GITHUB_ENV;
 
@@ -110,7 +108,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          uv tool install 'cibuildwheel==2.22.0'
+          uv tool install 'cibuildwheel==3.2.1'
 
       - name: Install OpenSSL for Windows
         if: runner.os == 'Windows'
@@ -127,7 +125,7 @@ jobs:
           conan profile detect
           conan install conanfile.py
 
-      - name: Install OpenSSL for MacOS
+      - name: Install libev for MacOS
         if: runner.os == 'MacOs'
         run: |
           brew install libev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,15 +129,12 @@ tag_regex = '(?P<version>\d*?\.\d*?\.\d*?)-scylla'
 build-frontend = "build[uv]"
 environment = { CASS_DRIVER_BUILD_CONCURRENCY = "2", CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST = "yes", CFLAGS = "-g0 -O3" }
 skip = [
-    "cp2*",
-    "cp36*",
-    "pp36*",
-    "cp37*",
-    "pp37*",
     "cp38*",
     "pp38*",
     "cp39*",
     "pp39*",
+    "cp3*t-*",
+    "pp3*t-*",
     "*i686",
     "*musllinux*",
 ]
@@ -149,6 +146,7 @@ manylinux-aarch64-image = "manylinux_2_28"
 manylinux-pypy_x86_64-image = "manylinux_2_28"
 manylinux-pypy_aarch64-image = "manylinux_2_28"
 
+enable = ["pypy"]
 [tool.cibuildwheel.linux]
 
 before-build = "rm -rf ~/.pyxbld && rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux && yum install -y libffi-devel libev libev-devel openssl openssl-devel"
@@ -171,7 +169,3 @@ test-command = [
 
 # TODO: set CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST to yes when https://github.com/scylladb/python-driver/issues/429 is fixed
 environment = { CASS_DRIVER_BUILD_CONCURRENCY = "2", CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST = "no" }
-
-[[tool.cibuildwheel.overrides]]
-select = "pp*"
-test-command = []


### PR DESCRIPTION
List of changes:
1. Enable pp wheels, new version requires them to be specifically enabled
2. Remove `CIBW_BUILD` and `CIBW_SKIP` from test disabling stage, now these parameters are not getting overwritten.
3. Remove skipping patterns for python 2, 3.6, 3.7, they are no supported by this version of `cibuildwheel`.
4. Added skip pattern for `freethread` python.
5. Remove override that disables tests for pypy, now they are not failing.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~