### PR TITLE
.github/workflows/docs-pages.yml: Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -2,6 +2,9 @@ name: "Docs / Publish"
 # For more information,
 # see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/python-driver/security/code-scanning/3](https://github.com/scylladb/python-driver/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions` block for the workflow or the specific job (`release`) so that the `GITHUB_TOKEN` has only the minimal rights required (likely `contents: write` to push built docs to the pages branch, and possibly `pages`/`id-token` if using newer Pages APIs). This prevents the job from inheriting broader organization/repository defaults.

For this specific workflow, the safest minimal change without altering behavior is to add a `permissions` block at the workflow root (applies to all jobs) or inside the `release` job. Since only one job exists, either is fine; placing it at the top level is a clear pattern. The deploy step uses `GITHUB_TOKEN` via a shell script to “Deploy docs to GitHub Pages”; typical patterns for pushing to a `gh-pages` branch require `contents: write`. To preserve existing behavior while still addressing the CodeQL warning, we should explicitly grant `contents: write`. If you later verify that only read access is needed, you can further reduce it, but with the information available we cannot safely restrict more than that.

Concretely:
- Edit `.github/workflows/docs-pages.yml`.
- Insert a `permissions:` block after the `name:` (line 1) and comments, before the `on:` block, with `contents: write`.
- No imports or additional methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
