### PR TITLE
Fix: Add missing serial_size() method to ShortType

### DIFF
--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -730,6 +730,10 @@ class ShortType(_CassandraType):
     def serialize(byts, protocol_version):
         return int16_pack(byts)
 
+    @classmethod
+    def serial_size(cls):
+        return 2
+
 class TimeType(_CassandraType):
     typename = 'time'
     # Time should be a fixed size 8 byte type but Cassandra 5.0 code marks it as


### PR DESCRIPTION
ShortType (smallint) is a fixed-size type (2 bytes) but was missing the serial_size() classmethod. This prevented optimizations that depend on knowing the fixed size of elements, such as the struct.unpack optimization in VectorType deserialization.

All other fixed-size numeric types (Int32Type, LongType, FloatType, DoubleType, BooleanType) already have serial_size() defined.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.