### PR TITLE
Remove DSE-specific content from documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -113,7 +113,7 @@ Manual Installation
 You can always install the driver directly from a source checkout or tarball.
 When installing manually, ensure the python dependencies are already
 installed. You can find the list of dependencies in
-`requirements.txt <https://github.com/datastax/python-driver/blob/master/requirements.txt>`_.
+`pyproject.toml <https://github.com/scylladb/python-driver/blob/master/pyproject.toml>`_.
 
 Once the dependencies are installed, simply run::
 
@@ -228,5 +228,4 @@ the libev event loop by doing the following:
 
 (*Optional*) Configuring SSL
 -----------------------------
-Andrew Mussey has published a thorough guide on
-`Using SSL with the DataStax Python driver <http://blog.amussey.com/post/64036730812/cassandra-2-0-client-server-ssl-with-datastax-python>`_.
+See the :ref:`security` section for details on configuring SSL.


### PR DESCRIPTION
Fixes #39

Removes DataStax Enterprise (DSE) specific information from the documentation:

**security.rst:**
- Replaced DataStax DSE documentation links with Scylla TLS/SSL documentation
- Removed entire "DSE Authentication" section including:
  - DSE Unified Authentication
  - Proxy Login
  - Proxy Execute
- Changed `dse-truststore.jks` to generic `truststore.jks`
- Updated Python docs link from 2.x to 3.x
- Fixed typo: "intructions" → "instructions"

**installation.rst:**
- Updated requirements.txt link to point to scylladb/python-driver pyproject.toml
- Replaced outdated DataStax blog post reference with link to security documentation section

Note: API documentation for `DSELoadBalancingPolicy` and `TableMetadataDSE68` is preserved as these classes exist in the codebase for compatibility.