### PR TITLE
Remove deprecated setup_requires in favor of PEP 517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ cache-keys = [
     { env = "CASS_DRIVER_NO_CYTHON" },
     { env = "CASS_DRIVER_BUILD_CONCURRENCY" },
     { env = "CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST" },
-    { env = "CASS_DRIVER_ALLOWED_CYTHON_VERSION" },
 
     # used by setuptools_scm
     { git = { commit = true, tags = true } },


### PR DESCRIPTION
## Summary

Removes the deprecated `setup_requires` mechanism from `setup.py` in favor of the PEP 517 build system already configured in `pyproject.toml`.

### Background

[PEP 517](https://peps.python.org/pep-0517/) standardized how Python packages declare build dependencies via `pyproject.toml`'s `[build-system].requires`. Before PEP 517, `setup_requires` in `setup()` was the way to pull in build-time dependencies like Cython. setuptools implemented this through `fetch_build_eggs`, which downloaded eggs at build time — bypassing pip's dependency resolver and causing various issues.

Starting with setuptools 70, using `setup_requires` emits a deprecation warning:

> setuptools.installer and fetch_build_eggs are deprecated. Requirements should be satisfied by a PEP 517 installer.

Our `pyproject.toml` already declares Cython as a PEP 517 build dependency:

```toml
[build-system]
requires = ["setuptools>=70", "Cython"]
```

This means any PEP 517 compliant installer (pip, uv, build) will install Cython before `setup.py` runs, making `setup_requires` redundant.

### Changes

- **Remove `setup_requires=['Cython>=3.0.11,<4']`** from the `setup()` call in `run_setup()` — redundant with `[build-system].requires` and the source of the deprecation warning
- **Remove `pre_build_check()` function** — only existed to gate `setup_requires`; compiler availability is still handled gracefully by `build_extensions.build_extension()` which catches and reports compilation failures
- **Remove `egg_info` bypass** (`try_cython &= 'egg_info' not in sys.argv`) — existed to prevent `setup_requires` from triggering during pip's metadata phase, no longer relevant
- **Remove `CASS_DRIVER_ALLOWED_CYTHON_VERSION` env var** — only affected the `setup_requires` Cython version pin; users who need a specific Cython version can use `UV_CONSTRAINT`, `PIP_CONSTRAINT`, or pre-install it before building

### What stays the same

- The `build_extensions` class and `_setup_extensions()` — these dynamically discover and compile Cython extensions at build time, which works fine under PEP 517
- The `try_cython` flag and `CASS_DRIVER_NO_CYTHON` env var — still controls whether Cython modules are built
- The dummy extension trick (`ext_modules=[Extension('DUMMY', [])]`) — still needed so setuptools invokes `build_ext`

Fixes #694

## Test plan

- [x] `uv sync` completes without PEP 517 deprecation warning
- [x] `python setup.py build_ext --inplace` completes without deprecation warning
- [x] Unit tests pass (590 passed, pre-existing failures unrelated)