### PR TITLE
cicd: drop macos-13 runner

### DIFF
--- a/.github/workflows/lib-build-and-push.yml
+++ b/.github/workflows/lib-build-and-push.yml
@@ -61,7 +61,7 @@ jobs:
              was_added=1
            elif [[ "${target}" == "macos-x86" ]]; then
              [ -n "$was_added" ] && echo -n ","  >> /tmp/matrix.json
-             echo -n  '{"os":"macos-13", "target": "macos-x86"}' >> /tmp/matrix.json
+             echo -n  '{"os":"macos-15-intel", "target": "macos-x86"}' >> /tmp/matrix.json
              was_added=1
            elif [[ "${target}" == "macos-arm" ]]; then
              [ -n "$was_added" ] && echo -n ","  >> /tmp/matrix.json
@@ -134,9 +134,9 @@ jobs:
         if: runner.os == 'MacOS'
         run: |
           ##### Set MACOSX_DEPLOYMENT_TARGET
-          if [ "${{ matrix.os }}" == "macos-13" ]; then
-            echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV;
-            echo "Enforcing target deployment for 13.0"
+          if [ "${{ matrix.os }}" == "macos-15-intel" ]; then
+            echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV;
+            echo "Enforcing target deployment for 15.0"
           elif [ "${{ matrix.os }}" == "macos-14" ]; then
             echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV;
             echo "Enforcing target deployment for 14.0"


### PR DESCRIPTION
It is being depricated, since we use it for x86 builds good replacement for it could be `macos-15-intel`.

Fixes: https://github.com/scylladb/python-driver/issues/556

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.