### PR TITLE
Use protocol-level BatchStatement in cqlengine BatchQuery

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2960,9 +2960,10 @@ class Session(object):
                     "2 or higher (supported in Cassandra 2.0 and higher).  Consider "
                     "setting Cluster.protocol_version to 2 to support this operation.")
             statement_keyspace = query.keyspace if ProtocolVersion.uses_keyspace_flag(self._protocol_version) else None
+            batch_timestamp = query.timestamp if query.timestamp is not None else timestamp
             message = BatchMessage(
                 query.batch_type, query._statements_and_parameters, cl,
-                serial_cl, timestamp, statement_keyspace)
+                serial_cl, batch_timestamp, statement_keyspace)
         elif isinstance(query, GraphStatement):
             # the statement_keyspace is not aplicable to GraphStatement
             message = QueryMessage(query.query, cl, serial_cl, fetch_size,

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -759,13 +759,22 @@ class BatchStatement(Statement):
     supported when using protocol version 3 or higher.
     """
 
+    timestamp = None
+    """
+    The optional timestamp for all operations in the batch, in microseconds
+    since the UNIX epoch. If not set, the client timestamp generator or
+    server time will be used.
+
+    .. versionadded:: 3.29.2
+    """
+
     _statements_and_parameters = None
     _session = None
     _is_lwt = False
 
     def __init__(self, batch_type=BatchType.LOGGED, retry_policy=None,
                  consistency_level=None, serial_consistency_level=None,
-                 session=None, custom_payload=None):
+                 session=None, custom_payload=None, timestamp=None):
         """
         `batch_type` specifies The :class:`.BatchType` for the batch operation.
         Defaults to :attr:`.BatchType.LOGGED`.
@@ -780,6 +789,10 @@ class BatchStatement(Statement):
         Note: as Statement objects are added to the batch, this map is
         updated with any values found in their custom payloads. These are
         only allowed when using protocol version 4 or higher.
+
+        `timestamp` is an optional timestamp for all operations in the batch,
+        in microseconds since the UNIX epoch. If set, this will override the
+        client timestamp generator.
 
         Example usage:
 
@@ -809,8 +822,12 @@ class BatchStatement(Statement):
 
         .. versionchanged:: 2.6.0
             Added `custom_payload` as a parameter
+
+        .. versionchanged:: 3.29.2
+            Added `timestamp` as a parameter
         """
         self.batch_type = batch_type
+        self.timestamp = timestamp
         self._statements_and_parameters = []
         self._session = session
         Statement.__init__(self, retry_policy=retry_policy, consistency_level=consistency_level,


### PR DESCRIPTION
## Summary

- Converts `BatchQuery.execute()` from CQL string serialization to protocol-level `BatchStatement`
- Adds `timestamp` attribute to `BatchStatement` for batch-level timestamps
- Fixes type detection issues (e.g., `isinstance(query, BatchStatement)` check at cluster.py:5332)

## Changes

1. **cassandra/query.py**: Added `timestamp` attribute to `BatchStatement`
2. **cassandra/cluster.py**: Use `BatchStatement.timestamp` when available
3. **cassandra/cqlengine/connection.py**: Handle `BatchStatement` in `execute()`
4. **cassandra/cqlengine/query.py**: Refactor `BatchQuery.execute()` to use `BatchStatement`

## Benefits

- Better performance (no string serialization overhead)
- Proper type detection (`isinstance` checks for `BatchStatement` now work)
- Batch-level timestamps preserved through protocol

Fixes #208