### PR TITLE
unit: fix test_successful_wait_for_connection failure

### DIFF
--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -9,6 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest.mock import NonCallableMagicMock
 
 
 def check_sequence_consistency(ordered_sequence, equal=False):
@@ -28,3 +29,9 @@ def _check_order_consistency(smaller, bigger, equal=False):
         assert smaller != bigger
         assert smaller < bigger
         assert bigger > smaller
+
+
+class HashableMock(NonCallableMagicMock):
+
+    def __hash__(self):
+        return id(self)


### PR DESCRIPTION
This test can fail with:
```
  >       elif connection in self._trash:
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  E       TypeError: __hash__ method should return an integer not 'MagicMock'
```
This fix does the following:
1. Makes mocked connections return `__hash__`
2. Makes mocked sessions have empty `_trash`

Fixes:  https://github.com/scylladb/python-driver/issues/580

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.