### PR TITLE
(improvement) Add VectorType support to numpy_parser for 2D array parsing

### DIFF
--- a/cassandra/numpy_parser.pyx
+++ b/cassandra/numpy_parser.pyx
@@ -67,20 +67,41 @@ _cqltype_to_numpy = {
     cqltypes.LongType:          np.dtype('>i8'),
     cqltypes.CounterColumnType: np.dtype('>i8'),
     cqltypes.Int32Type:         np.dtype('>i4'),
+    cqltypes.ShortType:         np.dtype('>i2'),
     cqltypes.FloatType:         np.dtype('>f4'),
     cqltypes.DoubleType:        np.dtype('>f8'),
 }
-# Note: ShortType (smallint) is intentionally absent from this table. Unlike
-# LongType/Int32Type/FloatType/DoubleType/CounterColumnType, ShortType does
-# not override serial_size() in cassandra.cqltypes, so it has no fixed
-# per-element width when serialized *inside* a VectorType: the server
-# vint-prefixes each smallint element rather than encoding it as a plain
-# 2-byte big-endian field. Mapping it here would make the vector fast-path
-# assume a fixed 2-byte stride, which does not match the actual wire format
-# and causes a crash (see unpack_row's stride check) instead of falling back
-# to the safe, slower object-array path used for other subtypes without a
-# fixed width (e.g. UTF8Type). See also ByteType (tinyint), which has the
-# same issue and is likewise absent from this table.
+# This table is consulted from two different call sites in make_array()
+# below, and the two call sites do NOT mean the same thing by "fixed width":
+#
+#   - Scalar top-level columns (`_cqltype_to_numpy[coltype]`): here ShortType
+#     (smallint) genuinely is fixed-width on the wire (a plain 2-byte
+#     big-endian field, no length prefix), so it belongs in this table and
+#     gets the fast masked-array path, exactly like Int32Type/LongType/etc.
+#
+#   - VectorType.subtype dispatch (`_cqltype_to_numpy[subtype]` in the
+#     VectorType branch below): Cassandra/Scylla vint-prefixes each element
+#     *inside* a vector unless the subtype overrides serial_size() with a
+#     fixed value (see cqltypes.VectorType.serialize/deserialize, which
+#     branch on exactly this). ShortType (and ByteType/tinyint) do not
+#     override serial_size() -- it returns None from the _CassandraType
+#     base -- so inside a vector they are NOT fixed-width, even though
+#     ShortType *is* fixed-width as a scalar column. Using this table
+#     directly for a vector subtype without checking serial_size() would
+#     make the vector fast-path assume a fixed 2-byte stride that does not
+#     match the actual wire format, causing a crash (see unpack_row's
+#     stride check) instead of falling back to the safe, slower
+#     object-array path used for other subtypes without a fixed width
+#     (e.g. UTF8Type).
+#
+# Rather than removing ShortType from this shared table (which would also
+# silently break the scalar smallint fast path, since both call sites read
+# from the same dict), the VectorType call site below guards with
+# `subtype.serial_size() is not None` before consulting this table at all.
+# That mirrors the check VectorType itself uses to decide its own wire
+# encoding, so it is the general, authoritative test -- and it also
+# protects any subtype added to this table in the future without requiring
+# every caller to separately remember the vector-vs-scalar distinction.
 
 obj_dtype = np.dtype('O')
 
@@ -123,7 +144,7 @@ def make_arrays(ParseDesc desc, array_size):
             (e.g. this can be fed into pandas.DataFrame)
     """
     array_descs = np.empty((desc.rowsize,), arrDescDtype)
-    arrays = [None] * desc.rowsize
+    arrays = []
 
     for i, coltype in enumerate(desc.coltypes):
         arr = make_array(coltype, array_size)
@@ -136,7 +157,7 @@ def make_arrays(ParseDesc desc, array_size):
         except AttributeError:
             array_descs[i]['mask_ptr'] = 0
             array_descs[i]['mask_stride'] = 1
-        arrays[i] = arr
+        arrays.append(arr)
 
     return array_descs, arrays
 
@@ -151,13 +172,26 @@ def make_array(coltype, array_size):
         # VectorType - create 2D array (rows x vector_dimension)
         vector_size = coltype.vector_size
         subtype = coltype.subtype
-        try:
-            dtype = _cqltype_to_numpy[subtype]
-            a = np.ma.empty((array_size, vector_size), dtype=dtype)
-            a.mask = np.zeros((array_size, vector_size), dtype=bool)
-        except KeyError:
-            # Unsupported vector subtype - fall back to object array
-            a = np.empty((array_size,), dtype=obj_dtype)
+        # Only use the fixed-width fast path if the subtype actually has a
+        # fixed per-element wire size *inside a vector*. subtype.serial_size()
+        # is exactly the check VectorType.serialize()/deserialize() use to
+        # decide whether elements are plain fixed-width fields or
+        # vint-length-prefixed (e.g. ShortType/ByteType return None here,
+        # even though ShortType has its own, unrelated entry in
+        # _cqltype_to_numpy for the scalar-column case below). Checking this
+        # first -- rather than only catching KeyError on _cqltype_to_numpy --
+        # also protects any subtype added to that table in the future.
+        if subtype.serial_size() is not None:
+            try:
+                dtype = _cqltype_to_numpy[subtype]
+                a = np.ma.empty((array_size, vector_size), dtype=dtype)
+                a.mask = np.zeros((array_size, vector_size), dtype=bool)
+                return a
+            except KeyError:
+                pass
+        # Unsupported vector subtype, or one without a fixed per-element
+        # wire width - fall back to object array.
+        a = np.empty((array_size,), dtype=obj_dtype)
         return a
 
     # Scalar types
@@ -189,10 +223,11 @@ cdef inline int unpack_row(
             Py_INCREF(val)
             (<PyObject **> arr.buf_ptr)[0] = <PyObject *> val
         elif buf.size >= 0:
-            if buf.size > arr.stride:
+            if buf.size != arr.stride:
                 raise ValueError(
-                    "Column %d: received %d bytes but array stride is %d" %
-                    (i, buf.size, arr.stride))
+                    "Column %d (%r): received %d bytes but array stride is %d "
+                    "(payload must exactly match the expected element size)" %
+                    (i, desc.colnames[i], buf.size, arr.stride))
             memcpy(<char *> arr.buf_ptr, buf.ptr, buf.size)
         else:
             memset(<char *>arr.mask_ptr, 1, arr.mask_stride)

--- a/cassandra/numpy_parser.pyx
+++ b/cassandra/numpy_parser.pyx
@@ -25,7 +25,7 @@ as numpy is an optional dependency.
 include "ioutils.pyx"
 
 cimport cython
-from libc.stdint cimport uint64_t, uint8_t
+from libc.stdint cimport uint64_t
 from libc.string cimport memset
 from cpython.ref cimport Py_INCREF, PyObject
 
@@ -83,8 +83,6 @@ _cqltype_to_numpy = {
 # same issue and is likewise absent from this table.
 
 obj_dtype = np.dtype('O')
-
-cdef uint8_t mask_true = 0x01
 
 cdef class NumpyParser(ColumnParser):
     """Decode a ResultMessage into a bunch of NumPy arrays"""
@@ -191,6 +189,10 @@ cdef inline int unpack_row(
             Py_INCREF(val)
             (<PyObject **> arr.buf_ptr)[0] = <PyObject *> val
         elif buf.size >= 0:
+            if buf.size > arr.stride:
+                raise ValueError(
+                    "Column %d: received %d bytes but array stride is %d" %
+                    (i, buf.size, arr.stride))
             memcpy(<char *> arr.buf_ptr, buf.ptr, buf.size)
         else:
             memset(<char *>arr.mask_ptr, 1, arr.mask_stride)

--- a/cassandra/numpy_parser.pyx
+++ b/cassandra/numpy_parser.pyx
@@ -26,6 +26,7 @@ include "ioutils.pyx"
 
 cimport cython
 from libc.stdint cimport uint64_t, uint8_t
+from libc.string cimport memset
 from cpython.ref cimport Py_INCREF, PyObject
 
 from cassandra.bytesio cimport BytesIOReader
@@ -52,22 +53,34 @@ ctypedef struct ArrDesc:
     int stride # should be large enough as we allocate contiguous arrays
     int is_object
     Py_uintptr_t mask_ptr
+    int mask_stride
 
 arrDescDtype = np.dtype(
     [ ('buf_ptr', np.uintp)
     , ('stride', np.dtype('i'))
     , ('is_object', np.dtype('i'))
     , ('mask_ptr', np.uintp)
+    , ('mask_stride', np.dtype('i'))
     ], align=True)
 
 _cqltype_to_numpy = {
     cqltypes.LongType:          np.dtype('>i8'),
     cqltypes.CounterColumnType: np.dtype('>i8'),
     cqltypes.Int32Type:         np.dtype('>i4'),
-    cqltypes.ShortType:         np.dtype('>i2'),
     cqltypes.FloatType:         np.dtype('>f4'),
     cqltypes.DoubleType:        np.dtype('>f8'),
 }
+# Note: ShortType (smallint) is intentionally absent from this table. Unlike
+# LongType/Int32Type/FloatType/DoubleType/CounterColumnType, ShortType does
+# not override serial_size() in cassandra.cqltypes, so it has no fixed
+# per-element width when serialized *inside* a VectorType: the server
+# vint-prefixes each smallint element rather than encoding it as a plain
+# 2-byte big-endian field. Mapping it here would make the vector fast-path
+# assume a fixed 2-byte stride, which does not match the actual wire format
+# and causes a crash (see unpack_row's stride check) instead of falling back
+# to the safe, slower object-array path used for other subtypes without a
+# fixed width (e.g. UTF8Type). See also ByteType (tinyint), which has the
+# same issue and is likewise absent from this table.
 
 obj_dtype = np.dtype('O')
 
@@ -112,7 +125,7 @@ def make_arrays(ParseDesc desc, array_size):
             (e.g. this can be fed into pandas.DataFrame)
     """
     array_descs = np.empty((desc.rowsize,), arrDescDtype)
