### PR TITLE
Fix factory() returning dead connections on close during setup

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -866,6 +866,9 @@ class Connection(object):
             if conn.is_unsupported_proto_version:
                 raise ProtocolVersionUnsupported(endpoint, conn.protocol_version)
             raise conn.last_error
+        elif conn.is_closed or conn.is_defunct:
+            raise ConnectionShutdown(
+                "Connection to %s was closed during setup" % (endpoint,))
         elif not conn.connected_event.is_set():
             conn.close()
             raise OperationTimedOut("Timed out creating connection (%s seconds)" % timeout)


### PR DESCRIPTION
## Summary
Fixes `Connection.factory()` returning a closed/defunct connection instead of raising an error.

After `connected_event.wait()` returns, `factory()` checks `last_error` and whether the event timed out. But if `close()` was called (not `defunct()`) and the reactor didn't set `last_error`, factory() falls through to `return conn` — returning a dead connection that fails immediately on use.

This is a defense-in-depth fix that catches the case regardless of whether individual reactors properly set `last_error` in their `close()` methods.

## Changes
- Add `is_closed`/`is_defunct` check after the `last_error` check in `factory()`
- Raise `ConnectionShutdown` instead of returning a dead connection

## Test plan
- [x] `tests/unit/test_connection.py` passes
- [x] `tests/unit/test_cluster.py` passes

Refs #614