### PR TITLE
token-aware-policy: drop _tablets_routing_v1 flag

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1734,14 +1734,6 @@ class Cluster(object):
                     self.shutdown()
                     raise
 
-                # Update the information about tablet support after connection handshake.
-                self.load_balancing_policy._tablets_routing_v1 = self.control_connection._tablets_routing_v1
-                child_policy = self.load_balancing_policy.child_policy if hasattr(self.load_balancing_policy, 'child_policy') else None
-                while child_policy is not None:
-                    if hasattr(child_policy, '_tablet_routing_v1'):
-                        child_policy._tablet_routing_v1 = self.control_connection._tablets_routing_v1
-                    child_policy = child_policy.child_policy if hasattr(child_policy, 'child_policy') else None
-
                 self.profile_manager.check_supported()  # todo: rename this method
 
                 if self.idle_heartbeat_interval:

--- a/cassandra/tablets.py
+++ b/cassandra/tablets.py
@@ -49,6 +49,9 @@ class Tablets(object):
         self._tablets = tablets
         self._lock = Lock()
 
+    def table_has_tablets(self, keyspace, table) -> bool:
+        return bool(self._tablets.get((keyspace, table), []))
+
     def get_tablet_for_key(self, keyspace, table, t):
         tablet = self._tablets.get((keyspace, table), [])
         if not tablet:


### PR DESCRIPTION
`_tablets_routing_v1` flag was introduced to check if server supports tablets. 
As result driver needs to sync it to policy when control connection is established, which is an unwanted problem.
Initial implementation did not sync `_tablets_routing_v1` for policies from execution profiles, as result tablets were not working in such case, the policy was always picking replicas from tokenmap.

Let's relay on presence of tablets for given table instead, which will not require any syncing.

Fixes: https://github.com/scylladb/python-driver/issues/575

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.