### PR TITLE
Don't mark node down when control connection fails to connect

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3546,10 +3546,6 @@ class ControlConnection(object):
         for host in lbp.make_query_plan():
             try:
                 return (self._try_connect(host), None)
-            except ConnectionException as exc:
-                errors[str(host.endpoint)] = exc
-                log.warning("[control connection] Error connecting to %s:", host, exc_info=True)
-                self._cluster.signal_connection_failure(host, exc, is_host_addition=False)
             except Exception as exc:
                 errors[str(host.endpoint)] = exc
                 log.warning("[control connection] Error connecting to %s:", host, exc_info=True)


### PR DESCRIPTION
Node pools should be stable, if cc fails to connect it is not good enough reason to neither to kill it nor to mark node down.
Doing that opens up cases when control connection marks nodes down and kills pools due to the short leaved network glitch.

Fixes: https://github.com/scylladb/python-driver/issues/622
## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.