### PR TITLE
Rename connection_metadata to client_routes

### DIFF
--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -957,7 +957,7 @@ known_event_types = frozenset((
     'TOPOLOGY_CHANGE',
     'STATUS_CHANGE',
     'SCHEMA_CHANGE',
-    'CONNECTION_METADATA_CHANGE'
+    'CLIENT_ROUTES_CHANGE'
 ))
 
 
@@ -989,7 +989,7 @@ class EventMessage(_MessageType):
         raise NotSupportedError('Unknown event type %r' % event_type)
 
     @classmethod
-    def recv_connection_metadata_change(cls, f, protocol_version):
+    def recv_client_routes_change(cls, f, protocol_version):
         # "UPDATE_NODES"
         change_type = read_string(f)
         connection_ids = read_stringlist(f)

--- a/tests/integration/standard/test_control_connection.py
+++ b/tests/integration/standard/test_control_connection.py
@@ -132,9 +132,9 @@ class ControlConnectionTests(unittest.TestCase):
             assert 9042 == host.broadcast_rpc_port
             assert 7000 == host.broadcast_port
 
-    @xfail_scylla_version_lt(reason='scylladb/scylladb#26992 - system.connection_metadata is not yet supported',
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#26992 - system.client_routes is not yet supported',
                              oss_scylla_version="7.0", ent_scylla_version="2025.4.0")
-    def test_connection_metadata_change_event(self):
+    def test_client_routes_change_event(self):
         cluster = TestCluster()
 
         # Establish control connection
@@ -157,7 +157,7 @@ class ControlConnectionTests(unittest.TestCase):
             finally:
                 flag.set()
 
-        cluster.control_connection._connection.register_watchers({"CONNECTION_METADATA_CHANGE": on_event})
+        cluster.control_connection._connection.register_watchers({"CLIENT_ROUTES_CHANGE": on_event})
 
         try:
             payload = [
@@ -185,7 +185,7 @@ class ControlConnectionTests(unittest.TestCase):
                 }
             ]
             response = requests.post(
-                "http://" + cluster.contact_points[0] + ":10000/v2/connection-metadata",
+                "http://" + cluster.contact_points[0] + ":10000/v2/client-routes",
                 json=payload,
                 headers={
                     "Content-Type": "application/json",


### PR DESCRIPTION
It was decided to rename table and events for better clarity.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~