### PR TITLE
Specify protocol version for cluster to use

### DIFF
--- a/tests/integration/standard/test_prepared_statements.py
+++ b/tests/integration/standard/test_prepared_statements.py
@@ -44,7 +44,7 @@ class PreparedStatementTests(unittest.TestCase):
         cls.cass_version = get_server_versions()
 
     def setUp(self):
-        self.cluster = TestCluster(metrics_enabled=True, allow_beta_protocol_version=True)
+        self.cluster = TestCluster(metrics_enabled=True, allow_beta_protocol_version=True, protocol_version=PROTOCOL_VERSION)
         self.session = self.cluster.connect()
 
     def tearDown(self):


### PR DESCRIPTION
Without this on cluster lvl we assumed protocol version is 4, even if it was 3. Test `test_imprecise_bind_values_dicts` rely on protocol specific behavior and was failing for v3.
