### PR TITLE
Fix TwistedConnection close() not setting last_error

### DIFF
--- a/cassandra/io/twistedreactor.py
+++ b/cassandra/io/twistedreactor.py
@@ -286,7 +286,10 @@ class TwistedConnection(Connection):
             msg = "Connection to %s was closed" % self.endpoint
             if self.last_error:
                 msg += ": %s" % (self.last_error,)
-            self.error_all_requests(ConnectionShutdown(msg))
+            shutdown_exc = ConnectionShutdown(msg)
+            self.error_all_requests(shutdown_exc)
+            if not self.connected_event.is_set():
+                self.last_error = shutdown_exc
             # don't leave in-progress operations hanging
             self.connected_event.set()
 


### PR DESCRIPTION
## Summary
Fixes TwistedConnection.close() not setting `last_error` when the connection is closed during setup.

- When close() is called before `connected_event` is set, `factory()` could return a dead connection because `last_error` was never set
- Twisted is not vulnerable to EBADF races (no raw socket I/O), but the factory() dead-connection bug affects it

## Changes
- Set `last_error` in `close()` when `connected_event` is not yet set (matching the asyncore pattern)

## Test plan
- [x] `tests/unit/io/test_twistedreactor.py` passes

Refs #614