### PR TITLE
Shuffle replicas by default

### DIFF
--- a/cassandra/policies.py
+++ b/cassandra/policies.py
@@ -476,12 +476,12 @@ class TokenAwarePolicy(LoadBalancingPolicy):
 
     _child_policy = None
     _cluster_metadata = None
-    shuffle_replicas = False
+    shuffle_replicas = True
     """
     Yield local replicas in a random order.
     """
 
-    def __init__(self, child_policy, shuffle_replicas=False):
+    def __init__(self, child_policy, shuffle_replicas=True):
         self._child_policy = child_policy
         self.shuffle_replicas = shuffle_replicas
 


### PR DESCRIPTION
Shuffling replicas results in a proper load balancing, almost in all cases, except LWT, which is voided even if shuffling is enabled. (LWT to be added in https://github.com/scylladb/python-driver/pull/584)