### PR TITLE
Drop support for python 3.9

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [8]
-        python-version: ["3.9", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         event_loop_manager: ["libev", "asyncio", "asyncore"]
         exclude:
           - python-version: "3.12"

--- a/.github/workflows/lib-build-and-push.yml
+++ b/.github/workflows/lib-build-and-push.yml
@@ -98,7 +98,7 @@ jobs:
           echo "CIBW_TEST_COMMAND=true" >> $GITHUB_ENV;
           echo "CIBW_TEST_COMMAND_WINDOWS=(exit 0)" >> $GITHUB_ENV;
           echo "CIBW_TEST_SKIP=*" >> $GITHUB_ENV;
-          echo "CIBW_SKIP=cp2* cp36* pp36* cp37* pp37* cp38* pp38* *i686 *musllinux*" >> $GITHUB_ENV;
+          echo "CIBW_SKIP=cp2* cp36* pp36* cp37* pp37* cp38* pp38* cp39* pp39* *i686 *musllinux*" >> $GITHUB_ENV;
           echo "CIBW_BUILD=cp3* pp3*" >> $GITHUB_ENV;
           echo "CIBW_BEFORE_TEST=true" >> $GITHUB_ENV;
           echo "CIBW_BEFORE_TEST_WINDOWS=(exit 0)" >> $GITHUB_ENV;

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Scylla Enterprise (2018.1.x+) using exclusively Cassandra's binary protocol and 
 .. image:: https://github.com/scylladb/python-driver/actions/workflows/integration-tests.yml/badge.svg?branch=master
    :target: https://github.com/scylladb/python-driver/actions/workflows/integration-tests.yml?query=event%3Apush+branch%3Amaster
 
-The driver supports Python versions 3.9-3.13.
+The driver supports Python versions 3.10-3.13.
 
 .. **Note:** This driver does not support big-endian systems.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ A Python client driver for `Scylla <https://docs.scylladb.com>`_.
 This driver works exclusively with the Cassandra Query Language v3 (CQL3)
 and Cassandra's native protocol.
 
-The driver supports Python 3.9-3.13.
+The driver supports Python 3.10-3.13.
 
 This driver is open source under the
 `Apache v2 License <http://www.apache.org/licenses/LICENSE-2.0.html>`_.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Supported Platforms
 -------------------
-Python versions 3.9-3.13 are supported. Both CPython (the standard Python
+Python versions 3.10-3.13 are supported. Both CPython (the standard Python
 implementation) and `PyPy <http://pypy.org>`_ are supported and tested.
 
 Linux, OSX, and Windows are supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
     'Natural Language :: English',
     'Operating System :: OS Independent',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
@@ -137,6 +136,8 @@ skip = [
     "pp37*",
     "cp38*",
     "pp38*",
+    "cp39*",
+    "pp39*",
     "*i686",
     "*musllinux*",
 ]


### PR DESCRIPTION
Python 3.9 reached it EOL date.
We can drop it from everywhere.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.