### PR TITLE
fix: https://python-driver.docs.scylladb.com/ returns 404

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,11 +28,10 @@ TAGS = [
     '3.29.5-scylla',
     '3.29.6-scylla',
     '3.29.7-scylla',
-    '3.29.8-scylla',
 ]
 BRANCHES = ['master']
 # Set the latest version.
-LATEST_VERSION = '3.29.8-scylla'
+LATEST_VERSION = '3.29.7-scylla'
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ['master']
 # Set which versions are deprecated


### PR DESCRIPTION
The current version in [conf.py](https://github.com/scylladb/python-driver/blob/master/docs/conf.py#L35) is:

> LATEST_VERSION = '3.29.8-scylla'

This version tag does not exist in the releases: https://github.com/scylladb/python-driver/releases, causing 404 errors. This change sets it back to 3.29.7.

