### PR TITLE
Upgrade dependency constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ requires-python = ">=3.9"
 "Issues" = "https://github.com/scylladb/python-driver/issues"
 
 [project.optional-dependencies]
-graph = ['gremlinpython==3.7.4']
-cle = ['cryptography>=35.0']
+graph = ['gremlinpython>=3.7.4,<4']
+cle = ['cryptography>=42.0']
 compress-lz4 = ['lz4']
 compress-snappy = ['python-snappy']
 
@@ -46,8 +46,8 @@ dev = [
     "twisted[tls]",
     "gevent",
     "eventlet>=0.33.3",
-    "cython",
-    "packaging",
+    "cython>=3.2",
+    "packaging>=25.0",
     "futurist",
     "asynctest",
     "pyyaml",
@@ -75,7 +75,7 @@ version = { attr = "cassandra.__version__" }                  # any module attri
 readme = { file = "README.rst", content-type = "text/x-rst" }
 
 [build-system]
-requires = ["setuptools>=42", "Cython"]
+requires = ["setuptools>=70", "Cython"]
 
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
## Summary

- Upgrade `gremlinpython` from `==3.7.4` to `>=3.7.4,<4` (allows latest 3.8.0)
- Raise `setuptools` floor from `>=42` to `>=70` in build-system.requires
- Pin `cython>=3.2` in dev dependencies
- Pin `packaging>=25.0` in dev dependencies
- Raise `cryptography` floor from `>=35.0` to `>=42.0`

## Test plan

- [x] `uv sync` completes successfully
- [x] Unit tests pass