### PR TITLE
Fix test_create_session_and_check_system_views_clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ compress-snappy = ['python-snappy']
 
 [dependency-groups]
 dev = [
-    "pytest",
+    "pytest~=8.0",
     "PyYAML",
     "pytz",
     "scales",


### PR DESCRIPTION
This test is failing with unknown reason:
```
FAILED tests/integration/standard/test_application_info.py::ApplicationInfoTest::test_create_session_and_check_system_views_clients - [XPASS(strict)] #scylladb/scylla-enterprise#5467 - not released yet
```

It is a bug of pytest 9.0.1, other ways to fix it did not yield any results.
pytest 9.0.0 has another problems when it is run with `twisted` installed.

So, only way for now is drop it all the way to `8.x.x`

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~