### PR TITLE
Use explicit sort key in ConcurrentExecutorListResults

### DIFF
--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -204,7 +204,7 @@ class ConcurrentExecutorListResults(_ConcurrentExecutor):
                     raise self._exception
         if self._exception and self._fail_fast:  # raise the exception even if there was no wait
             raise self._exception
-        return [r[1] for r in sorted(self._results_queue)]
+        return [r[1] for r in sorted(self._results_queue, key=lambda x: x[0])]
 
 
 


### PR DESCRIPTION
## Summary

Fixes bug in response handling:
```
TypeError: '<' not supported between instances of 'dict' and 'list'
```

- Sort results by index only via `key=lambda x: x[0]`, avoiding unnecessary comparison of `ExecutionResult` namedtuples which could fail on heterogeneous result/exception types

Fixes #715

## Test plan
- [x] Existing `execute_concurrent` tests cover correctness of result ordering
- [x] Single-line defensive change — no behavioral difference for normal operation