### PR TITLE
tests: drop `sure` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dev = [
     "pytest",
     "PyYAML",
     "pytz",
-    "sure",
     "scales",
     "pure-sasl",
     "twisted[tls]",

--- a/tests/integration/standard/test_use_keyspace.py
+++ b/tests/integration/standard/test_use_keyspace.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     import unittest  # noqa
 
-from mock import patch
+from unittest.mock import patch
 
 from cassandra.connection import Connection
 from cassandra.cluster import Cluster

--- a/tests/unit/io/test_eventletreactor.py
+++ b/tests/unit/io/test_eventletreactor.py
@@ -14,12 +14,12 @@
 
 
 import unittest
-from mock import patch
+
+from unittest.mock import patch
 
 from tests.unit.io.utils import TimerTestMixin
 from tests import notpypy, EVENT_LOOP_MANAGER
 
-from unittest.mock import patch
 
 try:
     from eventlet import monkey_patch

--- a/tests/unit/test_shard_aware.py
+++ b/tests/unit/test_shard_aware.py
@@ -18,7 +18,7 @@ except ImportError:
     import unittest  # noqa
 
 import logging
-from mock import MagicMock
+from unittest.mock import MagicMock
 from concurrent.futures import ThreadPoolExecutor
 
 from cassandra.cluster import ShardAwareOptions


### PR DESCRIPTION
This package colides with twisted implementation, which ends up in the following error:
```
  File "/home/runner/work/python-driver/python-driver/.venv/lib/python3.11/site-packages/sure/__init__.py", line 1084, in _new_dir
    patched = [x for x in old_dir(obj[0]) if isinstance(getattr(obj[0], x, None), AssertionBuilder)]
  File "/home/runner/work/python-driver/python-driver/.venv/lib/python3.11/site-packages/sure/__init__.py", line 1084, in <listcomp>
    patched = [x for x in old_dir(obj[0]) if isinstance(getattr(obj[0], x, None), AssertionBuilder)]
  File "/home/runner/work/python-driver/python-driver/.venv/lib/python3.11/site-packages/zope/interface/ro.py", line 224, in __get__
    for k in dir(klass):
  File "/home/runner/work/python-driver/python-driver/.venv/lib/python3.11/site-packages/sure/__init__.py", line 1084, in _new_dir
    patched = [x for x in old_dir(obj[0]) if isinstance(getattr(obj[0], x, None), AssertionBuilder)]
builtins.RecursionError: maximum recursion depth exceeded while calling a Python object
```

Fixes: https://github.com/scylladb/python-driver/issues/589
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.