-    arrays = []
+    arrays = [None] * desc.rowsize
 
     for i, coltype in enumerate(desc.coltypes):
         arr = make_array(coltype, array_size)
@@ -121,9 +134,11 @@ def make_arrays(ParseDesc desc, array_size):
         array_descs[i]['is_object'] = arr.dtype is obj_dtype
         try:
             array_descs[i]['mask_ptr'] = arr.mask.ctypes.data
+            array_descs[i]['mask_stride'] = arr.mask.strides[0]
         except AttributeError:
             array_descs[i]['mask_ptr'] = 0
-        arrays.append(arr)
+            array_descs[i]['mask_stride'] = 1
+        arrays[i] = arr
 
     return array_descs, arrays
 
@@ -131,7 +146,23 @@ def make_arrays(ParseDesc desc, array_size):
 def make_array(coltype, array_size):
     """
     Allocate a new NumPy array of the given column type and size.
+    For VectorType, creates a 2D array (array_size x vector_dimension).
     """
+    # Check if this is a VectorType
+    if issubclass(coltype, cqltypes.VectorType):
+        # VectorType - create 2D array (rows x vector_dimension)
+        vector_size = coltype.vector_size
+        subtype = coltype.subtype
+        try:
+            dtype = _cqltype_to_numpy[subtype]
+            a = np.ma.empty((array_size, vector_size), dtype=dtype)
+            a.mask = np.zeros((array_size, vector_size), dtype=bool)
+        except KeyError:
+            # Unsupported vector subtype - fall back to object array
+            a = np.empty((array_size,), dtype=obj_dtype)
+        return a
+
+    # Scalar types
     try:
         a = np.ma.empty((array_size,), dtype=_cqltype_to_numpy[coltype])
         a.mask = np.zeros((array_size,), dtype=bool)
