### PR TITLE
perf: Cache cassandra type parsing with LRU caching (hundreds of ns improvements - x1.1-1.6 speedup)

### DIFF
--- a/benchmarks/test_casstype_cache_benchmark.py
+++ b/benchmarks/test_casstype_cache_benchmark.py
@@ -1,0 +1,321 @@
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Benchmarks for lookup_casstype_simple / parse_casstype_args with and without
+LRU caching.
+
+Run with: pytest benchmarks/test_casstype_cache_benchmark.py -v
+
+Requires the ``pytest-benchmark`` plugin.
+Skipped automatically when the dependency is unavailable.
+"""
+
+import re
+
+import pytest
+
+pytest.importorskip("pytest_benchmark")
+
+from cassandra.cqltypes import (
+    apache_cassandra_type_prefix,
+    casstype_scanner,
+    lookup_casstype,
+    lookup_casstype_simple,
+    parse_casstype_args,
+    trim_if_startswith,
+    _casstypes,
+    mkUnrecognizedType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Reference: original uncached implementations
+# ---------------------------------------------------------------------------
+
+
+def lookup_casstype_simple_uncached(casstype):
+    """Original implementation without LRU cache."""
+    shortname = trim_if_startswith(casstype, apache_cassandra_type_prefix)
+    try:
+        typeclass = _casstypes[shortname]
+    except KeyError:
+        typeclass = mkUnrecognizedType(casstype)
+    return typeclass
+
+
+def parse_casstype_args_uncached(typestring):
+    """Original implementation without LRU cache."""
+    tokens, remainder = casstype_scanner.scan(typestring)
+    if remainder:
+        raise ValueError("weird characters %r at end" % remainder)
+
+    args = [([], [])]
+    for tok in tokens:
+        if tok == "(":
+            args.append(([], []))
+        elif tok == ")":
+            types, names = args.pop()
+            prev_types, prev_names = args[-1]
+            prev_types[-1] = prev_types[-1].apply_parameters(types, names)
+        else:
+            types, names = args[-1]
+            parts = re.split(":|=>", tok)
+            tok = parts.pop()
+            if parts:
+                names.append(parts[0])
+            else:
+                names.append(None)
+
+            try:
+                ctype = int(tok)
+            except ValueError:
+                ctype = lookup_casstype_simple_uncached(tok)
+            types.append(ctype)
+
+    return args[0][0][0]
+
+
+def lookup_casstype_uncached(casstype):
+    """Original lookup_casstype without any LRU caching underneath."""
+    from cassandra.cqltypes import CassandraType, CassandraTypeType
+
+    if isinstance(casstype, (CassandraType, CassandraTypeType)):
+        return casstype
+    if "(" not in casstype:
+        return lookup_casstype_simple_uncached(casstype)
+    try:
+        return parse_casstype_args_uncached(casstype)
+    except (ValueError, AssertionError, IndexError) as e:
+        raise ValueError("Don't know how to parse type string %r: %s" % (casstype, e))
+
+
+# ---------------------------------------------------------------------------
+# Test type strings
+# ---------------------------------------------------------------------------
+
+SIMPLE_TYPES = [
+    "UTF8Type",
+    "Int32Type",
+    "BooleanType",
+    "DoubleType",
+    "LongType",
+    "FloatType",
+    "TimestampType",
+    "UUIDType",
+    "InetAddressType",
+    "DecimalType",
+]
+
+SIMPLE_TYPES_FQ = [apache_cassandra_type_prefix + t for t in SIMPLE_TYPES]
+
+PARAMETERIZED_TYPES = [
+    "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.Int32Type)",
+    "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.UTF8Type)",
+    "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UUIDType)",
+    "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type))",
+]
+
+# Realistic mix: what a schema parse would encounter
+MIXED_TYPES = SIMPLE_TYPES_FQ + PARAMETERIZED_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Helper to clear any LRU caches on the module functions (no-op if uncached)
+# ---------------------------------------------------------------------------
+
+
+def _clear_caches():
+    """Clear LRU caches if they exist, otherwise no-op."""
+    for fn in (lookup_casstype_simple, parse_casstype_args):
+        if hasattr(fn, "cache_clear"):
+            fn.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Correctness tests
+# ---------------------------------------------------------------------------
+
+
+class TestCasstypeCacheCorrectness:
+    """Verify cached functions return the same types as uncached."""
+
+    @pytest.mark.parametrize("typestr", SIMPLE_TYPES)
+    def test_simple_type_matches(self, typestr):
+        _clear_caches()
+        assert lookup_casstype_simple(typestr) == lookup_casstype_simple_uncached(
+            typestr
+        )
+
+    @pytest.mark.parametrize("typestr", SIMPLE_TYPES_FQ)
+    def test_fq_simple_type_matches(self, typestr):
+        _clear_caches()
+        assert lookup_casstype_simple(typestr) == lookup_casstype_simple_uncached(
+            typestr
+        )
+
+    @pytest.mark.parametrize("typestr", PARAMETERIZED_TYPES)
+    def test_parameterized_type_matches(self, typestr):
+        _clear_caches()
+        cached = parse_casstype_args(typestr)
+        uncached = parse_casstype_args_uncached(typestr)
+        assert str(cached) == str(uncached)
+
+    @pytest.mark.parametrize("typestr", MIXED_TYPES)
+    def test_lookup_casstype_matches(self, typestr):
+        _clear_caches()
+        cached = lookup_casstype(typestr)
+        uncached = lookup_casstype_uncached(typestr)
+        assert str(cached) == str(uncached)
+
+
+# ---------------------------------------------------------------------------
+# Benchmarks: lookup_casstype_simple
+# ---------------------------------------------------------------------------
+
+
+class TestLookupCasstypeSimpleBenchmark:
+    """Benchmark lookup_casstype_simple cached vs uncached."""
+
+    # --- Short name (no prefix stripping) ---
+
+    @pytest.mark.benchmark(group="simple_short")
+    def test_uncached_short(self, benchmark):
+        benchmark(lookup_casstype_simple_uncached, "Int32Type")
+
+    @pytest.mark.benchmark(group="simple_short")
+    def test_cached_short(self, benchmark):
+        _clear_caches()
+        lookup_casstype_simple("Int32Type")  # warm cache
+        benchmark(lookup_casstype_simple, "Int32Type")
+
+    # --- Fully-qualified name (prefix stripping) ---
+
+    @pytest.mark.benchmark(group="simple_fq")
+    def test_uncached_fq(self, benchmark):
+        fq = apache_cassandra_type_prefix + "Int32Type"
+        benchmark(lookup_casstype_simple_uncached, fq)
+
+    @pytest.mark.benchmark(group="simple_fq")
+    def test_cached_fq(self, benchmark):
+        _clear_caches()
+        fq = apache_cassandra_type_prefix + "Int32Type"
+        lookup_casstype_simple(fq)  # warm cache
+        benchmark(lookup_casstype_simple, fq)
+
+    # --- Batch of 10 different types ---
+
+    @pytest.mark.benchmark(group="simple_batch10")
+    def test_uncached_batch10(self, benchmark):
+        def run():
+            for t in SIMPLE_TYPES:
+                lookup_casstype_simple_uncached(t)
+
+        benchmark(run)
+
+    @pytest.mark.benchmark(group="simple_batch10")
+    def test_cached_batch10(self, benchmark):
+        _clear_caches()
+        for t in SIMPLE_TYPES:
+            lookup_casstype_simple(t)  # warm cache
+
+        def run():
+            for t in SIMPLE_TYPES:
+                lookup_casstype_simple(t)
+
+        benchmark(run)
+
+
+# ---------------------------------------------------------------------------
+# Benchmarks: parse_casstype_args
+# ---------------------------------------------------------------------------
+
+
+class TestParseCasstypeArgsBenchmark:
+    """Benchmark parse_casstype_args cached vs uncached."""
+
+    # --- Simple parameterized type: MapType(UTF8Type, Int32Type) ---
+
+    @pytest.mark.benchmark(group="parse_map")
+    def test_uncached_map(self, benchmark):
+        benchmark(parse_casstype_args_uncached, PARAMETERIZED_TYPES[0])
+
+    @pytest.mark.benchmark(group="parse_map")
+    def test_cached_map(self, benchmark):
+        _clear_caches()
+        parse_casstype_args(PARAMETERIZED_TYPES[0])  # warm cache
+        benchmark(parse_casstype_args, PARAMETERIZED_TYPES[0])
+
+    # --- Nested: MapType(UTF8Type, ListType(Int32Type)) ---
+
+    @pytest.mark.benchmark(group="parse_nested")
+    def test_uncached_nested(self, benchmark):
+        benchmark(parse_casstype_args_uncached, PARAMETERIZED_TYPES[3])
+
+    @pytest.mark.benchmark(group="parse_nested")
+    def test_cached_nested(self, benchmark):
+        _clear_caches()
+        parse_casstype_args(PARAMETERIZED_TYPES[3])  # warm cache
+        benchmark(parse_casstype_args, PARAMETERIZED_TYPES[3])
+
+    # --- Batch of all 4 parameterized types ---
+
+    @pytest.mark.benchmark(group="parse_batch4")
+    def test_uncached_batch4(self, benchmark):
+        def run():
+            for t in PARAMETERIZED_TYPES:
+                parse_casstype_args_uncached(t)
+
+        benchmark(run)
+
+    @pytest.mark.benchmark(group="parse_batch4")
+    def test_cached_batch4(self, benchmark):
+        _clear_caches()
+        for t in PARAMETERIZED_TYPES:
+            parse_casstype_args(t)  # warm cache
+
+        def run():
+            for t in PARAMETERIZED_TYPES:
+                parse_casstype_args(t)
+
+        benchmark(run)
+
+
+# ---------------------------------------------------------------------------
+# Benchmarks: lookup_casstype (end-to-end, realistic mix)
+# ---------------------------------------------------------------------------
+
+
+class TestLookupCasstypeBenchmark:
+    """Benchmark the full lookup_casstype with a realistic type mix."""
+
+    @pytest.mark.benchmark(group="lookup_mixed")
+    def test_uncached_mixed(self, benchmark):
+        def run():
+            for t in MIXED_TYPES:
+                lookup_casstype_uncached(t)
+
+        benchmark(run)
+
+    @pytest.mark.benchmark(group="lookup_mixed")
+    def test_cached_mixed(self, benchmark):
+        _clear_caches()
+        for t in MIXED_TYPES:
+            lookup_casstype(t)  # warm cache
+
+        def run():
+            for t in MIXED_TYPES:
+                lookup_casstype(t)
+
+        benchmark(run)

--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -33,6 +33,7 @@ from binascii import unhexlify
 import calendar
 from collections import namedtuple
 from decimal import Decimal
+import functools
 import io
 from itertools import chain
 import logging
@@ -185,6 +186,20 @@ def strip_frozen(cql):
     return cql
 
 
+# Type strings passed to these two functions normally come from a small,
+# schema-bounded set (the distinct column/argument types declared across a
+# cluster's keyspaces). However the CUSTOM_TYPE branch in protocol.py, and
+# unrecognized "org.apache.cassandra.db.marshal.*" names in general, pass a
+# server-supplied class name straight through to lookup_casstype_simple()
+# without validation, so the cache is deliberately bounded (rather than
+# maxsize=None) to cap worst-case memory growth if a misbehaving or
+# malicious server sends many distinct/bogus type names. The bound is large
+# enough that realistic schemas (many tables/keyspaces, but far fewer
+# distinct type strings) won't thrash it in practice.
+_CASSTYPE_CACHE_MAXSIZE = 4096
+
+
+@functools.lru_cache(maxsize=_CASSTYPE_CACHE_MAXSIZE)
 def lookup_casstype_simple(casstype):
     """
     Given a Cassandra type name (either fully distinguished or not), hand
