### PR TITLE
Fix dict hanlding in pool and metrics

### DIFF
--- a/cassandra/metrics.py
+++ b/cassandra/metrics.py
@@ -134,9 +134,9 @@ class Metrics(object):
             scales.Stat('known_hosts',
                 lambda: len(cluster_proxy.metadata.all_hosts())),
             scales.Stat('connected_to',
-                lambda: len(set(chain.from_iterable(s._pools.keys() for s in cluster_proxy.sessions)))),
+                lambda: len(set(chain.from_iterable(list(s._pools.keys()) for s in cluster_proxy.sessions)))),
             scales.Stat('open_connections',
-                lambda: sum(sum(p.open_count for p in s._pools.values()) for s in cluster_proxy.sessions)))
+                lambda: sum(sum(p.open_count for p in list(s._pools.values())) for s in cluster_proxy.sessions)))
 
         # TODO, to be removed in 4.0
         # /cassandra contains the metrics of the first cluster registered


### PR DESCRIPTION
There are certain rules you need to following in the cases when dicts are modified and read in parallel. 
Otherwise you end up with `RuntimeError: dictionary changed size during iteration`. Rules are the following:
1. Any iteration over items or keys, needs to be done over a snapshot, i.e. `list()` or `set()`
2. Avoid unnecessary iterations like `len(d.keys())`, you can replace them with `len(d)`

This commit fixes code to match these rules in the `pool.py` and `metrics.py`

Fixes: https://github.com/scylladb/python-driver/issues/594

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.