### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -1,5 +1,8 @@
 name: Build and upload to PyPi manually
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/python-driver/security/code-scanning/7](https://github.com/scylladb/python-driver/security/code-scanning/7)

Generally, this issue is fixed by explicitly specifying `permissions` at the workflow root and/or per job so that `GITHUB_TOKEN` has the least privileges needed. For a build-and-publish workflow, the build job typically needs at most read access to repository contents (and sometimes no token at all), while the publish job may need `id-token: write` and possibly `contents: read`.

The best minimal change here is:
- Add a workflow-level `permissions: contents: read` so all jobs default to read-only repository access.
- Keep the existing `publish` job’s `permissions` (it already specifies `id-token: write`; the workflow-level default will be merged/overridden as usual).
- Optionally, if you want to be maximally strict and you know the build job does not need the token, you can also set `permissions: {}` on the `build-and-publish` job. However, without seeing the reusable workflow, that might break it if it expects `contents: read`. A safe default is to rely on the workflow-level `contents: read`.

Concretely:
- In `.github/workflows/publish-manually.yml`, insert a `permissions:` block after the `name:` and before `on:`:

```yaml
name: Build and upload to PyPi manually

permissions:
  contents: read

on:
  workflow_dispatch:
  ...
```

No additional imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
