### PR TITLE
Preserve meaningful last_error in LibevConnection close paths

### DIFF
--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -300,7 +300,10 @@ class LibevConnection(Connection):
             msg = "Connection to %s was closed" % self.endpoint
             if self.last_error:
                 msg += ": %s" % (self.last_error,)
-            self.error_all_requests(ConnectionShutdown(msg))
+            shutdown_exc = ConnectionShutdown(msg)
+            self.error_all_requests(shutdown_exc)
+            if not self.connected_event.is_set():
+                self.last_error = shutdown_exc
             self.connected_event.set()
 
     def handle_write(self, watcher, revents, errno=None):
@@ -378,6 +381,8 @@ class LibevConnection(Connection):
             self.process_io_buffer()
         else:
             log.debug("Connection %s closed by server", self)
+            self.last_error = ConnectionShutdown(
+                "Connection to %s was closed by server" % self.endpoint)
             self.close()
 
     def push(self, data):


### PR DESCRIPTION
## Summary
Improves error reporting in LibevConnection so that users see a clear `ConnectionShutdown` message instead of a confusing `[Errno 9] Bad file descriptor` when connections close during node restarts.

The libev reactor was already safe from the EBADF race — `defunct()` returns early when `is_closed` is true, and the single-threaded event loop + `_loop_will_run()` design prevents watchers from firing on closed fds. The actual problem was that `last_error` wasn't set to a meaningful value in two close paths, so the stale EBADF string leaked up to `factory()` and confused users.

## Changes
- Set `last_error` in `close()` when `connected_event` is not yet set, so `factory()` reports `ConnectionShutdown` instead of whatever stale error was on the connection
- Set `last_error` on server-initiated close (EOF) in `handle_read()` before calling `close()`

## Test plan
- [x] `tests/unit/io/test_libevreactor.py` passes

Refs #614