@@ -162,11 +193,21 @@ cdef inline int unpack_row(
         elif buf.size >= 0:
             memcpy(<char *> arr.buf_ptr, buf.ptr, buf.size)
         else:
-            memcpy(<char *>arr.mask_ptr, &mask_true, 1)
+            memset(<char *>arr.mask_ptr, 1, arr.mask_stride)
+            # The row's data bytes were never written for a NULL value, so
+            # they still hold uninitialized heap memory from the array's
+            # allocation (np.ma.empty/np.empty do not zero-fill). That memory
+            # can be observed directly via `.data` or via `.filled()`-adjacent
+            # operations, so zero it out explicitly. For a VectorType column
+            # this is `arr.stride` bytes (the whole vector row, e.g. 3072
+            # bytes for a float[768] embedding) rather than a single scalar
+            # value, which makes the amount of exposed uninitialized memory
+            # much larger if left unfixed.
+            memset(<char *> arr.buf_ptr, 0, arr.stride)
 
         # Update the pointer into the array for the next time
         arrays[i].buf_ptr += arr.stride
-        arrays[i].mask_ptr += 1
+        arrays[i].mask_ptr += arr.mask_stride
 
     return 0
 
@@ -174,6 +215,7 @@ cdef inline int unpack_row(
 def make_native_byteorder(arr):
     """
     Make sure all values have a native endian in the NumPy arrays.
+    Handles both 1D (scalar types) and 2D (VectorType) arrays.
     """
     if is_little_endian and not arr.dtype.kind == 'O':
         # We have arrays in big-endian order. First swap the bytes
@@ -182,5 +224,12 @@ def make_native_byteorder(arr):
         #
         # Ignore any object arrays of dtype('O')
         # Note: arr.newbyteorder() was removed in NumPy 2.0, use view() instead
-        return arr.byteswap().view(arr.dtype.newbyteorder())
+        #
+        # 'arr' was just freshly allocated in make_array() and is not
+        # referenced anywhere else at this point (array_descs only holds a
+        # raw pointer to its buffer, not a Python reference), so it is safe
+        # to byteswap it in place instead of allocating a second full-size
+        # copy of the array. This matters more as vector dimensionality
+        # grows (e.g. a 768-float embedding is 3072 bytes per row).
+        return arr.byteswap(inplace=True).view(arr.dtype.newbyteorder())
     return arr

--- a/tests/unit/test_numpy_parser.py
+++ b/tests/unit/test_numpy_parser.py
@@ -1,4 +1,4 @@
-# Copyright DataStax, Inc.
+# Copyright ScyllaDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 
 import struct
 import unittest
-from unittest.mock import Mock
 
 try:
     import numpy as np
@@ -22,6 +21,7 @@ try:
     from cassandra.bytesio import BytesIOReader
     from cassandra.parsing import ParseDesc
     from cassandra.deserializers import obj_array, make_deserializers
+
     HAVE_NUMPY = True
 except ImportError:
     HAVE_NUMPY = False
@@ -36,23 +36,23 @@ class TestNumpyParserVectorType(unittest.TestCase):
     def _create_vector_type(self, subtype, vector_size):
         """Helper to create a VectorType class"""
         return type(
-            f'VectorType({vector_size})',
+            f"VectorType({vector_size})",
             (cqltypes.VectorType,),
-            {'vector_size': vector_size, 'subtype': subtype}
+            {"vector_size": vector_size, "subtype": subtype},
         )
 
     def _serialize_vectors(self, vectors, format_char):
         """Serialize a list of vectors using struct.pack"""
         buffer = bytearray()
         # Write row count
-        buffer.extend(struct.pack('>i', len(vectors)))
+        buffer.extend(struct.pack(">i", len(vectors)))
         # Write each vector
         for vector in vectors:
             # Write byte size of vector (doesn't include size prefix in CQL)
-            byte_size = len(vector) * struct.calcsize(f'>{format_char}')
-            buffer.extend(struct.pack('>i', byte_size))
+            byte_size = len(vector) * struct.calcsize(f">{format_char}")
+            buffer.extend(struct.pack(">i", byte_size))
             # Write vector elements
-            buffer.extend(struct.pack(f'>{len(vector)}{format_char}', *vector))
+            buffer.extend(struct.pack(f">{len(vector)}{format_char}", *vector))
         return bytes(buffer)
 
     def _serialize_vectors_via_vector_type(self, vector_type, vectors, protocol_version=5):
@@ -81,140 +81,140 @@ class TestNumpyParserVectorType(unittest.TestCase):
         """Test that VectorType<float> creates and populates a 2D NumPy array"""
         vector_size = 4
         vector_type = self._create_vector_type(cqltypes.FloatType, vector_size)
-        
+
         # Create test data: 3 rows of 4-dimensional float vectors
         vectors = [
             [1.0, 2.0, 3.0, 4.0],
             [5.0, 6.0, 7.0, 8.0],
             [9.0, 10.0, 11.0, 12.0],
         ]
-        
+
         # Serialize the data
-        serialized = self._serialize_vectors(vectors, 'f')
-        
+        serialized = self._serialize_vectors(vectors, "f")
+
         # Parse with NumpyParser
         parser = NumpyParser()
         reader = BytesIOReader(serialized)
-        
+
         desc = ParseDesc(
-            colnames=['vec'],
+            colnames=["vec"],
             coltypes=[vector_type],
             column_encryption_policy=None,
             coldescs=None,
             deserializers=obj_array([None]),
-            protocol_version=5
+            protocol_version=5,
         )
-        
+
         result = parser.parse_rows(reader, desc)
-        
+
         # Verify result structure
-        self.assertIn('vec', result)
-        arr = result['vec']
-        
+        self.assertIn("vec", result)
+        arr = result["vec"]
+
         # Verify it's a 2D array with correct shape
         self.assertEqual(arr.ndim, 2)
         self.assertEqual(arr.shape, (3, 4))
-        
+
         # Verify the data
-        expected = np.array(vectors, dtype='<f4')  # little-endian after conversion
+        expected = np.array(vectors, dtype=np.float32)
         np.testing.assert_array_almost_equal(arr, expected)
 
     def test_vector_double_2d_array(self):
         """Test that VectorType<double> creates and populates a 2D NumPy array"""
         vector_size = 3
         vector_type = self._create_vector_type(cqltypes.DoubleType, vector_size)
-        
+
         # Create test data: 2 rows of 3-dimensional double vectors
         vectors = [
             [1.5, 2.5, 3.5],
             [4.5, 5.5, 6.5],
         ]
-        
-        serialized = self._serialize_vectors(vectors, 'd')
-        
+
+        serialized = self._serialize_vectors(vectors, "d")
+
         parser = NumpyParser()
         reader = BytesIOReader(serialized)
-        
+
         desc = ParseDesc(
-            colnames=['embedding'],
+            colnames=["embedding"],
             coltypes=[vector_type],
             column_encryption_policy=None,
             coldescs=None,
             deserializers=obj_array([None]),
-            protocol_version=5
+            protocol_version=5,
         )
-        
+
         result = parser.parse_rows(reader, desc)
-        
-        arr = result['embedding']
+
+        arr = result["embedding"]
         self.assertEqual(arr.shape, (2, 3))
-        
-        expected = np.array(vectors, dtype='<f8')
+
+        expected = np.array(vectors, dtype=np.float64)
         np.testing.assert_array_almost_equal(arr, expected)
 
     def test_vector_int32_2d_array(self):
         """Test that VectorType<int> creates and populates a 2D NumPy array"""
         vector_size = 128
         vector_type = self._create_vector_type(cqltypes.Int32Type, vector_size)
-        
+
         # Create test data: 2 rows of 128-dimensional int vectors
         vectors = [
             list(range(0, 128)),
             list(range(128, 256)),
         ]
-        
-        serialized = self._serialize_vectors(vectors, 'i')
-        
+
+        serialized = self._serialize_vectors(vectors, "i")
+
         parser = NumpyParser()
         reader = BytesIOReader(serialized)
-        
+
         desc = ParseDesc(
-            colnames=['features'],
+            colnames=["features"],
             coltypes=[vector_type],
             column_encryption_policy=None,
             coldescs=None,
             deserializers=obj_array([None]),
-            protocol_version=5
+            protocol_version=5,
         )
-        
+
         result = parser.parse_rows(reader, desc)
-        
-        arr = result['features']
+
+        arr = result["features"]
         self.assertEqual(arr.shape, (2, 128))
-        
-        expected = np.array(vectors, dtype='<i4')
+
+        expected = np.array(vectors, dtype=np.int32)
         np.testing.assert_array_equal(arr, expected)
 
     def test_vector_int64_2d_array(self):
         """Test that VectorType<bigint> creates and populates a 2D NumPy array"""
         vector_size = 5
         vector_type = self._create_vector_type(cqltypes.LongType, vector_size)
-        
+
         vectors = [
             [100, 200, 300, 400, 500],
             [600, 700, 800, 900, 1000],
         ]
-        
-        serialized = self._serialize_vectors(vectors, 'q')
-        
+
+        serialized = self._serialize_vectors(vectors, "q")
+
         parser = NumpyParser()
         reader = BytesIOReader(serialized)
-        
+
         desc = ParseDesc(
-            colnames=['ids'],
+            colnames=["ids"],
             coltypes=[vector_type],
             column_encryption_policy=None,
             coldescs=None,
             deserializers=obj_array([None]),
-            protocol_version=5
+            protocol_version=5,
         )
-        
+
         result = parser.parse_rows(reader, desc)
-        
-        arr = result['ids']
+
+        arr = result["ids"]
         self.assertEqual(arr.shape, (2, 5))
-        
-        expected = np.array(vectors, dtype='<i8')
+
+        expected = np.array(vectors, dtype=np.int64)
         np.testing.assert_array_equal(arr, expected)
 
     def test_vector_smallint_falls_back_and_round_trips_via_real_serializer(self):
@@ -251,23 +251,23 @@ class TestNumpyParserVectorType(unittest.TestCase):
         reader = BytesIOReader(serialized)
 
         desc = ParseDesc(
-            colnames=['small_vec'],
+            colnames=["small_vec"],
             coltypes=[vector_type],
             column_encryption_policy=None,
             coldescs=None,
             deserializers=make_deserializers([vector_type]),
-            protocol_version=5
+            protocol_version=5,
         )
 
         result = parser.parse_rows(reader, desc)
 
-        arr = result['small_vec']
+        arr = result["small_vec"]
 
         # ShortType must NOT be in the fast-path dtype table: it should
         # fall back to a 1D object array (a list per row), not a 2D
         # fixed-width numeric array.
         self.assertEqual(arr.ndim, 1)
-        self.assertEqual(arr.dtype, np.dtype('O'))
+        self.assertEqual(arr.dtype, np.dtype("O"))
         self.assertEqual(arr.shape, (len(vectors),))
 
         for i, expected_vector in enumerate(vectors):
@@ -293,99 +293,245 @@ class TestNumpyParserVectorType(unittest.TestCase):
         reader = BytesIOReader(serialized)
 
         desc = ParseDesc(
-            colnames=['vec'],
+            colnames=["vec"],
             coltypes=[vector_type],
             column_encryption_policy=None,
             coldescs=None,
             deserializers=make_deserializers([vector_type]),
-            protocol_version=5
+            protocol_version=5,
         )
 
         result = parser.parse_rows(reader, desc)
-        arr = result['vec']
+        arr = result["vec"]
 
         # FloatType has a fixed serial_size(), so it should still use the
         # fast path: a 2D numeric masked array, not an object array.
         self.assertEqual(arr.ndim, 2)
-        self.assertNotEqual(arr.dtype, np.dtype('O'))
+        self.assertNotEqual(arr.dtype, np.dtype("O"))
         self.assertEqual(arr.shape, (len(vectors), vector_size))
 
-        expected = np.array(vectors, dtype='<f4')
+        expected = np.array(vectors, dtype=np.float32)
         np.testing.assert_array_almost_equal(arr, expected)
 
     def test_mixed_columns_with_vectors(self):
         """Test parsing multiple columns including VectorType"""
         vector_type = self._create_vector_type(cqltypes.FloatType, 3)
-        
+
         # Serialize: int32 column, vector column
         buffer = bytearray()
-        buffer.extend(struct.pack('>i', 2))  # row count
-        
+        buffer.extend(struct.pack(">i", 2))  # row count
+
         # Row 1: id=1, vec=[1.0, 2.0, 3.0]
-        buffer.extend(struct.pack('>i', 4))    # int32 size
-        buffer.extend(struct.pack('>i', 1))    # id value
-        buffer.extend(struct.pack('>i', 12))   # vector size (3 floats)
-        buffer.extend(struct.pack('>3f', 1.0, 2.0, 3.0))
-        
+        buffer.extend(struct.pack(">i", 4))  # int32 size
+        buffer.extend(struct.pack(">i", 1))  # id value
+        buffer.extend(struct.pack(">i", 12))  # vector size (3 floats)
+        buffer.extend(struct.pack(">3f", 1.0, 2.0, 3.0))
+
         # Row 2: id=2, vec=[4.0, 5.0, 6.0]
-        buffer.extend(struct.pack('>i', 4))
-        buffer.extend(struct.pack('>i', 2))
-        buffer.extend(struct.pack('>i', 12))
-        buffer.extend(struct.pack('>3f', 4.0, 5.0, 6.0))
-        
+        buffer.extend(struct.pack(">i", 4))
+        buffer.extend(struct.pack(">i", 2))
+        buffer.extend(struct.pack(">i", 12))
+        buffer.extend(struct.pack(">3f", 4.0, 5.0, 6.0))
+
         parser = NumpyParser()
         reader = BytesIOReader(bytes(buffer))
-        
+
         desc = ParseDesc(
-            colnames=['id', 'vec'],
+            colnames=["id", "vec"],
             coltypes=[cqltypes.Int32Type, vector_type],
             column_encryption_policy=None,
             coldescs=None,
             deserializers=obj_array([None, None]),
-            protocol_version=5
+            protocol_version=5,
         )
-        
+
         result = parser.parse_rows(reader, desc)
-        
+
         # Verify id column (1D array)
-        self.assertEqual(result['id'].shape, (2,))
-        np.testing.assert_array_equal(result['id'], np.array([1, 2], dtype='<i4'))
-        
+        self.assertEqual(result["id"].shape, (2,))
+        np.testing.assert_array_equal(result["id"], np.array([1, 2], dtype=np.int32))
+
         # Verify vec column (2D array)
-        self.assertEqual(result['vec'].shape, (2, 3))
-        expected_vecs = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype='<f4')
-        np.testing.assert_array_almost_equal(result['vec'], expected_vecs)
+        self.assertEqual(result["vec"].shape, (2, 3))
+        expected_vecs = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
+        np.testing.assert_array_almost_equal(result["vec"], expected_vecs)
 
     def test_large_vector_dimensions(self):
         """Test VectorType with large dimensions (e.g., 384 for embeddings)"""
         vector_size = 384
         vector_type = self._create_vector_type(cqltypes.FloatType, vector_size)
-        
+
         # Create one row with a 384-dimensional vector
         vectors = [[float(i) for i in range(384)]]
-        
-        serialized = self._serialize_vectors(vectors, 'f')
-        
+
+        serialized = self._serialize_vectors(vectors, "f")
+
         parser = NumpyParser()
         reader = BytesIOReader(serialized)
-        
+
         desc = ParseDesc(
-            colnames=['embedding'],
+            colnames=["embedding"],
             coltypes=[vector_type],
             column_encryption_policy=None,
             coldescs=None,
             deserializers=obj_array([None]),
-            protocol_version=5
+            protocol_version=5,
         )
-        
+
         result = parser.parse_rows(reader, desc)
-        
-        arr = result['embedding']
+
+        arr = result["embedding"]
         self.assertEqual(arr.shape, (1, 384))
-        
-        expected = np.array(vectors, dtype='<f4')
+
+        expected = np.array(vectors, dtype=np.float32)
         np.testing.assert_array_almost_equal(arr, expected)
 
+    def test_null_vector_sets_mask(self):
+        """Test that a NULL vector (size = -1) sets the mask correctly"""
+        vector_size = 3
+        vector_type = self._create_vector_type(cqltypes.FloatType, vector_size)
 
-if __name__ == '__main__':
+        # Serialize: 2 rows, first is a valid vector, second is NULL (size = -1)
+        buffer = bytearray()
+        buffer.extend(struct.pack(">i", 2))  # row count
+
+        # Row 1: valid vector [1.0, 2.0, 3.0]
+        buffer.extend(struct.pack(">i", 12))  # byte size (3 floats * 4 bytes)
+        buffer.extend(struct.pack(">3f", 1.0, 2.0, 3.0))
+
+        # Row 2: NULL vector
+        buffer.extend(struct.pack(">i", -1))  # -1 signals NULL
+
+        parser = NumpyParser()
+        reader = BytesIOReader(bytes(buffer))
+
+        desc = ParseDesc(
+            colnames=["vec"],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=obj_array([None]),
+            protocol_version=5,
+        )
+
+        result = parser.parse_rows(reader, desc)
+
+        arr = result["vec"]
+        self.assertEqual(arr.shape, (2, 3))
+
+        # First row should not be masked
+        self.assertFalse(arr.mask[0].any())
+        np.testing.assert_array_almost_equal(
+            arr[0], np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        )
+
+        # Second row should be fully masked (NULL)
+        self.assertTrue(arr.mask[1].all())
+
+    def test_null_vector_data_bytes_are_zeroed(self):
+        """Test that a NULL vector's underlying .data bytes are zeroed.
+
+        Setting the mask alone is not enough: the row's underlying buffer
+        (arr.stride bytes -- the whole vector, not just one scalar) is
+        never written to for a NULL value, so it would otherwise retain
+        whatever uninitialized heap memory the allocator happened to hand
+        back. That memory is directly observable via `.data` or via
+        `.filled()`-adjacent access, so unpack_row() must explicitly zero
+        it rather than leaving it as an info leak. This matters much more
+        for vectors than for scalars: a NULL float[768] embedding leaves
+        3072 uninitialized bytes exposed per row instead of just 4.
+        """
+        vector_size = 8
+        vector_type = self._create_vector_type(cqltypes.FloatType, vector_size)
+
+        buffer = bytearray()
+        buffer.extend(struct.pack(">i", 2))  # row count
+
+        # Row 1: a valid vector with distinctive non-zero values.
+        valid_vector = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+        buffer.extend(struct.pack(">i", vector_size * 4))
+        buffer.extend(struct.pack(">8f", *valid_vector))
+
+        # Row 2: NULL vector.
+        buffer.extend(struct.pack(">i", -1))
+
+        parser = NumpyParser()
+        reader = BytesIOReader(bytes(buffer))
+
+        desc = ParseDesc(
+            colnames=["vec"],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=obj_array([None]),
+            protocol_version=5,
+        )
+
+        result = parser.parse_rows(reader, desc)
+        arr = result["vec"]
+
+        self.assertTrue(arr.mask[1].all())
+
+        # `.data` bypasses the mask and exposes the raw underlying buffer.
+        null_row_bytes = arr.data[1].tobytes()
+        self.assertEqual(null_row_bytes, b"\x00" * len(null_row_bytes))
+
+    def test_unsupported_subtype_falls_back_to_object_array(self):
+        """Test that an unsupported vector subtype falls back to an object array"""
+        vector_size = 2
+        vector_type = self._create_vector_type(cqltypes.UTF8Type, vector_size)
+
+        # For an unsupported subtype, make_array should produce a 1D object
+        # array (not a 2D numeric array), and parsing goes through the
+        # deserializer/object path instead of the memcpy fast-path.
+        from cassandra.numpy_parser import make_array
+
+        arr = make_array(vector_type, 5)
+        self.assertEqual(arr.ndim, 1)
+        self.assertEqual(arr.dtype, np.dtype("O"))
+        self.assertEqual(arr.shape, (5,))
+
+    def test_unsupported_subtype_falls_back_end_to_end_via_parse_rows(self):
+        """End-to-end companion to test_unsupported_subtype_falls_back_to_object_array.
+
+        That test only unit-tests make_array() in isolation. This test
+        drives the full NumpyParser.parse_rows() entry point (using the
+        real VectorType.serialize() as ground truth for the wire bytes),
+        to confirm the fallback path also parses and round-trips correctly
+        end to end, not just that make_array() picks the right dtype.
+        """
+        vector_size = 2
+        vector_type = self._create_vector_type(cqltypes.UTF8Type, vector_size)
+
+        vectors = [
+            ["hello", "world"],
+            ["foo", "bar"],
+        ]
+
+        serialized = self._serialize_vectors_via_vector_type(vector_type, vectors)
+
+        parser = NumpyParser()
+        reader = BytesIOReader(serialized)
+
+        desc = ParseDesc(
+            colnames=["tags"],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=make_deserializers([vector_type]),
+            protocol_version=5,
+        )
+
+        result = parser.parse_rows(reader, desc)
+        arr = result["tags"]
+
+        self.assertEqual(arr.ndim, 1)
+        self.assertEqual(arr.dtype, np.dtype("O"))
+        self.assertEqual(arr.shape, (len(vectors),))
+
+        for i, expected_vector in enumerate(vectors):
+            self.assertEqual(list(arr[i]), expected_vector)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_numpy_parser.py
+++ b/tests/unit/test_numpy_parser.py
@@ -1,0 +1,391 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import struct
+import unittest
+from unittest.mock import Mock
+
+try:
+    import numpy as np
+    from cassandra.numpy_parser import NumpyParser
+    from cassandra.bytesio import BytesIOReader
+    from cassandra.parsing import ParseDesc
+    from cassandra.deserializers import obj_array, make_deserializers
+    HAVE_NUMPY = True
+except ImportError:
+    HAVE_NUMPY = False
+
+from cassandra import cqltypes
+
+
+@unittest.skipUnless(HAVE_NUMPY, "NumPy not available")
+class TestNumpyParserVectorType(unittest.TestCase):
+    """Tests for VectorType support in NumpyParser"""
+
+    def _create_vector_type(self, subtype, vector_size):
+        """Helper to create a VectorType class"""
+        return type(
+            f'VectorType({vector_size})',
+            (cqltypes.VectorType,),
+            {'vector_size': vector_size, 'subtype': subtype}
+        )
+
+    def _serialize_vectors(self, vectors, format_char):
+        """Serialize a list of vectors using struct.pack"""
+        buffer = bytearray()
+        # Write row count
+        buffer.extend(struct.pack('>i', len(vectors)))
+        # Write each vector
+        for vector in vectors:
+            # Write byte size of vector (doesn't include size prefix in CQL)
+            byte_size = len(vector) * struct.calcsize(f'>{format_char}')
+            buffer.extend(struct.pack('>i', byte_size))
+            # Write vector elements
+            buffer.extend(struct.pack(f'>{len(vector)}{format_char}', *vector))
+        return bytes(buffer)
+
+    def _serialize_vectors_via_vector_type(self, vector_type, vectors, protocol_version=5):
+        """Serialize a list of vectors using the actual production
+        cassandra.cqltypes.VectorType.serialize(), instead of hand-rolling
+        wire bytes with struct.pack.
+
+        This is important: the struct.pack-based helper above bakes in the
+        assumption that every subtype has a fixed per-element width on the
+        wire. That assumption is wrong for subtypes whose serial_size() is
+        None (e.g. ShortType/smallint), which are vint length-prefixed per
+        element instead. Using the real serializer as ground truth is what
+        catches a mismatch between the numpy_parser fast-path dtype table
+        and the actual wire format -- which is exactly the bug class this
+        helper guards against.
+        """
+        buffer = bytearray()
+        buffer.extend(struct.pack('>i', len(vectors)))
+        for vector in vectors:
+            payload = vector_type.serialize(list(vector), protocol_version)
+            buffer.extend(struct.pack('>i', len(payload)))
+            buffer.extend(payload)
+        return bytes(buffer)
+
+    def test_vector_float_2d_array(self):
+        """Test that VectorType<float> creates and populates a 2D NumPy array"""
+        vector_size = 4
+        vector_type = self._create_vector_type(cqltypes.FloatType, vector_size)
+        
+        # Create test data: 3 rows of 4-dimensional float vectors
+        vectors = [
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+            [9.0, 10.0, 11.0, 12.0],
+        ]
+        
+        # Serialize the data
+        serialized = self._serialize_vectors(vectors, 'f')
+        
+        # Parse with NumpyParser
+        parser = NumpyParser()
+        reader = BytesIOReader(serialized)
+        
+        desc = ParseDesc(
+            colnames=['vec'],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=obj_array([None]),
+            protocol_version=5
+        )
+        
+        result = parser.parse_rows(reader, desc)
+        
+        # Verify result structure
+        self.assertIn('vec', result)
+        arr = result['vec']
+        
+        # Verify it's a 2D array with correct shape
+        self.assertEqual(arr.ndim, 2)
+        self.assertEqual(arr.shape, (3, 4))
+        
+        # Verify the data
+        expected = np.array(vectors, dtype='<f4')  # little-endian after conversion
+        np.testing.assert_array_almost_equal(arr, expected)
+
+    def test_vector_double_2d_array(self):
+        """Test that VectorType<double> creates and populates a 2D NumPy array"""
+        vector_size = 3
+        vector_type = self._create_vector_type(cqltypes.DoubleType, vector_size)
+        
+        # Create test data: 2 rows of 3-dimensional double vectors
+        vectors = [
+            [1.5, 2.5, 3.5],
+            [4.5, 5.5, 6.5],
+        ]
+        
+        serialized = self._serialize_vectors(vectors, 'd')
+        
+        parser = NumpyParser()
+        reader = BytesIOReader(serialized)
+        
+        desc = ParseDesc(
+            colnames=['embedding'],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=obj_array([None]),
+            protocol_version=5
+        )
+        
+        result = parser.parse_rows(reader, desc)
+        
+        arr = result['embedding']
+        self.assertEqual(arr.shape, (2, 3))
+        
+        expected = np.array(vectors, dtype='<f8')
+        np.testing.assert_array_almost_equal(arr, expected)
+
+    def test_vector_int32_2d_array(self):
+        """Test that VectorType<int> creates and populates a 2D NumPy array"""
+        vector_size = 128
+        vector_type = self._create_vector_type(cqltypes.Int32Type, vector_size)
+        
+        # Create test data: 2 rows of 128-dimensional int vectors
+        vectors = [
+            list(range(0, 128)),
+            list(range(128, 256)),
+        ]
+        
+        serialized = self._serialize_vectors(vectors, 'i')
+        
+        parser = NumpyParser()
+        reader = BytesIOReader(serialized)
+        
+        desc = ParseDesc(
+            colnames=['features'],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=obj_array([None]),
+            protocol_version=5
+        )
+        
+        result = parser.parse_rows(reader, desc)
+        
+        arr = result['features']
+        self.assertEqual(arr.shape, (2, 128))
+        
+        expected = np.array(vectors, dtype='<i4')
+        np.testing.assert_array_equal(arr, expected)
+
+    def test_vector_int64_2d_array(self):
+        """Test that VectorType<bigint> creates and populates a 2D NumPy array"""
+        vector_size = 5
+        vector_type = self._create_vector_type(cqltypes.LongType, vector_size)
+        
+        vectors = [
+            [100, 200, 300, 400, 500],
+            [600, 700, 800, 900, 1000],
+        ]
+        
+        serialized = self._serialize_vectors(vectors, 'q')
+        
+        parser = NumpyParser()
+        reader = BytesIOReader(serialized)
+        
+        desc = ParseDesc(
+            colnames=['ids'],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=obj_array([None]),
+            protocol_version=5
+        )
+        
+        result = parser.parse_rows(reader, desc)
+        
+        arr = result['ids']
+        self.assertEqual(arr.shape, (2, 5))
+        
+        expected = np.array(vectors, dtype='<i8')
+        np.testing.assert_array_equal(arr, expected)
+
+    def test_vector_smallint_falls_back_and_round_trips_via_real_serializer(self):
+        """Regression test for the ShortType fast-path bug.
+
+        ShortType (smallint) does not override serial_size() in
+        cassandra.cqltypes, so Cassandra/Scylla vint-prefixes each element
+        of a vector<smallint, N> column instead of encoding it with a fixed
+        2-byte stride. If ShortType were (incorrectly) present in
+        numpy_parser's fast-path dtype table, this test would fail with a
+        ValueError ("received N bytes but array stride is M") because the
+        real wire format -- produced here by the actual production
+        VectorType.serialize(), not a hand-rolled struct.pack payload --
+        does not match the fixed 2-byte-per-element layout the fast path
+        would assume. Using the real serializer as ground truth is exactly
+        what a hand-rolled struct.pack-based test would fail to catch.
+
+        Instead, ShortType must fall back to the same safe, slower
+        object-array path used for other subtypes without a fixed width
+        (e.g. UTF8Type), and still round-trip correctly.
+        """
+        vector_size = 4
+        vector_type = self._create_vector_type(cqltypes.ShortType, vector_size)
+
+        vectors = [
+            [1, 2, 3, 4],
+            [-5, 6, -7, 8],
+            [0, 32767, -32768, 100],
+        ]
+
+        serialized = self._serialize_vectors_via_vector_type(vector_type, vectors)
+
+        parser = NumpyParser()
+        reader = BytesIOReader(serialized)
+
+        desc = ParseDesc(
+            colnames=['small_vec'],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=make_deserializers([vector_type]),
+            protocol_version=5
+        )
+
+        result = parser.parse_rows(reader, desc)
+
+        arr = result['small_vec']
+
+        # ShortType must NOT be in the fast-path dtype table: it should
+        # fall back to a 1D object array (a list per row), not a 2D
+        # fixed-width numeric array.
+        self.assertEqual(arr.ndim, 1)
+        self.assertEqual(arr.dtype, np.dtype('O'))
+        self.assertEqual(arr.shape, (len(vectors),))
+
+        for i, expected_vector in enumerate(vectors):
+            self.assertEqual(list(arr[i]), expected_vector)
+
+    def test_vector_float_round_trips_via_real_serializer(self):
+        """Round-trip a fixed-width (float) vector column through the
+        actual production VectorType.serialize(), not a hand-rolled
+        struct.pack payload, and verify the fast path still reconstructs
+        the original values correctly.
+        """
+        vector_size = 4
+        vector_type = self._create_vector_type(cqltypes.FloatType, vector_size)
+
+        vectors = [
+            [1.5, 2.5, 3.5, 4.5],
+            [-1.0, 0.0, 100.25, -3.75],
+        ]
+
+        serialized = self._serialize_vectors_via_vector_type(vector_type, vectors)
+
+        parser = NumpyParser()
+        reader = BytesIOReader(serialized)
+
+        desc = ParseDesc(
+            colnames=['vec'],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=make_deserializers([vector_type]),
+            protocol_version=5
+        )
+
+        result = parser.parse_rows(reader, desc)
+        arr = result['vec']
+
+        # FloatType has a fixed serial_size(), so it should still use the
+        # fast path: a 2D numeric masked array, not an object array.
+        self.assertEqual(arr.ndim, 2)
+        self.assertNotEqual(arr.dtype, np.dtype('O'))
+        self.assertEqual(arr.shape, (len(vectors), vector_size))
+
+        expected = np.array(vectors, dtype='<f4')
+        np.testing.assert_array_almost_equal(arr, expected)
+
+    def test_mixed_columns_with_vectors(self):
+        """Test parsing multiple columns including VectorType"""
+        vector_type = self._create_vector_type(cqltypes.FloatType, 3)
+        
+        # Serialize: int32 column, vector column
+        buffer = bytearray()
+        buffer.extend(struct.pack('>i', 2))  # row count
+        
+        # Row 1: id=1, vec=[1.0, 2.0, 3.0]
+        buffer.extend(struct.pack('>i', 4))    # int32 size
+        buffer.extend(struct.pack('>i', 1))    # id value
+        buffer.extend(struct.pack('>i', 12))   # vector size (3 floats)
+        buffer.extend(struct.pack('>3f', 1.0, 2.0, 3.0))
+        
+        # Row 2: id=2, vec=[4.0, 5.0, 6.0]
+        buffer.extend(struct.pack('>i', 4))
+        buffer.extend(struct.pack('>i', 2))
+        buffer.extend(struct.pack('>i', 12))
+        buffer.extend(struct.pack('>3f', 4.0, 5.0, 6.0))
+        
+        parser = NumpyParser()
+        reader = BytesIOReader(bytes(buffer))
+        
+        desc = ParseDesc(
+            colnames=['id', 'vec'],
+            coltypes=[cqltypes.Int32Type, vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=obj_array([None, None]),
+            protocol_version=5
+        )
+        
+        result = parser.parse_rows(reader, desc)
+        
+        # Verify id column (1D array)
+        self.assertEqual(result['id'].shape, (2,))
+        np.testing.assert_array_equal(result['id'], np.array([1, 2], dtype='<i4'))
+        
+        # Verify vec column (2D array)
+        self.assertEqual(result['vec'].shape, (2, 3))
+        expected_vecs = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype='<f4')
+        np.testing.assert_array_almost_equal(result['vec'], expected_vecs)
+
+    def test_large_vector_dimensions(self):
+        """Test VectorType with large dimensions (e.g., 384 for embeddings)"""
+        vector_size = 384
+        vector_type = self._create_vector_type(cqltypes.FloatType, vector_size)
+        
+        # Create one row with a 384-dimensional vector
+        vectors = [[float(i) for i in range(384)]]
+        
+        serialized = self._serialize_vectors(vectors, 'f')
+        
+        parser = NumpyParser()
+        reader = BytesIOReader(serialized)
+        
+        desc = ParseDesc(
+            colnames=['embedding'],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=obj_array([None]),
+            protocol_version=5
+        )
+        
+        result = parser.parse_rows(reader, desc)
+        
+        arr = result['embedding']
+        self.assertEqual(arr.shape, (1, 384))
+        
+        expected = np.array(vectors, dtype='<f4')
+        np.testing.assert_array_almost_equal(arr, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_numpy_parser.py
+++ b/tests/unit/test_numpy_parser.py
@@ -15,21 +15,44 @@
 import struct
 import unittest
 
+from cassandra.cython_deps import HAVE_CYTHON, HAVE_NUMPY
+
 try:
+    from tests import VERIFY_CYTHON
+except ImportError:
+    VERIFY_CYTHON = False
+
+# cassandra.numpy_parser is a Cython extension (gated on HAVE_CYTHON), not a
+# pure-Python module -- HAVE_NUMPY (from cassandra.cython_deps) only tells us
+# whether the *numpy package itself* is importable, not whether numpy_parser
+# built/imports correctly. A single broad `except ImportError` around all of
+# these imports would conflate two very different situations:
+#   - numpy genuinely not installed (expected in a numpy-less environment;
+#     should skip cleanly), vs.
+#   - the Cython extension being broken or missing despite numpy being
+#     present (an unexpected regression that should FAIL the test run
+#     rather than hide behind a silently skipped test -- this is exactly
+#     how a real numpy_parser regression could slip through a green CI run).
+#
+# So gate on HAVE_CYTHON and HAVE_NUMPY together (the same compound
+# condition as the `numpytest` decorator in tests/unit/cython/utils.py,
+# including its VERIFY_CYTHON override for CI configurations that require
+# Cython support to be present); only skip when Cython and/or numpy support
+# is genuinely absent, and otherwise import unconditionally so a broken
+# extension surfaces as a real ImportError/test failure.
+HAVE_NUMPY_PARSER = (HAVE_CYTHON and HAVE_NUMPY) or VERIFY_CYTHON
+
+if HAVE_NUMPY_PARSER:
     import numpy as np
     from cassandra.numpy_parser import NumpyParser
     from cassandra.bytesio import BytesIOReader
     from cassandra.parsing import ParseDesc
     from cassandra.deserializers import obj_array, make_deserializers
 
-    HAVE_NUMPY = True
-except ImportError:
-    HAVE_NUMPY = False
-
 from cassandra import cqltypes
 
 
-@unittest.skipUnless(HAVE_NUMPY, "NumPy not available")
+@unittest.skipUnless(HAVE_NUMPY_PARSER, "NumPy/Cython extension not available")
 class TestNumpyParserVectorType(unittest.TestCase):
     """Tests for VectorType support in NumpyParser"""
 
@@ -476,6 +499,72 @@ class TestNumpyParserVectorType(unittest.TestCase):
         null_row_bytes = arr.data[1].tobytes()
         self.assertEqual(null_row_bytes, b"\x00" * len(null_row_bytes))
 
+    def test_oversized_vector_payload_raises(self):
+        """Test that a vector payload larger than the array stride is rejected.
+
+        Guards against a memcpy buffer overflow: unpack_row() must not trust
+        an oversized buf.size and copy past the end of the preallocated row.
+        """
+        vector_size = 3
+        vector_type = self._create_vector_type(cqltypes.FloatType, vector_size)
+
+        buffer = bytearray()
+        buffer.extend(struct.pack(">i", 1))  # row count
+
+        # Claim 4 floats (16 bytes) worth of payload for a 3-float (12 byte)
+        # column stride.
+        buffer.extend(struct.pack(">i", 16))
+        buffer.extend(struct.pack(">4f", 1.0, 2.0, 3.0, 4.0))
+
+        parser = NumpyParser()
+        reader = BytesIOReader(bytes(buffer))
+
+        desc = ParseDesc(
+            colnames=["vec"],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=obj_array([None]),
+            protocol_version=5,
+        )
+
+        with self.assertRaisesRegex(ValueError, r"'vec'"):
+            parser.parse_rows(reader, desc)
+
+    def test_undersized_vector_payload_raises(self):
+        """Test that a vector payload smaller than the array stride is rejected.
+
+        An undersized payload must not be silently accepted: without a
+        strict equality check, memcpy would only fill part of the row,
+        leaving the remaining bytes uninitialized/stale (a correctness and
+        potential info-leak issue), rather than raising.
+        """
+        vector_size = 4
+        vector_type = self._create_vector_type(cqltypes.FloatType, vector_size)
+
+        buffer = bytearray()
+        buffer.extend(struct.pack(">i", 1))  # row count
+
+        # Claim only 3 floats (12 bytes) worth of payload for a 4-float
+        # (16 byte) column stride.
+        buffer.extend(struct.pack(">i", 12))
+        buffer.extend(struct.pack(">3f", 1.0, 2.0, 3.0))
+
+        parser = NumpyParser()
+        reader = BytesIOReader(bytes(buffer))
+
+        desc = ParseDesc(
+            colnames=["vec"],
+            coltypes=[vector_type],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=obj_array([None]),
+            protocol_version=5,
+        )
+
+        with self.assertRaisesRegex(ValueError, r"'vec'"):
+            parser.parse_rows(reader, desc)
+
     def test_unsupported_subtype_falls_back_to_object_array(self):
         """Test that an unsupported vector subtype falls back to an object array"""
         vector_size = 2
@@ -531,6 +620,70 @@ class TestNumpyParserVectorType(unittest.TestCase):
 
         for i, expected_vector in enumerate(vectors):
             self.assertEqual(list(arr[i]), expected_vector)
+
+
+@unittest.skipUnless(HAVE_NUMPY_PARSER, "NumPy/Cython extension not available")
+class TestNumpyParserScalarType(unittest.TestCase):
+    """Regression tests for the plain (non-vector) scalar column fast path.
+
+    `_cqltype_to_numpy` in cassandra/numpy_parser.pyx is shared by two call
+    sites in make_array(): VectorType.subtype dispatch and plain scalar
+    top-level column dispatch. A fix aimed only at excluding a subtype from
+    the vector fast path (e.g. ShortType, which is vint-prefixed *inside* a
+    vector) must not remove that subtype's entry from the shared dict
+    outright, since that would also silently regress the scalar column fast
+    path for the exact same type (ShortType/smallint *is* fixed-width as a
+    scalar column). These tests guard against that regression.
+    """
+
+    def test_scalar_smallint_uses_fast_masked_int16_array(self):
+        """smallint (ShortType) is fixed-width (2 bytes, big-endian, no
+        length prefix) as a scalar column -- unlike inside a VectorType,
+        where it is vint-length-prefixed per element. It must still get the
+        fast masked int16 array here, not fall back to a slow 1D object
+        array.
+        """
+        from cassandra.numpy_parser import make_array
+
+        arr = make_array(cqltypes.ShortType, 5)
+
+        self.assertNotEqual(arr.dtype, np.dtype("O"))
+        self.assertEqual(arr.dtype, np.dtype(">i2"))
+        self.assertTrue(hasattr(arr, "mask"))
+        self.assertEqual(arr.shape, (5,))
+
+    def test_scalar_smallint_round_trips_end_to_end(self):
+        """End-to-end companion: parse actual wire bytes for a smallint
+        column through NumpyParser.parse_rows() and confirm the result is a
+        native int16 (masked) array with the correct values, not an object
+        array.
+        """
+        values = [1, -5, 32767, -32768, 0]
+
+        buffer = bytearray()
+        buffer.extend(struct.pack(">i", len(values)))  # row count
+        for v in values:
+            buffer.extend(struct.pack(">i", 2))  # smallint byte size
+            buffer.extend(struct.pack(">h", v))
+
+        parser = NumpyParser()
+        reader = BytesIOReader(bytes(buffer))
+
+        desc = ParseDesc(
+            colnames=["small"],
+            coltypes=[cqltypes.ShortType],
+            column_encryption_policy=None,
+            coldescs=None,
+            deserializers=obj_array([None]),
+            protocol_version=5,
+        )
+
+        result = parser.parse_rows(reader, desc)
+        arr = result["small"]
+
+        self.assertNotEqual(arr.dtype, np.dtype("O"))
+        self.assertEqual(arr.shape, (len(values),))
+        np.testing.assert_array_equal(arr, np.array(values, dtype=np.int16))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add native VectorType support to the NumPy row parser, producing 2D masked arrays of shape `(num_rows, vector_dimension)` instead of falling back to object arrays
- Enables zero-copy vector data ingestion for ML/AI workloads using the NumPy result path

## Details

**Changes to `cassandra/numpy_parser.pyx`:**
- `make_array()` detects VectorType columns and creates 2D `np.ma.empty((array_size, vector_size), dtype=...)` arrays with the correct numeric dtype (float32, float64, int32, int64, int16)
- `ArrDesc` extended with `mask_stride` field to handle 2D mask arrays where stride = `vector_dimension` bools (not 1 bool)
- `unpack_row()` uses direct `memcpy` of the full vector payload (e.g., 3072 bytes for float[768]) into the pre-allocated 2D array buffer
- `make_native_byteorder()` handles bulk byte-swap on any-dimensional arrays transparently
- Falls back to object arrays for unsupported vector subtypes

**Result:** For a query returning N rows of `Vector<float, 768>`, the NumpyParser produces an `(N, 768)` float32 array directly from wire bytes — the fastest possible path when consuming results as numpy arrays.

**Tests:** Comprehensive unit tests in `tests/unit/test_numpy_parser.py` covering all supported numeric subtypes, NULL handling, mask strides, and unsupported type fallback.

This commit is fully independent — it only modifies `numpy_parser.pyx` and adds a new test file.