@@ -203,6 +218,7 @@ def lookup_casstype_simple(casstype):
     return typeclass
 
 
+@functools.lru_cache(maxsize=_CASSTYPE_CACHE_MAXSIZE)
 def parse_casstype_args(typestring):
     tokens, remainder = casstype_scanner.scan(typestring)
     if remainder:
@@ -215,7 +231,7 @@ def parse_casstype_args(typestring):
             args.append(([], []))
         elif tok == ')':
             types, names = args.pop()
-            prev_types, prev_names = args[-1]
+            prev_types, _ = args[-1]
             prev_types[-1] = prev_types[-1].apply_parameters(types, names)
         else:
             types, names = args[-1]
@@ -1001,6 +1017,13 @@ class UserType(TupleType):
             del cls._cache[(keyspace, udt_name)]
         except KeyError:
             pass
+        # parse_casstype_args() (used when resolving UDT columns from schema
+        # type strings) is LRU-cached and may already hold a memoized class
+        # built from the entry we just evicted. Clear it too, otherwise a
+        # later parse of the same type string would keep returning the
+        # stale, pre-eviction class instead of going through
+        # make_udt_class() again.
+        parse_casstype_args.cache_clear()
 
     @classmethod
     def apply_parameters(cls, subtypes, names):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -17,13 +17,13 @@ import datetime
 import tempfile
 import time
 import uuid
