### PR TITLE
tests: enable vector integration tests on Scylla 2025.4+

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -279,6 +279,11 @@ greaterthanorequalcass3_10 = unittest.skipUnless(CASSANDRA_VERSION >= Version('3
 greaterthanorequalcass3_11 = unittest.skipUnless(CASSANDRA_VERSION >= Version('3.11'), 'Cassandra version 3.11 or greater required')
 greaterthanorequalcass40 = unittest.skipUnless(CASSANDRA_VERSION >= Version('4.0'), 'Cassandra version 4.0 or greater required')
 greaterthanorequalcass50 = unittest.skipUnless(CASSANDRA_VERSION >= Version('5.0-beta'), 'Cassandra version 5.0 or greater required')
+def _has_vector_type():
+    if SCYLLA_VERSION is not None:
+        return Version(get_scylla_version(SCYLLA_VERSION)) >= Version('2025.4')
+    return CASSANDRA_VERSION >= Version('5.0-beta')
+
 lessthanorequalcass40 = unittest.skipUnless(CASSANDRA_VERSION <= Version('4.0'), 'Cassandra version less or equal to 4.0 required')
 lessthancass40 = unittest.skipUnless(CASSANDRA_VERSION < Version('4.0'), 'Cassandra version less than 4.0 required')
 lessthancass30 = unittest.skipUnless(CASSANDRA_VERSION < Version('3.0'), 'Cassandra version less then 3.0 required')
@@ -297,6 +302,9 @@ requires_composite_type = pytest.mark.skipif(SCYLLA_VERSION is not None,
                                             reason='Scylla does not support composite types')
 requires_custom_payload = pytest.mark.skipif(SCYLLA_VERSION is not None or PROTOCOL_VERSION < 4,
                                             reason='Scylla does not support custom payloads. Cassandra requires native protocol v4.0+')
+requires_vector_type = unittest.skipUnless(
+    _has_vector_type(),
+    'Cassandra >= 5.0 or Scylla >= 2025.4 required')
 xfail_scylla = lambda reason, *args, **kwargs: pytest.mark.xfail(SCYLLA_VERSION is not None, reason=reason, *args, **kwargs)
 incorrect_test = lambda reason='This test seems to be incorrect and should be fixed', *args, **kwargs: pytest.mark.xfail(reason=reason, *args, **kwargs)
 

--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -40,7 +40,8 @@ from tests.util import assertEqual
 
 from tests.integration import use_singledc, execute_until_pass, notprotocolv1, \
     BasicSharedKeyspaceUnitTestCase, greaterthancass21, lessthancass30, \
-    greaterthanorequalcass3_10, TestCluster, requires_composite_type, greaterthanorequalcass50
+    greaterthanorequalcass3_10, TestCluster, requires_composite_type, \
+    requires_vector_type
 from tests.integration.datatype_utils import update_datatypes, PRIMITIVE_DATATYPES, COLLECTION_TYPES, PRIMITIVE_DATATYPES_KEYS, \
     get_sample, get_all_samples, get_collection_sample
 import pytest
@@ -984,7 +985,7 @@ class TypeTestsProtocol(BasicSharedKeyspaceUnitTestCase):
         finally:
             session.cluster.shutdown()
 
-@greaterthanorequalcass50
+@requires_vector_type
 class TypeTestsVector(BasicSharedKeyspaceUnitTestCase):
 
     def _get_first_j(self, rs):


### PR DESCRIPTION
Vector type is supported on Scylla 2025.4 and above. Enable the integration tests.

Tested locally against both 2025.4.2 and 2026.1 and they pass.
Tested locally against 2025.1, where it is skipped, as it should be.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.