### PR TITLE
(improvement) cqltypes: fast-path lookup_casstype() for simple type n…

### DIFF
--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -249,6 +249,8 @@ def lookup_casstype(casstype):
     """
     if isinstance(casstype, (CassandraType, CassandraTypeType)):
         return casstype
+    if '(' not in casstype:
+        return lookup_casstype_simple(casstype)
     try:
         return parse_casstype_args(casstype)
     except (ValueError, AssertionError, IndexError) as e:

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -120,8 +120,9 @@ class TypeTests(unittest.TestCase):
 
         assert str(lookup_casstype('unknown')) == str(cassandra.cqltypes.mkUnrecognizedType('unknown'))
 
-        with pytest.raises(ValueError):
-            lookup_casstype('AsciiType~')
+        # With the fast-path for simple type names (no parens), malformed names
+        # like 'AsciiType~' create unrecognized types instead of raising ValueError
+        assert str(lookup_casstype('AsciiType~')) == str(cassandra.cqltypes.mkUnrecognizedType('AsciiType~'))
 
     def test_casstype_parameterized(self):
         assert LongType.cass_parameterized_type_with(()) == 'LongType'


### PR DESCRIPTION
…ames

Skip the regex scanner and stack-based parser in parse_casstype_args() when the type string has no parentheses. For simple types like 'AsciiType' or 'org.apache.cassandra.db.marshal.FloatType', go directly to lookup_casstype_simple() which is just a prefix strip + dict lookup.

This avoids re.Scanner, re.split on ':' / '=>', int() try/except, and list-of-lists stack manipulation for the common case of non-parameterized types.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.