-from binascii import unhexlify
+from binascii import hexlify, unhexlify
 
 import cassandra
 from cassandra import util
 from cassandra.cqltypes import (
     CassandraType, DateRangeType, DateType, DecimalType,
-    EmptyValue, LongType, SetType, UTF8Type,
+    EmptyValue, LongType, SetType, UTF8Type, UserType,
     cql_typename, int8_pack, int64_pack, int64_unpack, lookup_casstype,
     lookup_casstype_simple, parse_casstype_args,
     int32_pack, Int32Type, ListType, MapType, VectorType,
@@ -191,6 +191,88 @@ class TypeTests(unittest.TestCase):
 
         assert UTF8Type == ctype.subtypes[2]
         assert [b'city', None, b'zip'] == ctype.names
+
+    def test_lookup_casstype_simple_is_cached_and_consistent(self):
+        """
+        lookup_casstype_simple() is decorated with functools.lru_cache().
+        Repeated calls with the same string must keep returning a type
+        that is equal to (and, for cache hits, literally the same object
+        as) what an uncached call would produce, and cache_info() should
+        reflect the hits/misses.
+        """
+        lookup_casstype_simple.cache_clear()
+
+        first = lookup_casstype_simple('Int32Type')
+        second = lookup_casstype_simple('Int32Type')
+        assert first is Int32Type
+        assert second is first
+
+        info = lookup_casstype_simple.cache_info()
+        assert info.hits >= 1
+        assert info.misses >= 1
+
+        # An unrecognized/custom type name is memoized too: repeated lookups
+        # of the same unknown name return the identical placeholder class.
+        custom_first = lookup_casstype_simple('com.example.MyCustomType')
+        custom_second = lookup_casstype_simple('com.example.MyCustomType')
+        assert custom_second is custom_first
+
+    def test_parse_casstype_args_is_cached_and_consistent(self):
+        """
+        parse_casstype_args() is decorated with functools.lru_cache(). The
+        same type string must always resolve to an equivalent (and, on a
+        cache hit, identical) type.
+        """
+        parse_casstype_args.cache_clear()
+        type_str = "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.Int32Type)"
+
+        first = parse_casstype_args(type_str)
+        second = parse_casstype_args(type_str)
+        assert second is first
+        assert issubclass(first, MapType)
+        assert list(first.subtypes) == [UTF8Type, Int32Type]
+
+        info = parse_casstype_args.cache_info()
+        assert info.hits >= 1
+
+    def test_parse_casstype_args_udt_cache_invalidated_on_evict(self):
+        """
+        cassandra.cluster.Cluster.register_user_type() invalidates the
+        per-(keyspace, udt_name) class cache in UserType via
+        evict_udt_class(). Since parse_casstype_args() is now LRU-cached,
+        it must also stop returning the stale, pre-eviction class for a UDT
+        type string once evict_udt_class() has been called for that UDT --
+        otherwise the eviction would be silently masked by the cache.
+        """
+        keyspace = 'ks1'
+        udt_name = 'cache_invalidation_test_type'
+        field_name = 'a'
+        type_str = "org.apache.cassandra.db.marshal.UserType(%s,%s,%s:org.apache.cassandra.db.marshal.Int32Type)" % (
+            keyspace,
+            hexlify(udt_name.encode()).decode(),
+            hexlify(field_name.encode()).decode(),
+        )
+
+        parse_casstype_args.cache_clear()
+        try:
+            first = parse_casstype_args(type_str)
+            assert first.fieldnames == (field_name,)
+            assert first.subtypes == (Int32Type,)
+
+            # cache hit: identical object back
+            assert parse_casstype_args(type_str) is first
+
+            UserType.evict_udt_class(keyspace, udt_name)
+
+            # Must not be the stale, cached-before-eviction class.
+            second = parse_casstype_args(type_str)
+            assert second is not first
+            # ...but still correctly resolved.
+            assert second.fieldnames == (field_name,)
+            assert second.subtypes == (Int32Type,)
+        finally:
+            UserType.evict_udt_class(keyspace, udt_name)
+            parse_casstype_args.cache_clear()
 
     def test_parse_casstype_vector(self):
         ctype = parse_casstype_args("org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 3)")


### PR DESCRIPTION
## Summary

Cache `lookup_casstype_simple()` and `parse_casstype_args()` with `@functools.lru_cache()` to avoid repeated string manipulation and regex scanning when the same type strings are resolved multiple times (common during schema parsing and query result deserialization).

The fast-path for simple types (without parentheses) was already merged separately. This PR adds caching on top of that.

Also fixes an unused variable warning (`prev_names` → `_`).

Includes a pytest-benchmark comparison (cached vs uncached).

## Changes

- **`cassandra/cqltypes.py`**: Added `import functools`, `@functools.lru_cache(maxsize=4096)` on `lookup_casstype_simple()` and `parse_casstype_args()`, fixed unused `prev_names` variable, and fixed `UserType.evict_udt_class()` to also clear the `parse_casstype_args()` cache (see "Cache correctness" below).
- **`benchmarks/test_casstype_cache_benchmark.py`**: New benchmark file with correctness tests and cached vs uncached performance comparisons.
- **`tests/unit/test_types.py`**: Added unit tests covering cache hit/miss behavior and the UDT eviction/invalidation interaction described below.

## Benchmark results

### `lookup_casstype_simple` — clear wins from cache

| Benchmark | Cached | Uncached | Speedup |
|---|---|---|---|
| Short name (`UTF8Type`) | 135 ns | 217 ns | **1.6x** |
| Fully-qualified name (`o.a.c.db.marshal.UTF8Type`) | 274 ns | 414 ns | **1.5x** |
| Batch of 10 types | 1.57 µs | 1.83 µs | **1.2x** |

### `parse_casstype_args` — modest gains for parameterized types

| Benchmark | Cached | Uncached | Speedup |
|---|---|---|---|
| MapType(UTF8,Int32) | 26.9 µs | 29.1 µs | 1.08x |
| Nested MapType(UTF8,ListType(Int32)) | 46.9 µs | 55.6 µs | 1.19x |

### End-to-end `lookup_casstype` (mixed simple + parameterized)

| Benchmark | Cached | Uncached | Speedup |
|---|---|---|---|
| Mixed batch (simple + parameterized) | 296 µs | 321 µs | 1.08x |

The biggest gains are on `lookup_casstype_simple`, which is called most frequently (every column in every row). The `parse_casstype_args` cache helps for parameterized types (maps, lists, sets, tuples) where the regex scanner is the bottleneck.

## Cache bound (corrected from an earlier revision)

An earlier revision of this PR called `lru_cache()` with no arguments and described that as "unbounded... no risk of unbounded memory growth." That claim was wrong on both counts: `functools.lru_cache()` with no arguments defaults to `maxsize=128` (not unbounded), and 128 is small enough that a schema with more than 128 distinct type strings (easy to hit with more than a handful of tables/UDTs) would thrash the cache.

Both caches now use an explicit `maxsize=4096`. This is deliberately bounded rather than `maxsize=None`/unbounded: type strings reaching these functions aren't always schema-bounded — `protocol.py`'s `CUSTOM_TYPE` branch passes a server-supplied class name straight to `lookup_casstype()`/`lookup_casstype_simple()` with no validation, so an unbounded cache would let a misbehaving or malicious server grow the cache without limit. 4096 is generous enough to avoid thrashing on realistic schemas while still capping worst-case memory growth.

## Cache correctness (UDT invalidation)

`UserType` already has its own per-`(keyspace, udt_name)` class cache (`UserType._cache`), with an explicit `evict_udt_class()` invalidation hook called from `Cluster.register_user_type()`. Since `parse_casstype_args()` is now also cached, and it's the function that (via `apply_parameters` → `make_udt_class`) produces the class for a `UserType(...)` type string, the new LRU cache could return a stale, pre-eviction class for a type string that was already cached before `evict_udt_class()` ran — silently masking the eviction. Row (de)serialization itself is unaffected (it goes through `protocol.py`'s `read_type()`, which calls `make_udt_class()` directly and always refreshes `mapped_class`), but schema-metadata resolution via `lookup_casstype()`/`parse_casstype_args()` was not.

Fixed by clearing `parse_casstype_args`'s cache inside `evict_udt_class()`. Verified with a reproduction (confirmed the bug existed pre-fix, and no longer does), and added a regression test (`test_parse_casstype_args_udt_cache_invalidated_on_evict`).
