### PR TITLE
Remove redundant skip decorators for broadcast_rpc_port tests

### DIFF
--- a/tests/integration/standard/test_control_connection.py
+++ b/tests/integration/standard/test_control_connection.py
@@ -108,8 +108,6 @@ class ControlConnectionTests(unittest.TestCase):
 
         assert new_host1 != new_host2
 
-    # TODO: enable after https://github.com/scylladb/python-driver/issues/121 is fixed
-    @unittest.skip('Fails on scylla due to the broadcast_rpc_port is None')
     @greaterthanorequalcass40
     def test_control_connection_port_discovery(self):
         """

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -57,8 +57,6 @@ def setup_module():
 
 
 class HostMetaDataTests(BasicExistingKeyspaceUnitTestCase):
-    # TODO: enable after https://github.com/scylladb/python-driver/issues/121 is fixed
-    @unittest.skip('Fails on scylla due to the broadcast_rpc_port is None')
     @local
     def test_host_addresses(self):
         """
@@ -85,8 +83,10 @@ class HostMetaDataTests(BasicExistingKeyspaceUnitTestCase):
         local_host = con.host
 
         # The control connection node should have the listen address set.
-        listen_addrs = [host.listen_address for host in self.cluster.metadata.all_hosts()]
-        assert local_host in listen_addrs
+        # Note: Scylla does not populate listen_address in system.local
+        if SCYLLA_VERSION is None:
+            listen_addrs = [host.listen_address for host in self.cluster.metadata.all_hosts()]
+            assert local_host in listen_addrs
 
         # The control connection node should have the broadcast_rpc_address set.
         rpc_addrs = [host.broadcast_rpc_address for host in self.cluster.metadata.all_hosts()]

--- a/tests/integration/standard/test_single_interface.py
+++ b/tests/integration/standard/test_single_interface.py
@@ -44,8 +44,6 @@ class SingleInterfaceTest(unittest.TestCase):
         if self.cluster is not None:
             self.cluster.shutdown()
 
-    # TODO: enable after https://github.com/scylladb/python-driver/issues/121 is fixed
-    @unittest.skip('Fails on scylla due to the broadcast_rpc_port is None')
     def test_single_interface(self):
         """
         Test that we can connect to a multiple hosts bound to a single interface.


### PR DESCRIPTION
## Summary
- Remove unnecessary `@unittest.skip` decorators that reference issue #121
- Remove TODO comments about enabling tests after issue #121 is fixed
- Skip `listen_address` check for Scylla (Scylla doesn't populate this field in `system.local`)

The skip decorators were redundant because:

1. **test_control_connection_port_discovery**: Already has `@greaterthanorequalcass40` which skips for Scylla (mapped to Cassandra 3.11.4)
2. **test_single_interface**: The entire `SingleInterfaceTest` class has `@greaterthanorequalcass40`
3. **test_host_addresses**: Port assertions are conditional on `CASSANDRA_VERSION >= Version('4-a')`

Since Scylla's `CASSANDRA_VERSION` defaults to `3.11.4` (via `MAPPED_SCYLLA_VERSION`), these version checks already prevent the port-related assertions from running on Scylla clusters.

Additionally, the `listen_address` assertion in `test_host_addresses` is now skipped for Scylla since Scylla doesn't populate this field in its `system.local` table.

## Test plan
- [x] Run integration tests against Scylla to verify tests pass
- [x] Run integration tests against Cassandra 4.0+ to verify port discovery works

Fixes #121