### PR TITLE
(improvement) cluster: cache parsed tablet routing type in ResponseFu…

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -4345,6 +4345,7 @@ class ResponseFuture(object):
     _spec_execution_plan = NoSpeculativeExecutionPlan()
     _continuous_paging_session = None
     _host = None
+    _TABLET_ROUTING_CTYPE = None
 
     _warned_timeout = False
 
@@ -4642,7 +4643,10 @@ class ResponseFuture(object):
             if self._custom_payload and self.session.cluster.control_connection._tablets_routing_v1 and 'tablets-routing-v1' in self._custom_payload:
                 protocol = self.session.cluster.protocol_version
                 info = self._custom_payload.get('tablets-routing-v1')
-                ctype = types.lookup_casstype('TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)))')
+                ctype = ResponseFuture._TABLET_ROUTING_CTYPE
+                if ctype is None:
+                    ctype = types.lookup_casstype('TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)))')
+                    ResponseFuture._TABLET_ROUTING_CTYPE = ctype
                 tablet_routing_info = ctype.from_binary(info, protocol)
                 first_token = tablet_routing_info[0]
                 last_token = tablet_routing_info[1]


### PR DESCRIPTION
…ture

The _set_result() method re-parses the same complex TupleType string on every query result that includes tablet routing info. Cache the parsed type as a class attribute on ResponseFuture so lookup_casstype() is only called once for the lifetime of the process.

This is a simple cherry-pick from a larger series, but I think it has merit by itself, and is on the 'hot-path'. 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.