### PR TITLE
Add frozen parameter to collection columns with FULL index support

### DIFF
--- a/cassandra/cqlengine/management.py
+++ b/cassandra/cqlengine/management.py
@@ -282,7 +282,11 @@ def _sync_table(model, connection=None):
 
         qs = ['CREATE INDEX']
         qs += ['ON {0}'.format(cf_name)]
-        qs += ['("{0}")'.format(column.db_field_name)]
+        # Use FULL index for frozen collections, VALUES index (implicit) for non-frozen
+        if isinstance(column, columns.BaseContainerColumn) and column.frozen:
+            qs += ['(FULL("{0}"))'.format(column.db_field_name)]
+        else:
+            qs += ['("{0}")'.format(column.db_field_name)]
         qs = ' '.join(qs)
         execute(qs, connection=connection)
 

--- a/tests/unit/cqlengine/test_columns.py
+++ b/tests/unit/cqlengine/test_columns.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from cassandra.cqlengine.columns import Column
+from cassandra.cqlengine.columns import Column, List, Set, Map, Text, Integer
 
 
 class ColumnTest(unittest.TestCase):
@@ -65,4 +65,45 @@ class ColumnTest(unittest.TestCase):
     def test_hash(self):
         c0 = Column()
         assert id(c0) == c0.__hash__()
+
+
+class FrozenCollectionTest(unittest.TestCase):
+    """Test frozen parameter for collection columns (List, Set, Map)."""
+
+    def test_list_default_not_frozen(self):
+        col = List(Text)
+        assert col.frozen is False
+        assert col.db_type == 'list<text>'
+
+    def test_list_frozen_true(self):
+        col = List(Text, frozen=True)
+        assert col.frozen is True
+        assert col.db_type == 'frozen<list<text>>'
+
+    def test_set_default_not_frozen(self):
+        col = Set(Text)
+        assert col.frozen is False
+        assert col.db_type == 'set<text>'
+
+    def test_set_frozen_true(self):
+        col = Set(Text, frozen=True)
+        assert col.frozen is True
+        assert col.db_type == 'frozen<set<text>>'
+
+    def test_map_default_not_frozen(self):
+        col = Map(Text, Integer)
+        assert col.frozen is False
+        assert col.db_type == 'map<text, int>'
+
+    def test_map_frozen_true(self):
+        col = Map(Text, Integer, frozen=True)
+        assert col.frozen is True
+        assert col.db_type == 'frozen<map<text, int>>'
+
+    def test_frozen_with_index(self):
+        """Test that frozen collections can be created with index=True."""
+        col = List(Text, frozen=True, index=True)
+        assert col.frozen is True
+        assert col.index is True
+        assert col.db_type == 'frozen<list<text>>'
 


### PR DESCRIPTION
## Summary

- Add `frozen` parameter to `List`, `Set`, and `Map` collection columns in cqlengine
- When `frozen=True`, collection is wrapped as `frozen<collection>`
- Indexes on frozen collections use `FULL(column)` instead of implicit VALUES indexing

## Example Usage

```python
class MyModel(Model):
    id = columns.Integer(primary_key=True)
    items = columns.List(columns.Text, frozen=True, index=True)
```

Generates:
```cql
CREATE TABLE mymodel (id int PRIMARY KEY, items frozen<list<text>>);
CREATE INDEX ON mymodel (FULL(items));
```

## Test plan

- [x] Unit tests added for frozen parameter on List, Set, and Map
- [x] Unit tests verify correct `db_type` generation
- [x] Integration tests needed to verify table/index creation with ScyllaDB

Fixes #677