### PR TITLE
Fix floating-point precision loss for timestamps far from epoch

### DIFF
--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -636,24 +636,24 @@ class DateType(_CassandraType):
             except ValueError:
                 continue
             # scale seconds to millis for the raw value
-            return (calendar.timegm(tval) + offset) * 1e3
+            return (calendar.timegm(tval) + offset) * 1000
         else:
             raise ValueError("can't interpret %r as a date" % (val,))
 
     @staticmethod
     def deserialize(byts, protocol_version):
-        timestamp = int64_unpack(byts) / 1000.0
-        return util.datetime_from_timestamp(timestamp)
+        timestamp_ms = int64_unpack(byts)
+        return util.datetime_from_ms_timestamp(timestamp_ms)
 
     @staticmethod
     def serialize(v, protocol_version):
         try:
             # v is datetime
             timestamp_seconds = calendar.timegm(v.utctimetuple())
-            timestamp = timestamp_seconds * 1e3 + getattr(v, 'microsecond', 0) / 1e3
+            timestamp = timestamp_seconds * 1000 + getattr(v, 'microsecond', 0) // 1000
         except AttributeError:
             try:
-                timestamp = calendar.timegm(v.timetuple()) * 1e3
+                timestamp = calendar.timegm(v.timetuple()) * 1000
             except AttributeError:
                 # Ints and floats are valid timestamps too
                 if type(v) not in _number_types:

--- a/cassandra/cython_utils.pxd
+++ b/cassandra/cython_utils.pxd
@@ -1,2 +1,3 @@
 from libc.stdint cimport int64_t
 cdef datetime_from_timestamp(double timestamp)
+cdef datetime_from_ms_timestamp(int64_t timestamp_ms)

--- a/cassandra/cython_utils.pyx
+++ b/cassandra/cython_utils.pyx
@@ -60,3 +60,22 @@ cdef datetime_from_timestamp(double timestamp):
     microseconds += <int>tmp
 
     return DATETIME_EPOC + timedelta_new(days, seconds, microseconds)
