### PR TITLE
Remove Python 2 compatibility code

### DIFF
--- a/tests/integration/long/test_large_data.py
+++ b/tests/integration/long/test_large_data.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    from Queue import Queue, Empty
-except ImportError:
-    from queue import Queue, Empty  # noqa
+from queue import Queue, Empty
 
 from struct import pack
 import logging, sys, traceback, time

--- a/tests/integration/standard/test_shard_aware.py
+++ b/tests/integration/standard/test_shard_aware.py
@@ -17,15 +17,9 @@ import random
 from subprocess import run
 import logging
 
-try:
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-except ImportError:
-    from futures import ThreadPoolExecutor, as_completed  # noqa
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest  # noqa
+import unittest
 import pytest
 
 from cassandra.cluster import Cluster

--- a/tests/integration/standard/test_use_keyspace.py
+++ b/tests/integration/standard/test_use_keyspace.py
@@ -2,10 +2,7 @@ import os
 import time
 import logging
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest  # noqa
+import unittest
 
 from unittest.mock import patch
 

--- a/tests/unit/io/eventlet_utils.py
+++ b/tests/unit/io/eventlet_utils.py
@@ -16,21 +16,15 @@
 import os
 import select
 import socket
-try:
-    import thread
-    import Queue
-    import __builtin__
-    #For python3 compatibility
-except ImportError:
-    import _thread as thread
-    import queue as Queue
-    import builtins as __builtin__
+import _thread as thread
+import queue as Queue
+import builtins as __builtin__
 
 import threading
 import ssl
 import time
 import eventlet
-from imp import reload
+from importlib import reload
 
 def eventlet_un_patch_all():
     """

--- a/tests/unit/test_protocol_features.py
+++ b/tests/unit/test_protocol_features.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest  # noqa
+import unittest
 
 import logging
 

--- a/tests/unit/test_shard_aware.py
+++ b/tests/unit/test_shard_aware.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest  # noqa
+import unittest
 
 import logging
 from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary

Remove Python 2 compatibility shims that are no longer needed since the driver requires Python 3.10+.

## Changes

- Remove `try/except` for `Queue` vs `queue` → use `queue` directly
- Remove `try/except` for `__builtin__` vs `builtins` → use `builtins` directly  
- Remove `try/except` for `thread` vs `_thread` → use `_thread` directly
- Remove `try/except` for `futures` vs `concurrent.futures` → use `concurrent.futures` directly
- Remove `try/except` for `unittest2` vs `unittest` → use `unittest` directly
- Replace deprecated `imp.reload` with `importlib.reload`

## Files changed

- `tests/unit/io/eventlet_utils.py`
- `tests/integration/long/test_large_data.py`
- `tests/integration/standard/test_shard_aware.py`
- `tests/integration/standard/test_use_keyspace.py`
- `tests/unit/test_protocol_features.py`
- `tests/unit/test_shard_aware.py`

## Test plan

- [x] Unit tests pass locally (`pytest tests/unit/test_protocol_features.py tests/unit/test_shard_aware.py`)
- [x] CI tests pass