+
+
+cdef datetime_from_ms_timestamp(int64_t timestamp_ms):
+    """
+    Creates a datetime from a timestamp in milliseconds using integer
+    arithmetic to preserve precision for large values.
+    """
+    cdef int64_t total_seconds = timestamp_ms // 1000
+    cdef int microseconds = <int>((timestamp_ms % 1000) * 1000)
+    # For negative timestamps, ensure microseconds is non-negative
+    if microseconds < 0:
+        total_seconds -= 1
+        microseconds += 1000000
+    cdef int days = <int>(total_seconds // 86400)
+    cdef int seconds = <int>(total_seconds % 86400)
+    if seconds < 0:
+        days -= 1
+        seconds += 86400
+    return DATETIME_EPOC + timedelta_new(days, seconds, microseconds)

--- a/cassandra/deserializers.pyx
+++ b/cassandra/deserializers.pyx
@@ -17,7 +17,7 @@ from libc.stdint cimport int32_t, uint16_t
 
 include 'cython_marshal.pyx'
 from cassandra.buffer cimport Buffer, to_bytes, slice_buffer
-from cassandra.cython_utils cimport datetime_from_timestamp
+from cassandra.cython_utils cimport datetime_from_timestamp, datetime_from_ms_timestamp
 
 from cython.view cimport array as cython_array
 from cassandra.tuple cimport tuple_new, tuple_set
@@ -135,8 +135,8 @@ cdef class DesCounterColumnType(DesLongType):
 
 cdef class DesDateType(Deserializer):
     cdef deserialize(self, Buffer *buf, int protocol_version):
-        cdef double timestamp = unpack_num[int64_t](buf) / 1000.0
-        return datetime_from_timestamp(timestamp)
+        cdef int64_t timestamp_ms = unpack_num[int64_t](buf)
+        return datetime_from_ms_timestamp(timestamp_ms)
 
 
 cdef class TimestampType(DesDateType):

--- a/cassandra/encoder.py
+++ b/cassandra/encoder.py
@@ -142,7 +142,7 @@ class Encoder(object):
         with millisecond precision.
         """
         timestamp = calendar.timegm(val.utctimetuple())
-        return str(int(timestamp * 1e3 + getattr(val, 'microsecond', 0) / 1e3))
+        return str(timestamp * 1000 + getattr(val, 'microsecond', 0) // 1000)
 
     def cql_encode_date(self, val):
         """

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -62,6 +62,16 @@ def datetime_from_timestamp(timestamp):
     return dt
 
 
+def datetime_from_ms_timestamp(timestamp_ms):
+    """
+    Creates a timezone-agnostic datetime from a timestamp in milliseconds,
+    using integer arithmetic to preserve precision for large values.
+
+    :param timestamp_ms: a unix timestamp, in milliseconds (integer)
+    """
+    return DATETIME_EPOC + datetime.timedelta(milliseconds=timestamp_ms)
+
+
 def utc_datetime_from_ms_timestamp(timestamp):
     """
     Creates a UTC datetime from a timestamp in milliseconds. See

--- a/tests/unit/cython/test_utils.py
+++ b/tests/unit/cython/test_utils.py
@@ -24,3 +24,7 @@ class UtilsTest(unittest.TestCase):
     @cythontest
     def test_datetime_from_timestamp(self):
         utils_testhelper.test_datetime_from_timestamp()
+
+    @cythontest
+    def test_datetime_from_ms_timestamp(self):
+        utils_testhelper.test_datetime_from_ms_timestamp()

--- a/tests/unit/cython/utils_testhelper.pyx
+++ b/tests/unit/cython/utils_testhelper.pyx
@@ -14,10 +14,23 @@
 
 import datetime
 
-from cassandra.cython_utils cimport datetime_from_timestamp
+from cassandra.cython_utils cimport datetime_from_timestamp, datetime_from_ms_timestamp
 
 
 def test_datetime_from_timestamp():
     assert datetime_from_timestamp(1454781157.123456) == datetime.datetime(2016, 2, 6, 17, 52, 37, 123456)
     # PYTHON-452
     assert datetime_from_timestamp(2177403010.123456) == datetime.datetime(2038, 12, 31, 10, 10, 10, 123456)
+
+
+def test_datetime_from_ms_timestamp():
+    # epoch
+    assert datetime_from_ms_timestamp(0) == datetime.datetime(1970, 1, 1)
+    # positive with millisecond precision
+    assert datetime_from_ms_timestamp(1454781157123) == datetime.datetime(2016, 2, 6, 17, 52, 37, 123000)
+    # large positive far from epoch (GH-532)
+    assert datetime_from_ms_timestamp(10413792000001) == datetime.datetime(2300, 1, 1, 0, 0, 0, 1000)
+    # negative timestamp
+    assert datetime_from_ms_timestamp(-770172256000) == datetime.datetime(1945, 8, 5, 23, 15, 44)
+    # large negative with millisecond precision
+    assert datetime_from_ms_timestamp(-11676095999999) == datetime.datetime(1600, 1, 1, 0, 0, 0, 1000)

--- a/tests/unit/test_time_util.py
+++ b/tests/unit/test_time_util.py
@@ -36,6 +36,19 @@ class TimeUtilTest(unittest.TestCase):
 
         assert util.datetime_from_timestamp(2177403010.123456) == datetime.datetime(2038, 12, 31, 10, 10, 10, 123456)
 
+    def test_datetime_from_ms_timestamp(self):
+        # epoch
+        assert util.datetime_from_ms_timestamp(0) == datetime.datetime(1970, 1, 1)
+        # positive with millisecond precision
+        assert util.datetime_from_ms_timestamp(1000) == datetime.datetime(1970, 1, 1, 0, 0, 1)
+        assert util.datetime_from_ms_timestamp(1454781157123) == datetime.datetime(2016, 2, 6, 17, 52, 37, 123000)
+        # large positive far from epoch (GH-532) - must not lose precision
+        assert util.datetime_from_ms_timestamp(10413792000001) == datetime.datetime(2300, 1, 1, 0, 0, 0, 1000)
+        # negative timestamp
+        assert util.datetime_from_ms_timestamp(-770172256000) == datetime.datetime(1945, 8, 5, 23, 15, 44)
+        # large negative with millisecond precision
+        assert util.datetime_from_ms_timestamp(-11676095999999) == datetime.datetime(1600, 1, 1, 0, 0, 0, 1000)
+
     def test_times_from_uuid1(self):
         node = uuid.getnode()
         now = time.time()


### PR DESCRIPTION
## Summary
- Replace float arithmetic (`1e3`, `/1000.0`) with integer arithmetic (`1000`, `//1000`) in `DateType` serialize/deserialize and `Encoder.cql_encode_datetime` to prevent millisecond precision loss for dates far from the Unix epoch (e.g. year 2300+)
- Add `datetime_from_ms_timestamp()` in both pure-Python (`util.py`) and Cython (`cython_utils.pyx`) that operates on integer milliseconds directly, avoiding the lossy float-seconds intermediate representation
- The Cython variant decomposes milliseconds into days/seconds/microseconds and calls the fast `timedelta_new()` C API to avoid performance regression on the hot deserialization path

Fixes #532

## Test plan
- [x] New unit tests for large positive timestamps (year 2300) with round-trip verification
- [x] New unit tests for large negative timestamps (year 1600) with full datetime assertion
- [x] Direct unit tests for `util.datetime_from_ms_timestamp` (epoch, positive, large positive, negative, large negative)
- [x] Cython-specific tests for `datetime_from_ms_timestamp` via `utils_testhelper.pyx`
- [x] All existing `DateType` and `TimeUtil` tests pass