### PR TITLE
(improvement) perf: remove copies on the read path (us improvements - x1.5-3.7 speedup!)

### DIFF
--- a/benchmarks/decode_benchmark.py
+++ b/benchmarks/decode_benchmark.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Isolated benchmark for ProtocolHandler.decode_message().
+
+Measures the throughput of decoding synthetic RESULT/ROWS messages of
+varying sizes.  Does NOT require a live Cassandra/Scylla cluster.
+
+Run on both ``master`` and the ``remove_copies`` branch to compare:
+
+    python benchmarks/decode_benchmark.py
+    python benchmarks/decode_benchmark.py --scenarios small_100,large_5k_1KB
+    python benchmarks/decode_benchmark.py --cython-only --iterations 20
+    python benchmarks/decode_benchmark.py --cprofile medium_1k_1KB
+"""
+
+from __future__ import print_function
+
+import argparse
+import gc
+import os
+import statistics
+import struct
+import sys
+import time
+
+# ---------------------------------------------------------------------------
+# Pin to a single CPU core for consistent results
+# ---------------------------------------------------------------------------
+try:
+    os.sched_setaffinity(0, {0})
+except (AttributeError, OSError):
+    # sched_setaffinity is Linux-only; silently skip on other platforms
+    pass
+
+# ---------------------------------------------------------------------------
+# Make sure the driver package is importable from the repo root
+# ---------------------------------------------------------------------------
+_benchdir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_benchdir, ".."))
+
+from io import BytesIO
+from cassandra.marshal import int32_pack, int64_pack, double_pack
+from cassandra.protocol import (
+    write_int,
+    write_short,
+    write_string,
+    write_value,
+    ProtocolHandler,
+    _ProtocolHandler,
+    HAVE_CYTHON,
+)
+
+# ---------------------------------------------------------------------------
+# CQL type codes (native protocol v4)
+# ---------------------------------------------------------------------------
+TYPE_BIGINT = 0x0002
+TYPE_BLOB = 0x0003
+TYPE_DOUBLE = 0x0007
+TYPE_INT = 0x0009
+TYPE_VARCHAR = 0x000D
+
+# Metadata flag
+_FLAGS_GLOBAL_TABLES_SPEC = 0x0001
+
+# ResultMessage kind
+_RESULT_KIND_ROWS = 0x0002
+
+# ResultMessage opcode
+_OPCODE_RESULT = 0x08
+
+
+# ======================================================================
+# Synthetic message construction
+# ======================================================================
+
+
+def _build_rows_body(columns, row_values_fn, row_count):
+    """
+    Build the raw bytes for a RESULT/ROWS message body.
+
+    Parameters
+    ----------
+    columns : list of (name: str, type_code: int)
+        Column definitions.
+    row_values_fn : callable() -> list[bytes|None]
+        Returns one row of pre-encoded cell values each time it is called.
+    row_count : int
+        Number of rows to encode.
+
+    Returns
+    -------
+    bytes
+        Complete RESULT body ready for ``decode_message()``.
+    """
+    buf = BytesIO()
+
+    # kind = ROWS
+    write_int(buf, _RESULT_KIND_ROWS)
+
+    # --- metadata ---
+    write_int(buf, _FLAGS_GLOBAL_TABLES_SPEC)
+    write_int(buf, len(columns))
+    write_string(buf, "ks")
+    write_string(buf, "tbl")
+    for col_name, type_code in columns:
+        write_string(buf, col_name)
+        write_short(buf, type_code)
+
+    # --- rows ---
+    write_int(buf, row_count)
+    for _ in range(row_count):
+        for cell in row_values_fn():
+            write_value(buf, cell)
+
+    return buf.getvalue()
+
+
+# ======================================================================
+# Scenario definitions
+# ======================================================================
+
+
+def _make_text(size):
+    """Return a UTF-8 encoded bytes value of exactly *size* bytes."""
+    return b"x" * size
+
+
+def _scenario_small_100():
+    """100 rows, 3 cols (text 50B, int, bigint) ~3 KB"""
+    columns = [
+        ("col_text", TYPE_VARCHAR),
+        ("col_int", TYPE_INT),
+        ("col_bigint", TYPE_BIGINT),
+    ]
+    text_val = _make_text(50)
+    int_val = int32_pack(42)
+    bigint_val = int64_pack(123456789)
+    row = lambda: [text_val, int_val, bigint_val]
+    return _build_rows_body(columns, row, 100)
+
+
+def _scenario_medium_1k_256B():
+    """1000 rows, 3 cols (text 256B, int, bigint) ~273 KB"""
+    columns = [
+        ("col_text", TYPE_VARCHAR),
+        ("col_int", TYPE_INT),
+        ("col_bigint", TYPE_BIGINT),
+    ]
+    text_val = _make_text(256)
+    int_val = int32_pack(42)
+    bigint_val = int64_pack(123456789)
+    row = lambda: [text_val, int_val, bigint_val]
+    return _build_rows_body(columns, row, 1000)
+
+
+def _scenario_medium_1k_1KB():
+    """1000 rows, 3 cols (text 1024B, int, bigint) ~1 MB"""
+    columns = [
+        ("col_text", TYPE_VARCHAR),
+        ("col_int", TYPE_INT),
+        ("col_bigint", TYPE_BIGINT),
+    ]
+    text_val = _make_text(1024)
+    int_val = int32_pack(42)
+    bigint_val = int64_pack(123456789)
+    row = lambda: [text_val, int_val, bigint_val]
+    return _build_rows_body(columns, row, 1000)
+
+
+def _scenario_large_5k_1KB():
+    """5000 rows, 3 cols (text 1024B, int, bigint) ~5 MB"""
+    columns = [
+        ("col_text", TYPE_VARCHAR),
+        ("col_int", TYPE_INT),
+        ("col_bigint", TYPE_BIGINT),
+    ]
+    text_val = _make_text(1024)
+    int_val = int32_pack(42)
+    bigint_val = int64_pack(123456789)
+    row = lambda: [text_val, int_val, bigint_val]
+    return _build_rows_body(columns, row, 5000)
+
+
+def _scenario_large_1k_4KB():
+    """1000 rows, 3 cols (text 4096B, int, bigint) ~4 MB"""
+    columns = [
+        ("col_text", TYPE_VARCHAR),
+        ("col_int", TYPE_INT),
+        ("col_bigint", TYPE_BIGINT),
+    ]
+    text_val = _make_text(4096)
+    int_val = int32_pack(42)
+    bigint_val = int64_pack(123456789)
+    row = lambda: [text_val, int_val, bigint_val]
+    return _build_rows_body(columns, row, 1000)
+
+
+def _scenario_wide_5k_doubles():
+    """5000 rows, 10 cols (10x double) ~586 KB"""
+    columns = [("col_d%d" % i, TYPE_DOUBLE) for i in range(10)]
+    vals = [double_pack(1.0 + i * 0.1) for i in range(10)]
+    row = lambda: list(vals)
+    return _build_rows_body(columns, row, 5000)
+
+
+def _scenario_wide_1k_20cols():
+    """1000 rows, 20 cols (10x text 64B, 5x int, 3x bigint, 2x double) ~850 KB"""
+    columns = []
+    for i in range(10):
+        columns.append(("col_text%d" % i, TYPE_VARCHAR))
+    for i in range(5):
+        columns.append(("col_int%d" % i, TYPE_INT))
+    for i in range(3):
+        columns.append(("col_bigint%d" % i, TYPE_BIGINT))
+    for i in range(2):
+        columns.append(("col_double%d" % i, TYPE_DOUBLE))
+
+    text_val = _make_text(64)
+    int_val = int32_pack(42)
+    bigint_val = int64_pack(123456789)
+    double_val = double_pack(3.14159)
+
+    def row():
+        cells = []
+        for _ in range(10):
+            cells.append(text_val)
+        for _ in range(5):
+            cells.append(int_val)
+        for _ in range(3):
+            cells.append(bigint_val)
+        for _ in range(2):
+            cells.append(double_val)
+        return cells
+
+    return _build_rows_body(columns, row, 1000)
+
+
+def _scenario_blob_1k_16KB():
+    """1000 rows, 2 cols (int, 16 KB blob) ~16 MB"""
+    columns = [
+        ("col_int", TYPE_INT),
+        ("col_blob", TYPE_BLOB),
+    ]
+    int_val = int32_pack(42)
+    blob_val = os.urandom(16384)
+    row = lambda: [int_val, blob_val]
+    return _build_rows_body(columns, row, 1000)
+
+
+SCENARIOS = {
+    "small_100": ("100 rows, 3 cols (text 50B, int, bigint)", _scenario_small_100),
+    "medium_1k_256B": (
+        "1000 rows, 3 cols (text 256B, int, bigint)",
+        _scenario_medium_1k_256B,
+    ),
+    "medium_1k_1KB": (
+        "1000 rows, 3 cols (text 1024B, int, bigint)",
+        _scenario_medium_1k_1KB,
+    ),
+    "large_5k_1KB": (
+        "5000 rows, 3 cols (text 1024B, int, bigint)",
+        _scenario_large_5k_1KB,
+    ),
+    "large_1k_4KB": (
+        "1000 rows, 3 cols (text 4096B, int, bigint)",
+        _scenario_large_1k_4KB,
+    ),
+    "wide_5k_doubles": ("5000 rows, 10 cols (10x double)", _scenario_wide_5k_doubles),
+    "wide_1k_20cols": (
+        "1000 rows, 20 cols (10x text64, 5x int, ...)",
+        _scenario_wide_1k_20cols,
+    ),
+    "blob_1k_16KB": ("1000 rows, 2 cols (int, 16 KB blob)", _scenario_blob_1k_16KB),
+}
+
+# Ordered list so output is deterministic
+SCENARIO_ORDER = [
+    "small_100",
+    "medium_1k_256B",
+    "medium_1k_1KB",
+    "large_5k_1KB",
+    "large_1k_4KB",
+    "wide_5k_doubles",
+    "wide_1k_20cols",
+    "blob_1k_16KB",
+]
+
+
+# ======================================================================
+# Benchmark runner
+# ======================================================================
+
+
+def _decode(handler, body):
+    """Call decode_message with the standard benchmark parameters."""
+    return handler.decode_message(
+        protocol_version=4,
+        protocol_features=None,
+        user_type_map={},
+        stream_id=0,
+        flags=0,
+        opcode=_OPCODE_RESULT,
+        body=body,
+        decompressor=None,
+        result_metadata=None,
+    )
+
+
+def _run_iterations(handler, body, iterations, warmup):
+    """
+    Run *warmup* + *iterations* decode calls, return list of elapsed
+    times (seconds) for the measured iterations only.
+    """
+    # Warm-up: let JIT / caches settle
+    for _ in range(warmup):
+        _decode(handler, body)
+
+    gc.disable()
+    try:
+        times = []
+        for _ in range(iterations):
+            t0 = time.perf_counter()
+            _decode(handler, body)
+            t1 = time.perf_counter()
+            times.append(t1 - t0)
+    finally:
+        gc.enable()
+    return times
+
+
+def _format_time(seconds):
+    """Human-readable time string.  Always reports in microseconds for
+    consistent cross-scenario comparison."""
+    return "%.1f us" % (seconds * 1e6)
+
+
+def _format_throughput(body_size, seconds):
+    """MB/s throughput string."""
+    mb = body_size / (1024 * 1024)
+    return "%.1f MB/s" % (mb / seconds)
+
+
+def _report(label, times, body_size, row_count):
+    """Print a single result line."""
+    t_min = min(times)
+    t_med = statistics.median(times)
+    t_mean = statistics.mean(times)
+    rows_per_sec = row_count / t_med
+
+    if rows_per_sec >= 1e6:
+        rps_str = "%.2fM rows/s" % (rows_per_sec / 1e6)
+    elif rows_per_sec >= 1e3:
+        rps_str = "%.0fK rows/s" % (rows_per_sec / 1e3)
+    else:
+        rps_str = "%.0f rows/s" % rows_per_sec
+
+    print(
+        "  %-14s  min=%s  median=%s  mean=%s  (%s, %s)"
+        % (
+            label,
+            _format_time(t_min),
+            _format_time(t_med),
+            _format_time(t_mean),
+            _format_throughput(body_size, t_med),
+            rps_str,
+        )
+    )
+
+
+def _extract_row_count(scenario_name):
+    """Infer the row count from the scenario name for rows/s reporting."""
+    mapping = {
+        "small_100": 100,
+        "medium_1k_256B": 1000,
+        "medium_1k_1KB": 1000,
+        "large_5k_1KB": 5000,
+        "large_1k_4KB": 1000,
+        "wide_5k_doubles": 5000,
+        "wide_1k_20cols": 1000,
+        "blob_1k_16KB": 1000,
+    }
+    return mapping.get(scenario_name, 0)
+
+
+def run_benchmark(
+    scenarios, iterations, warmup, cython_only, python_only, cprofile_scenario
+):
+    """
+    Run the benchmark for each requested scenario.
+    """
+    print("=" * 78)
+    print("Decode Benchmark")
+    print("=" * 78)
+    print("  Cython available : %s" % HAVE_CYTHON)
+    print("  Iterations       : %d (+ %d warmup)" % (iterations, warmup))
+    print("  CPU pinned       : %s" % _is_pinned())
+    print()
+
+    handlers = []
+    if not python_only:
+        if HAVE_CYTHON:
+            handlers.append(("Cython", ProtocolHandler))
+        elif not cython_only:
+            print("  [NOTE] Cython extensions not available, skipping Cython path\n")
+    if not cython_only:
+        handlers.append(("Python", _ProtocolHandler))
+
+    if not handlers:
+        print(
+            "ERROR: no handlers selected (Cython not available and --cython-only set)"
+        )
+        sys.exit(1)
+
+    profiler = None
+    if cprofile_scenario:
+        import cProfile
+
+        profiler = cProfile.Profile()
+
+    for name in scenarios:
+        desc, builder = SCENARIOS[name]
+        body = builder()
+        body_size = len(body)
+        row_count = _extract_row_count(name)
+
+        print("Scenario: %s  (%s, %s body)" % (name, desc, _format_size(body_size)))
+
+        for label, handler in handlers:
+            if profiler and name == cprofile_scenario:
+                profiler.enable()
+
+            times = _run_iterations(handler, body, iterations, warmup)
+
+            if profiler and name == cprofile_scenario:
+                profiler.disable()
+
+            _report(label + ":", times, body_size, row_count)
+
+        print()
+
+    if profiler:
+        print("-" * 78)
+        print("cProfile results for scenario '%s':" % cprofile_scenario)
+        print("-" * 78)
+        import pstats
+
+        stats = pstats.Stats(profiler)
+        stats.strip_dirs()
+        stats.sort_stats("cumulative")
+        stats.print_stats(30)
+
+
+def _format_size(nbytes):
+    """Human-readable byte size."""
+    if nbytes >= 1024 * 1024:
+        return "%.1f MB" % (nbytes / (1024 * 1024))
+    elif nbytes >= 1024:
+        return "%.1f KB" % (nbytes / 1024)
+    else:
+        return "%d B" % nbytes
+
+
+def _is_pinned():
+    """Check if the process is pinned to a single CPU core."""
+    try:
+        affinity = os.sched_getaffinity(0)
+        return len(affinity) == 1
+    except (AttributeError, OSError):
+        return False
+
+
+# ======================================================================
+# CLI
+# ======================================================================
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Isolated decode_message benchmark (no cluster required)"
+    )
+    parser.add_argument(
+        "--iterations",
+        "-n",
+        type=int,
+        default=10,
+        help="Number of timed iterations per scenario (default: 10)",
+    )
+    parser.add_argument(
+        "--warmup",
+        "-w",
+        type=int,
+        default=3,
+        help="Number of warmup iterations (default: 3)",
+    )
+    parser.add_argument(
+        "--scenarios",
+        "-s",
+        type=str,
+        default=None,
+        help="Comma-separated list of scenarios to run (default: all). "
+        "Available: %s" % ", ".join(SCENARIO_ORDER),
+    )
+    parser.add_argument(
+        "--cython-only",
+        action="store_true",
+        default=False,
+        help="Only benchmark the Cython (fast) path",
+    )
+    parser.add_argument(
+        "--python-only",
+        action="store_true",
+        default=False,
+        help="Only benchmark the pure-Python path",
+    )
+    parser.add_argument(
+        "--cprofile",
+        type=str,
+        default=None,
+        metavar="SCENARIO",
+        help="Enable cProfile for the named scenario and print top-30 stats",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        default=False,
+        help="List available scenarios and exit",
+    )
+
+    args = parser.parse_args()
+
+    if args.list:
+        print("Available scenarios:")
+        for name in SCENARIO_ORDER:
+            desc, builder = SCENARIOS[name]
+            print("  %-20s  %s" % (name, desc))
+        sys.exit(0)
+
+    if args.cython_only and args.python_only:
+        parser.error("--cython-only and --python-only are mutually exclusive")
+
+    if args.scenarios:
+        selected = [s.strip() for s in args.scenarios.split(",")]
+        for s in selected:
+            if s not in SCENARIOS:
+                parser.error("Unknown scenario: %s" % s)
+    else:
+        selected = list(SCENARIO_ORDER)
+
+    if args.cprofile and args.cprofile not in selected:
+        parser.error(
+            "--cprofile scenario '%s' is not in the selected scenarios" % args.cprofile
+        )
+
+    run_benchmark(
+        scenarios=selected,
+        iterations=args.iterations,
+        warmup=args.warmup,
+        cython_only=args.cython_only,
+        python_only=args.python_only,
+        cprofile_scenario=args.cprofile,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cassandra/bytesio.pxd
+++ b/cassandra/bytesio.pxd
@@ -17,4 +17,5 @@ cdef class BytesIOReader:
     cdef char *buf_ptr
     cdef Py_ssize_t pos
     cdef Py_ssize_t size
+    cdef Py_ssize_t _initial_offset
     cdef char *read(self, Py_ssize_t n = ?) except NULL

--- a/cassandra/bytesio.pyx
+++ b/cassandra/bytesio.pyx
@@ -16,12 +16,18 @@ cdef class BytesIOReader:
     """
     This class provides efficient support for reading bytes from a 'bytes' buffer,
     by returning char * values directly without allocating intermediate objects.
+
+    An optional offset allows reading from the middle of an existing buffer,
+    avoiding a copy when only a suffix of the bytes is needed.
     """
 
-    def __init__(self, bytes buf):
+    def __init__(self, bytes buf, Py_ssize_t offset=0):
+        if offset < 0 or offset > len(buf):
+            raise ValueError("offset %d out of range for buffer of length %d" % (offset, len(buf)))
         self.buf = buf
-        self.size = len(buf)
-        self.buf_ptr = self.buf
+        self._initial_offset = offset
+        self.size = len(buf) - offset
+        self.buf_ptr = <char*>self.buf + offset
 
     cdef char *read(self, Py_ssize_t n = -1) except NULL:
         """Read at most size bytes from the file

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -926,6 +926,17 @@ class Cluster(object):
     To try with your own workload, set ``sockopts = [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]``
     """
 
+    in_buffer_size = None
+    """
+    An optional override (in bytes) for the per-connection socket receive
+    buffer size (see :attr:`.Connection.in_buffer_size`, which defaults to
+    16 KiB). A larger value reduces the number of ``recv()`` calls needed to
+    read large result sets, at the cost of additional steady-state memory
+    per connection -- a cost that is multiplied by the number of connections
+    in the pool, so it may matter at scale. Leave unset to use the
+    connection class's default.
+    """
+
     max_schema_agreement_wait = 10
     """
     The maximum duration (in seconds) that the driver will wait for schema
@@ -1233,6 +1244,7 @@ class Cluster(object):
                  connection_class=None,
                  ssl_options=None,
                  sockopts=None,
+                 in_buffer_size=None,
                  cql_version=None,
                  protocol_version=_NOT_SET,
                  executor_threads=2,
@@ -1518,6 +1530,7 @@ class Cluster(object):
         self.ssl_options = ssl_options
         self.ssl_context = ssl_context
         self.sockopts = sockopts
+        self.in_buffer_size = in_buffer_size
         self.cql_version = cql_version
         self.max_schema_agreement_wait = max_schema_agreement_wait
         self.control_connection_timeout = control_connection_timeout
@@ -1762,6 +1775,7 @@ class Cluster(object):
         kwargs_dict.setdefault('port', self.port)
         kwargs_dict.setdefault('compression', self.compression)
         kwargs_dict.setdefault('sockopts', self.sockopts)
+        kwargs_dict.setdefault('in_buffer_size', self.in_buffer_size)
         kwargs_dict.setdefault('ssl_options', self.ssl_options)
         kwargs_dict.setdefault('ssl_context', self.ssl_context)
         kwargs_dict.setdefault('cql_version', self.cql_version)

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -746,14 +746,28 @@ class _ConnectionIOBuffer(object):
     def readable_cql_frame_bytes(self):
         return self.cql_frame_buffer.tell()
 
+    @staticmethod
+    def _reset_buffer(buf):
+        """
+        Reset a BytesIO buffer by discarding consumed data.
+
+        Uses ``getbuffer()[pos:]`` (a zero-copy memoryview slice) instead of
+        ``.read()`` which would first allocate an intermediate ``bytes`` object.
+        The ``BytesIO()`` constructor still copies the data into its own backing
+        store either way, so the net saving is one temporary ``bytes`` allocation
+        on the hot receive path.
+        """
+        pos = buf.tell()
+        new_buf = io.BytesIO(buf.getbuffer()[pos:])
+        new_buf.seek(0, 2)  # 2 == SEEK_END
+        return new_buf
+
     def reset_io_buffer(self):
-        self._io_buffer = io.BytesIO(self._io_buffer.read())
-        self._io_buffer.seek(0, 2)  # 2 == SEEK_END
+        self._io_buffer = self._reset_buffer(self._io_buffer)
 
     def reset_cql_frame_buffer(self):
         if self.is_checksumming_enabled:
-            self._cql_frame_buffer = io.BytesIO(self._cql_frame_buffer.read())
-            self._cql_frame_buffer.seek(0, 2)  # 2 == SEEK_END
+            self._cql_frame_buffer = self._reset_buffer(self._cql_frame_buffer)
         else:
             self.reset_io_buffer()
 
@@ -787,7 +801,9 @@ class Connection(object):
 
     CALLBACK_ERR_THREAD_THRESHOLD = 100
 
-    in_buffer_size = 4096
+    # 16 KiB recv buffer reduces the number of syscalls when reading
+    # large result sets, at a modest per-connection memory cost.
+    in_buffer_size = 16384
     out_buffer_size = 4096
 
     cql_version = None
@@ -1307,19 +1323,23 @@ class Connection(object):
 
     @defunct_on_error
     def _read_frame_header(self):
-        buf = self._io_buffer.cql_frame_buffer.getvalue()
-        pos = len(buf)
+        cql_buf = self._io_buffer.cql_frame_buffer
+        pos = cql_buf.tell()
         if pos:
-            version = buf[0] & PROTOCOL_VERSION_MASK
-            if version not in ProtocolVersion.SUPPORTED_VERSIONS:
-                raise ProtocolError("This version of the driver does not support protocol version %d" % version)
-            # this frame header struct is everything after the version byte
-            header_size = frame_header_v3.size + 1
-            if pos >= header_size:
-                flags, stream, op, body_len = frame_header_v3.unpack_from(buf, 1)
-                if body_len < 0:
-                    raise ProtocolError("Received negative body length: %r" % body_len)
-                self._current_frame = _Frame(version, flags, stream, op, header_size, body_len + header_size)
+            buf = cql_buf.getbuffer()
+            try:
+                version = buf[0] & PROTOCOL_VERSION_MASK
+                if version not in ProtocolVersion.SUPPORTED_VERSIONS:
+                    raise ProtocolError("This version of the driver does not support protocol version %d" % version)
+                # this frame header struct is everything after the version byte
+                header_size = frame_header_v3.size + 1
+                if pos >= header_size:
+                    flags, stream, op, body_len = frame_header_v3.unpack_from(buf, 1)
+                    if body_len < 0:
+                        raise ProtocolError("Received negative body length: %r" % body_len)
+                    self._current_frame = _Frame(version, flags, stream, op, header_size, body_len + header_size)
+            finally:
+                del buf  # release memoryview before any buffer mutation
         return pos
 
     @defunct_on_error
@@ -1373,8 +1393,16 @@ class Connection(object):
                 return
             else:
                 frame = self._current_frame
-                self._io_buffer.cql_frame_buffer.seek(frame.body_offset)
-                msg = self._io_buffer.cql_frame_buffer.read(frame.end_pos - frame.body_offset)
+                # Use memoryview to avoid intermediate allocation, then
+                # convert to bytes.  Explicitly release the memoryview
+                # before any buffer mutation (seek / reset).
+                cql_buf = self._io_buffer.cql_frame_buffer
+                buf = cql_buf.getbuffer()
+                try:
+                    msg = bytes(buf[frame.body_offset:frame.end_pos])
+                finally:
+                    del buf  # release memoryview before buffer mutation
+                cql_buf.seek(frame.end_pos)
                 self.process_msg(frame, msg)
                 self._io_buffer.reset_cql_frame_buffer()
                 self._current_frame = None

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -746,14 +746,32 @@ class _ConnectionIOBuffer(object):
     def readable_cql_frame_bytes(self):
         return self.cql_frame_buffer.tell()
 
+    @staticmethod
+    def _reset_buffer(buf):
+        """
+        Reset a BytesIO buffer by discarding consumed data.
+
+        Uses ``getbuffer()[pos:]`` (a zero-copy memoryview slice) instead of
+        ``.read()`` which would first allocate an intermediate ``bytes`` object.
+        The ``BytesIO()`` constructor still copies the data into its own backing
+        store either way, so the net saving is one temporary ``bytes`` allocation
+        on the hot receive path.
+        """
+        pos = buf.tell()
+        view = buf.getbuffer()
+        try:
+            new_buf = io.BytesIO(view[pos:])
+        finally:
+            del view  # release memoryview before any buffer mutation
+        new_buf.seek(0, 2)  # 2 == SEEK_END
+        return new_buf
+
     def reset_io_buffer(self):
-        self._io_buffer = io.BytesIO(self._io_buffer.read())
-        self._io_buffer.seek(0, 2)  # 2 == SEEK_END
+        self._io_buffer = self._reset_buffer(self._io_buffer)
 
     def reset_cql_frame_buffer(self):
         if self.is_checksumming_enabled:
-            self._cql_frame_buffer = io.BytesIO(self._cql_frame_buffer.read())
-            self._cql_frame_buffer.seek(0, 2)  # 2 == SEEK_END
+            self._cql_frame_buffer = self._reset_buffer(self._cql_frame_buffer)
         else:
             self.reset_io_buffer()
 
@@ -787,7 +805,13 @@ class Connection(object):
 
     CALLBACK_ERR_THREAD_THRESHOLD = 100
 
-    in_buffer_size = 4096
+    # 16 KiB recv buffer reduces the number of syscalls when reading
+    # large result sets, at a modest per-connection memory cost (this is
+    # multiplied by the number of connections in the pool, so it can matter
+    # at scale). Override via the ``in_buffer_size`` kwarg, or globally via
+    # :attr:`.Cluster.in_buffer_size`, if the extra per-connection memory is
+    # a concern or if a different value benchmarks better for your workload.
+    in_buffer_size = 16384
     out_buffer_size = 4096
 
     cql_version = None
@@ -880,7 +904,8 @@ class Connection(object):
                  cql_version=None, protocol_version=ProtocolVersion.MAX_SUPPORTED, is_control_connection=False,
                  user_type_map=None, connect_timeout=None, allow_beta_protocol_version=False, no_compact=False,
                  ssl_context=None, owning_pool=None, shard_id=None, total_shards=None,
-                 on_orphaned_stream_released=None, application_info: Optional[ApplicationInfoBase] = None):
+                 on_orphaned_stream_released=None, application_info: Optional[ApplicationInfoBase] = None,
+                 in_buffer_size=None):
         # TODO next major rename host to endpoint and remove port kwarg.
         self.endpoint = host if isinstance(host, EndPoint) else DefaultEndPoint(host, port)
 
@@ -889,6 +914,8 @@ class Connection(object):
         self.ssl_context = ssl_context
         self.sockopts = sockopts
         self.compression = compression
+        if in_buffer_size is not None:
+            self.in_buffer_size = in_buffer_size
         self.cql_version = cql_version
         self.protocol_version = protocol_version
         self.is_control_connection = is_control_connection
@@ -1313,19 +1340,23 @@ class Connection(object):
 
     @defunct_on_error
     def _read_frame_header(self):
-        buf = self._io_buffer.cql_frame_buffer.getvalue()
-        pos = len(buf)
+        cql_buf = self._io_buffer.cql_frame_buffer
+        pos = cql_buf.tell()
         if pos:
-            version = buf[0] & PROTOCOL_VERSION_MASK
-            if version not in ProtocolVersion.SUPPORTED_VERSIONS:
-                raise ProtocolError("This version of the driver does not support protocol version %d" % version)
-            # this frame header struct is everything after the version byte
-            header_size = frame_header_v3.size + 1
-            if pos >= header_size:
-                flags, stream, op, body_len = frame_header_v3.unpack_from(buf, 1)
-                if body_len < 0:
-                    raise ProtocolError("Received negative body length: %r" % body_len)
-                self._current_frame = _Frame(version, flags, stream, op, header_size, body_len + header_size)
+            buf = cql_buf.getbuffer()
+            try:
+                version = buf[0] & PROTOCOL_VERSION_MASK
+                if version not in ProtocolVersion.SUPPORTED_VERSIONS:
+                    raise ProtocolError("This version of the driver does not support protocol version %d" % version)
+                # this frame header struct is everything after the version byte
+                header_size = frame_header_v3.size + 1
+                if pos >= header_size:
+                    flags, stream, op, body_len = frame_header_v3.unpack_from(buf, 1)
+                    if body_len < 0:
+                        raise ProtocolError("Received negative body length: %r" % body_len)
+                    self._current_frame = _Frame(version, flags, stream, op, header_size, body_len + header_size)
+            finally:
+                del buf  # release memoryview before any buffer mutation
         return pos
 
     @defunct_on_error
@@ -1379,8 +1410,16 @@ class Connection(object):
                 return
             else:
                 frame = self._current_frame
-                self._io_buffer.cql_frame_buffer.seek(frame.body_offset)
-                msg = self._io_buffer.cql_frame_buffer.read(frame.end_pos - frame.body_offset)
+                # Use memoryview to avoid intermediate allocation, then
+                # convert to bytes.  Explicitly release the memoryview
+                # before any buffer mutation (seek / reset).
+                cql_buf = self._io_buffer.cql_frame_buffer
+                buf = cql_buf.getbuffer()
+                try:
+                    msg = bytes(buf[frame.body_offset:frame.end_pos])
+                finally:
+                    del buf  # release memoryview before buffer mutation
+                cql_buf.seek(frame.end_pos)
                 self.process_msg(frame, msg)
                 self._io_buffer.reset_cql_frame_buffer()
                 self._current_frame = None

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -53,6 +53,43 @@ class NotSupportedError(Exception):
 class InternalError(Exception):
     pass
 
+
+class BytesReader:
+    """
+    Lightweight reader for bytes data without BytesIO overhead.
+    Provides the same read() interface but operates directly on a
+    bytes object, avoiding internal buffer copies.
+
+    Unlike io.BytesIO.read(n), read(n) raises EOFError when fewer than
+    n bytes remain.  This is intentional: protocol parsing should fail
+    fast on truncated or malformed frames rather than silently returning
+    short data.
+    """
+    __slots__ = ('_data', '_pos', '_size')
+
+    def __init__(self, data):
+        # Materialize memoryview up front so read() never needs to check
+        self._data = bytes(data) if isinstance(data, memoryview) else data
+        self._pos = 0
+        self._size = len(self._data)
+
+    def read(self, n=-1):
+        if n < 0:
+            result = self._data[self._pos:]
+            self._pos = self._size
+        else:
+            end = self._pos + n
+            if end > self._size:
+                raise EOFError("Cannot read past the end of the buffer")
+            result = self._data[self._pos:end]
+            self._pos = end
+        return result
+
+    def remaining_buffer(self):
+        """Return (underlying_bytes, current_position) for zero-copy handoff."""
+        return self._data, self._pos
+
+
 ColumnMetadata = namedtuple("ColumnMetadata", ['keyspace_name', 'table_name', 'name', 'type'])
 
 HEADER_DIRECTION_TO_CLIENT = 0x80
@@ -1155,7 +1192,8 @@ class _ProtocolHandler(object):
             body = decompressor(body)
             flags ^= COMPRESSED_FLAG
 
-        body = io.BytesIO(body)
+        # Use lightweight BytesReader instead of io.BytesIO to avoid buffer copy
+        body = BytesReader(body)
         if flags & TRACING_FLAG:
             trace_id = UUID(bytes=body.read(16))
             flags ^= TRACING_FLAG

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -56,6 +56,54 @@ class NotSupportedError(Exception):
 class InternalError(Exception):
     pass
 
+
+class BytesReader:
+    """
+    Lightweight reader for bytes data without BytesIO overhead.
+    Provides the same read() interface but operates directly on a
+    bytes object, avoiding internal buffer copies.
+
+    Unlike io.BytesIO.read(n), read(n) raises EOFError when fewer than
+    n bytes remain.  This is intentional: protocol parsing should fail
+    fast on truncated or malformed frames rather than silently returning
+    short data.
+
+    A plain, already-immutable ``bytes`` object is stored as-is (no copy):
+    downstream zero-copy consumers (e.g. the Cython row parser) keep a
+    reference to it via ``remaining_buffer()``, which is only safe because
+    ``bytes`` can never be mutated in place. Any other buffer-like input
+    (``memoryview``, ``bytearray``, ...) is materialized into a fresh
+    ``bytes`` copy up front, so a caller mutating or recycling its original
+    buffer afterwards can never corrupt or dangle a reader that's still
+    holding onto (or handing out slices of) this data.
+    """
+    __slots__ = ('_data', '_pos', '_size')
+
+    def __init__(self, data):
+        # Only a plain `bytes` object is guaranteed immutable and safe to
+        # alias without copying; anything else (memoryview, bytearray, ...)
+        # is materialized up front.
+        self._data = data if isinstance(data, bytes) else bytes(data)
+        self._pos = 0
+        self._size = len(self._data)
+
+    def read(self, n=-1):
+        if n < 0:
+            result = self._data[self._pos:]
+            self._pos = self._size
+        else:
+            end = self._pos + n
+            if end > self._size:
+                raise EOFError("Cannot read past the end of the buffer")
+            result = self._data[self._pos:end]
+            self._pos = end
+        return result
+
+    def remaining_buffer(self):
+        """Return (underlying_bytes, current_position) for zero-copy handoff."""
+        return self._data, self._pos
+
+
 ColumnMetadata = namedtuple("ColumnMetadata", ['keyspace_name', 'table_name', 'name', 'type'])
 
 HEADER_DIRECTION_TO_CLIENT = 0x80
@@ -1207,32 +1255,53 @@ class _ProtocolHandler(object):
             body = decompressor(body)
             flags ^= COMPRESSED_FLAG
 
-        body = io.BytesIO(body)
-        if flags & TRACING_FLAG:
-            trace_id = UUID(bytes=body.read(16))
-            flags ^= TRACING_FLAG
-        else:
-            trace_id = None
+        # Use lightweight BytesReader instead of io.BytesIO to avoid buffer copy.
+        #
+        # Unlike io.BytesIO, BytesReader.read(n) raises EOFError (rather than
+        # silently returning a short read) when the body is truncated. EOFError
+        # is not part of the driver's public decode-error vocabulary, so it is
+        # caught here -- at the decode_message() API boundary -- and translated
+        # into the canonical ProtocolError, the same exception type already
+        # used for other malformed-frame conditions (see _read_frame_header in
+        # connection.py). This keeps BytesReader itself generic/reusable while
+        # ensuring callers of this public entry point only ever see driver
+        # exception types for decode failures.
+        body = BytesReader(body)
+        try:
+            if flags & TRACING_FLAG:
+                trace_id = UUID(bytes=body.read(16))
+                flags ^= TRACING_FLAG
+            else:
+                trace_id = None
 
-        if flags & WARNING_FLAG:
-            warnings = read_stringlist(body)
-            flags ^= WARNING_FLAG
-        else:
-            warnings = None
+            if flags & WARNING_FLAG:
+                warnings = read_stringlist(body)
+                flags ^= WARNING_FLAG
+            else:
+                warnings = None
 
-        if flags & CUSTOM_PAYLOAD_FLAG:
-            custom_payload = read_bytesmap(body)
-            flags ^= CUSTOM_PAYLOAD_FLAG
-        else:
-            custom_payload = None
+            if flags & CUSTOM_PAYLOAD_FLAG:
+                custom_payload = read_bytesmap(body)
+                flags ^= CUSTOM_PAYLOAD_FLAG
+            else:
+                custom_payload = None
 
-        flags &= USE_BETA_MASK  # will only be set if we asserted it in connection estabishment
+            flags &= USE_BETA_MASK  # will only be set if we asserted it in connection estabishment
 
-        if flags:
-            log.warning("Unknown protocol flags set: %02x. May cause problems.", flags)
+            if flags:
+                log.warning("Unknown protocol flags set: %02x. May cause problems.", flags)
 
-        msg_class = cls.message_types_by_opcode[opcode]
-        msg = msg_class.recv_body(body, protocol_version, protocol_features, user_type_map, result_metadata, cls.column_encryption_policy)
+            msg_class = cls.message_types_by_opcode[opcode]
+            msg = msg_class.recv_body(body, protocol_version, protocol_features, user_type_map, result_metadata, cls.column_encryption_policy)
+        except EOFError as exc:
+            # Local import to avoid a circular import at module load time:
+            # cassandra.connection imports from cassandra.protocol, so
+            # cassandra.protocol cannot import cassandra.connection at
+            # module scope.
+            from cassandra.connection import ProtocolError
+            raise ProtocolError(
+                "Ran out of data decoding %r message body (opcode %r): %s" %
+                (cls.message_types_by_opcode.get(opcode, opcode), opcode, exc)) from exc
         msg.stream_id = stream_id
         msg.trace_id = trace_id
         msg.custom_payload = custom_payload

--- a/cassandra/row_parser.pyx
+++ b/cassandra/row_parser.pyx
@@ -35,13 +35,19 @@ def make_recv_results_rows(ColumnParser colparser):
         desc = ParseDesc(self.column_names, self.column_types, column_encryption_policy,
                         [ColDesc(md[0], md[1], md[2]) for md in column_metadata],
                         make_deserializers(self.column_types), protocol_version)
-        reader = BytesIOReader(f.read())
+        # Zero-copy handoff: reuse the underlying bytes buffer at its current
+        # position instead of copying via f.read().
+        if hasattr(f, 'remaining_buffer'):
+            buf_data, buf_offset = f.remaining_buffer()
+            reader = BytesIOReader(buf_data, buf_offset)
+        else:
+            reader = BytesIOReader(f.read())
         try:
             self.parsed_rows = colparser.parse_rows(reader, desc)
         except Exception as e:
             # Use explicitly the TupleRowParser to display better error messages for column decoding failures
             rowparser = TupleRowParser()
-            reader.buf_ptr = reader.buf
+            reader.buf_ptr = <char*>reader.buf + reader._initial_offset
             reader.pos = 0
             rowcount = read_int(reader)
             for i in range(rowcount):

--- a/tests/unit/test_bytesio_reader.py
+++ b/tests/unit/test_bytesio_reader.py
@@ -1,0 +1,67 @@
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import pytest
+
+try:
+    from cassandra.bytesio import BytesIOReader
+
+    has_cython = True
+except ImportError:
+    has_cython = False
+
+
+@pytest.mark.skipif(not has_cython, reason="Cython extensions not compiled")
+class BytesIOReaderTest(unittest.TestCase):
+    """Tests for the Cython BytesIOReader, including the offset parameter.
+
+    Note: BytesIOReader.read() is a cdef method, so it cannot be called
+    directly from Python.  Reading with an offset is exercised through the
+    end-to-end decode_message test in test_protocol.py which goes through
+    the Cython row parser path (remaining_buffer -> BytesIOReader(buf, offset)).
+    """
+
+    def test_construct_no_offset(self):
+        # Should not raise
+        reader = BytesIOReader(b"\x00\x01\x02\x03\x04\x05")
+
+    def test_construct_with_zero_offset(self):
+        reader = BytesIOReader(b"hello world", 0)
+
+    def test_construct_with_offset(self):
+        reader = BytesIOReader(b"header_row_data", 7)
+
+    def test_construct_offset_at_end(self):
+        data = b"abcdef"
+        reader = BytesIOReader(data, len(data))
+
+    def test_construct_negative_offset_raises(self):
+        with self.assertRaises(ValueError):
+            BytesIOReader(b"hello", -1)
+
+    def test_construct_offset_past_end_raises(self):
+        with self.assertRaises(ValueError):
+            BytesIOReader(b"hello", 6)
+
+    def test_construct_offset_way_past_end_raises(self):
+        with self.assertRaises(ValueError):
+            BytesIOReader(b"hello", 100)
+
+    def test_construct_empty_buffer_zero_offset(self):
+        reader = BytesIOReader(b"", 0)
+
+    def test_construct_empty_buffer_nonzero_offset_raises(self):
+        with self.assertRaises(ValueError):
+            BytesIOReader(b"", 1)

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -22,7 +22,8 @@ from cassandra import OperationTimedOut
 from cassandra.cluster import Cluster
 from cassandra.connection import (Connection, HEADER_DIRECTION_TO_CLIENT, ProtocolError,
                                   locally_supported_compressions, ConnectionHeartbeat, _Frame, Timer, TimerManager,
-                                  ConnectionException, ConnectionShutdown, DefaultEndPoint, ShardAwarePortGenerator)
+                                  ConnectionException, ConnectionShutdown, DefaultEndPoint, ShardAwarePortGenerator,
+                                  _ConnectionIOBuffer)
 from cassandra.marshal import uint8_pack, uint32_pack, int32_pack
 from cassandra.protocol import (write_stringmultimap, write_int, write_string,
                                 SupportedMessage, ProtocolHandler)
@@ -571,3 +572,42 @@ class TestShardawarePortGenerator(unittest.TestCase):
         second_run = list(itertools.islice(gen.generate(0, 2), 5))
 
         assert first_run == second_run
+
+
+class ResetBufferTest(unittest.TestCase):
+    """Tests for _ConnectionIOBuffer._reset_buffer static method."""
+
+    def test_preserves_remaining_data(self):
+        buf = BytesIO()
+        buf.write(b"already_consumed_new_data")
+        buf.seek(17)  # position after "already_consumed_"
+        result = _ConnectionIOBuffer._reset_buffer(buf)
+        self.assertEqual(result.getvalue(), b"new_data")
+        # Cursor is at SEEK_END, ready for further writes
+        self.assertEqual(result.tell(), len(b"new_data"))
+
+    def test_empty_remaining(self):
+        buf = BytesIO()
+        buf.write(b"all_consumed")
+        buf.seek(12)
+        result = _ConnectionIOBuffer._reset_buffer(buf)
+        self.assertEqual(result.getvalue(), b"")
+        self.assertEqual(result.tell(), 0)
+
+    def test_nothing_consumed(self):
+        buf = BytesIO()
+        buf.write(b"all_remaining")
+        buf.seek(0)
+        result = _ConnectionIOBuffer._reset_buffer(buf)
+        self.assertEqual(result.getvalue(), b"all_remaining")
+        # Cursor is at SEEK_END, ready for further writes
+        self.assertEqual(result.tell(), len(b"all_remaining"))
+
+    def test_new_buffer_is_writable(self):
+        buf = BytesIO()
+        buf.write(b"head_tail")
+        buf.seek(5)
+        result = _ConnectionIOBuffer._reset_buffer(buf)
+        result.seek(0, 2)  # seek to end
+        result.write(b"_more")
+        self.assertEqual(result.getvalue(), b"tail_more")

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -22,7 +22,8 @@ from cassandra import OperationTimedOut
 from cassandra.cluster import Cluster
 from cassandra.connection import (Connection, HEADER_DIRECTION_TO_CLIENT, ProtocolError,
                                   locally_supported_compressions, ConnectionHeartbeat, HeartbeatFuture, _Frame, Timer, TimerManager,
-                                  ConnectionException, ConnectionShutdown, DefaultEndPoint, ShardAwarePortGenerator)
+                                  ConnectionException, ConnectionShutdown, DefaultEndPoint, ShardAwarePortGenerator,
+                                  _ConnectionIOBuffer)
 from cassandra.marshal import uint8_pack, uint32_pack, int32_pack
 from cassandra.protocol import (write_stringmultimap, write_int, write_string,
                                 SupportedMessage, ProtocolHandler, ResultMessage,
@@ -384,6 +385,112 @@ class ConnectionTest(unittest.TestCase):
         assert "Bad file descriptor" in error_message
 
 
+class PipelinedFramesTest(unittest.TestCase):
+    """
+    Regression tests for a potential frame-parsing stall raised in review:
+    ``_read_frame_header``/``process_io_buffer`` compute ``pos`` from
+    ``cql_frame_buffer.tell()`` (the BytesIO cursor position) rather than
+    ``len(cql_frame_buffer.getvalue())`` (the true buffered length). Those
+    two values are only equivalent if the cursor always sits at the true end
+    of the buffer whenever ``pos`` is read.
+
+    These tests exercise the scenario the concern describes: multiple CQL
+    frames arriving together (pipelined) in a single socket read, including
+    a case where the second frame's data initially arrives incomplete. If
+    the cursor were ever left short of the true buffered length at the point
+    ``pos`` is computed, the second (pipelined) frame would not be
+    recognized as complete until further, possibly-never-arriving, data
+    showed up on the wire -- i.e. a silent stall.
+    """
+
+    def make_connection(self, **kwargs):
+        c = Connection(DefaultEndPoint('1.2.3.4'), **kwargs)
+        c._socket = Mock()
+        c._socket.send.side_effect = lambda x: len(x)
+        return c
+
+    def make_header_prefix(self, message_class, version=Connection.protocol_version, stream_id=0):
+        return bytes().join(map(uint8_pack, [
+            0xff & (HEADER_DIRECTION_TO_CLIENT | version),
+            0,  # flags (compression)
+            0,  # MSB for v3+ stream
+            stream_id,
+            message_class.opcode
+        ]))
+
+    def make_options_body(self):
+        options_buf = BytesIO()
+        write_stringmultimap(options_buf, {
+            'CQL_VERSION': ['3.0.1'],
+            'COMPRESSION': []
+        })
+        return options_buf.getvalue()
+
+    def make_msg(self, header, body=b""):
+        return header + uint32_pack(len(body)) + body
+
+    def _two_frames(self):
+        options = self.make_options_body()
+        frame0 = self.make_msg(self.make_header_prefix(SupportedMessage, stream_id=0), options)
+        frame1 = self.make_msg(self.make_header_prefix(SupportedMessage, stream_id=1), options)
+        return frame0, frame1
+
+    def test_two_complete_frames_in_one_read_both_processed(self):
+        """
+        Two complete frames delivered together in a single ``recv()`` (i.e.
+        a single ``.write()`` to the io buffer) must both be parsed out of
+        one ``process_io_buffer()`` call -- the second frame's completeness
+        must not depend on any additional data arriving.
+        """
+        c = self.make_connection()
+        callback0, callback1 = Mock(), Mock()
+        mock_decoder = Mock(side_effect=lambda *a, **k: Mock())
+        c._requests = {
+            0: (callback0, mock_decoder, []),
+            1: (callback1, mock_decoder, []),
+        }
+
+        frame0, frame1 = self._two_frames()
+        c._iobuf.write(frame0 + frame1)
+        c.process_io_buffer()
+
+        callback0.assert_called_once()
+        callback1.assert_called_once()
+        # The buffer should be fully drained, not stalled with leftover data.
+        self.assertEqual(c._io_buffer.cql_frame_buffer.tell(), 0)
+
+    def test_second_pipelined_frame_completes_after_more_data_arrives(self):
+        """
+        If the second frame arrives only partially (header only) alongside
+        the first frame, it must not be processed yet -- but once the rest
+        of its bytes arrive in a later read, it must be recognized and
+        processed without any further stall.
+        """
+        c = self.make_connection()
+        callback0, callback1 = Mock(), Mock()
+        mock_decoder = Mock(side_effect=lambda *a, **k: Mock())
+        c._requests = {
+            0: (callback0, mock_decoder, []),
+            1: (callback1, mock_decoder, []),
+        }
+
+        frame0, frame1 = self._two_frames()
+
+        # First read: complete frame0, plus only the 9-byte header of frame1.
+        c._iobuf.write(frame0 + frame1[:9])
+        c.process_io_buffer()
+
+        callback0.assert_called_once()
+        callback1.assert_not_called()
+
+        # Second read: the remainder of frame1 arrives later.
+        c._iobuf.write(frame1[9:])
+        c.process_io_buffer()
+
+        callback1.assert_called_once()
+        self.assertIsNone(c._current_frame)
+
+
 @patch('cassandra.connection.ConnectionHeartbeat._raise_if_stopped')
 class ConnectionHeartbeatTest(unittest.TestCase):
 
@@ -653,3 +760,58 @@ class TestShardawarePortGenerator(unittest.TestCase):
         second_run = list(itertools.islice(gen.generate(0, 2), 5))
 
         assert first_run == second_run
+
+
+class ResetBufferTest(unittest.TestCase):
+    """Tests for _ConnectionIOBuffer._reset_buffer static method."""
+
+    def test_preserves_remaining_data(self):
+        buf = BytesIO()
+        buf.write(b"already_consumed_new_data")
+        buf.seek(17)  # position after "already_consumed_"
+        result = _ConnectionIOBuffer._reset_buffer(buf)
+        self.assertEqual(result.getvalue(), b"new_data")
+        # Cursor is at SEEK_END, ready for further writes
+        self.assertEqual(result.tell(), len(b"new_data"))
+
+    def test_empty_remaining(self):
+        buf = BytesIO()
+        buf.write(b"all_consumed")
+        buf.seek(12)
+        result = _ConnectionIOBuffer._reset_buffer(buf)
+        self.assertEqual(result.getvalue(), b"")
+        self.assertEqual(result.tell(), 0)
+
+    def test_nothing_consumed(self):
+        buf = BytesIO()
+        buf.write(b"all_remaining")
+        buf.seek(0)
+        result = _ConnectionIOBuffer._reset_buffer(buf)
+        self.assertEqual(result.getvalue(), b"all_remaining")
+        # Cursor is at SEEK_END, ready for further writes
+        self.assertEqual(result.tell(), len(b"all_remaining"))
+
+    def test_new_buffer_is_writable(self):
+        buf = BytesIO()
+        buf.write(b"head_tail")
+        buf.seek(5)
+        result = _ConnectionIOBuffer._reset_buffer(buf)
+        result.seek(0, 2)  # seek to end
+        result.write(b"_more")
+        self.assertEqual(result.getvalue(), b"tail_more")
+
+    def test_does_not_leak_buffer_export_on_original(self):
+        """
+        _reset_buffer's ``getbuffer()`` memoryview must be released (not just
+        the returned new buffer being fine to use) so that the *original*
+        buffer object can still be safely resized/closed afterwards. If the
+        export leaked, mutating the original buffer would raise:
+        BufferError: Existing exports of data: object cannot be re-sized.
+        """
+        buf = BytesIO()
+        buf.write(b"head_tail")
+        buf.seek(5)
+        _ConnectionIOBuffer._reset_buffer(buf)
+        # Should not raise BufferError -- the memoryview export taken
+        # internally by _reset_buffer must already be released by now.
+        buf.truncate(0)

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -13,15 +13,26 @@
 # limitations under the License.
 
 import unittest
+from io import BytesIO
 
 from unittest.mock import Mock
 
 from cassandra import ProtocolVersion, UnsupportedOperation
 from cassandra.protocol import (
-    PrepareMessage, QueryMessage, ExecuteMessage, UnsupportedOperation,
-    _PAGING_OPTIONS_FLAG, _WITH_SERIAL_CONSISTENCY_FLAG,
-    _PAGE_SIZE_FLAG, _WITH_PAGING_STATE_FLAG,
-    BatchMessage
+    PrepareMessage,
+    QueryMessage,
+    ExecuteMessage,
+    UnsupportedOperation,
+    _PAGING_OPTIONS_FLAG,
+    _WITH_SERIAL_CONSISTENCY_FLAG,
+    _PAGE_SIZE_FLAG,
+    _WITH_PAGING_STATE_FLAG,
+    BatchMessage,
+    BytesReader,
+    ProtocolHandler,
+    SupportedMessage,
+    ReadyMessage,
+    write_stringmultimap,
 )
 from cassandra.query import BatchType
 from cassandra.marshal import uint32_unpack
@@ -30,7 +41,6 @@ import pytest
 
 
 class MessageTest(unittest.TestCase):
-
     def test_prepare_message(self):
         """
         Test to check the appropriate calls are made
@@ -57,16 +67,26 @@ class MessageTest(unittest.TestCase):
         io = Mock()
 
         message.send_body(io, 4)
-        self._check_calls(io, [(b'\x00\x01',), (b'1',), (b'\x00\x04',), (b'\x01',), (b'\x00\x00',)])
+        self._check_calls(
+            io, [(b"\x00\x01",), (b"1",), (b"\x00\x04",), (b"\x01",), (b"\x00\x00",)]
+        )
 
         io.reset_mock()
         message.result_metadata_id = 'foo'
         message.send_body(io, 5)
 
-        self._check_calls(io, [(b'\x00\x01',), (b'1',),
-                               (b'\x00\x03',), (b'foo',),
-                               (b'\x00\x04',),
-                               (b'\x00\x00\x00\x01',), (b'\x00\x00',)])
+        self._check_calls(
+            io,
+            [
+                (b"\x00\x01",),
+                (b"1",),
+                (b'\x00\x03',),
+                (b"foo",),
+                (b'\x00\x04',),
+                (b'\x00\x00\x00\x01',),
+                (b"\x00\x00",),
+            ],
+        )
 
     def test_query_message(self):
         """
@@ -82,11 +102,16 @@ class MessageTest(unittest.TestCase):
         io = Mock()
 
         message.send_body(io, 4)
-        self._check_calls(io, [(b'\x00\x00\x00\x01',), (b'a',), (b'\x00\x03',), (b'\x00',)])
+        self._check_calls(
+            io, [(b"\x00\x00\x00\x01",), (b"a",), (b"\x00\x03",), (b"\x00",)]
+        )
 
         io.reset_mock()
         message.send_body(io, 5)
-        self._check_calls(io, [(b'\x00\x00\x00\x01',), (b'a',), (b'\x00\x03',), (b'\x00\x00\x00\x00',)])
+        self._check_calls(
+            io,
+            [(b"\x00\x00\x00\x01",), (b"a",), (b"\x00\x03",), (b"\x00\x00\x00\x00",)],
+        )
 
     def _check_calls(self, io, expected):
         assert tuple(c[1] for c in io.write.mock_calls) == tuple(expected)
@@ -118,13 +143,16 @@ class MessageTest(unittest.TestCase):
         for version in ProtocolVersion.SUPPORTED_VERSIONS:
             if ProtocolVersion.uses_keyspace_flag(version):
                 message.send_body(io, version)
-                self._check_calls(io, [
-                    (b'\x00\x00\x00\x01',),
-                    (b'a',),
-                    (b'\x00\x00\x00\x01',),
-                    (b'\x00\x02',),
-                    (b'ks',),
-                ])
+                self._check_calls(
+                    io,
+                    [
+                        (b'\x00\x00\x00\x01',),
+                        (b'a',),
+                        (b'\x00\x00\x00\x01',),
+                        (b'\x00\x02',),
+                        (b'ks',),
+                    ],
+                )
             else:
                 with pytest.raises(UnsupportedOperation):
                     message.send_body(io, version)
@@ -150,42 +178,201 @@ class MessageTest(unittest.TestCase):
         QueryMessage('a', consistency_level=3, keyspace='ks').send_body(
             io, protocol_version=5
         )
-        self._check_calls(io, base_expected + [
-            (b'\x00\x02',),  # length of keyspace string
-            (b'ks',),
-        ])
+        self._check_calls(
+            io,
+            base_expected
+            + [
+                (b'\x00\x02',),  # length of keyspace string
+                (b'ks',),
+            ],
+        )
 
         io.reset_mock()
 
         QueryMessage('a', consistency_level=3, keyspace='keyspace').send_body(
             io, protocol_version=5
         )
-        self._check_calls(io, base_expected + [
-            (b'\x00\x08',),  # length of keyspace string
-            (b'keyspace',),
-        ])
+        self._check_calls(
+            io,
+            base_expected
+            + [
+                (b'\x00\x08',),  # length of keyspace string
+                (b'keyspace',),
+            ],
+        )
 
     def test_batch_message_with_keyspace(self):
         self.maxDiff = None
         io = Mock(name='io')
         batch = BatchMessage(
             batch_type=BatchType.LOGGED,
-            queries=((False, 'stmt a', ('param a',)),
-                     (False, 'stmt b', ('param b',)),
-                     (False, 'stmt c', ('param c',))
-                     ),
+            queries=(
+                (False, "stmt a", ("param a",)),
+                (False, 'stmt b', ('param b',)),
+                (False, "stmt c", ("param c",)),
+            ),
             consistency_level=3,
-            keyspace='ks'
+            keyspace="ks",
         )
         batch.send_body(io, protocol_version=5)
-        self._check_calls(io,
-            ((b'\x00',), (b'\x00\x03',), (b'\x00',),
-             (b'\x00\x00\x00\x06',), (b'stmt a',),
-             (b'\x00\x01',), (b'\x00\x00\x00\x07',), ('param a',),
-             (b'\x00',), (b'\x00\x00\x00\x06',), (b'stmt b',),
-             (b'\x00\x01',), (b'\x00\x00\x00\x07',), ('param b',),
-             (b'\x00',), (b'\x00\x00\x00\x06',), (b'stmt c',),
-             (b'\x00\x01',), (b'\x00\x00\x00\x07',), ('param c',),
-             (b'\x00\x03',),
-             (b'\x00\x00\x00\x80',), (b'\x00\x02',), (b'ks',))
+        self._check_calls(
+            io,
+            (
+                (b"\x00",),
+                (b"\x00\x03",),
+                (b"\x00",),
+                (b"\x00\x00\x00\x06",),
+                (b"stmt a",),
+                (b"\x00\x01",),
+                (b"\x00\x00\x00\x07",),
+                ("param a",),
+                (b"\x00",),
+                (b"\x00\x00\x00\x06",),
+                (b"stmt b",),
+                (b"\x00\x01",),
+                (b"\x00\x00\x00\x07",),
+                ("param b",),
+                (b"\x00",),
+                (b"\x00\x00\x00\x06",),
+                (b"stmt c",),
+                (b"\x00\x01",),
+                (b"\x00\x00\x00\x07",),
+                ("param c",),
+                (b"\x00\x03",),
+                (b"\x00\x00\x00\x80",),
+                (b"\x00\x02",),
+                (b"ks",),
+            ),
         )
+
+
+class BytesReaderTest(unittest.TestCase):
+    """Tests for the BytesReader class used in decode_message."""
+
+    def test_read_exact(self):
+        r = BytesReader(b"abcdef")
+        self.assertEqual(r.read(3), b"abc")
+        self.assertEqual(r.read(3), b"def")
+
+    def test_read_sequential(self):
+        r = BytesReader(b"\x00\x01\x02\x03")
+        self.assertEqual(r.read(1), b"\x00")
+        self.assertEqual(r.read(2), b"\x01\x02")
+        self.assertEqual(r.read(1), b"\x03")
+
+    def test_read_zero_bytes(self):
+        r = BytesReader(b"abc")
+        self.assertEqual(r.read(0), b"")
+        self.assertEqual(r.read(3), b"abc")
+
+    def test_read_all_no_args(self):
+        r = BytesReader(b"hello")
+        self.assertEqual(r.read(), b"hello")
+
+    def test_read_all_negative(self):
+        r = BytesReader(b"hello")
+        self.assertEqual(r.read(-1), b"hello")
+
+    def test_read_all_after_partial(self):
+        r = BytesReader(b"hello world")
+        r.read(6)
+        self.assertEqual(r.read(), b"world")
+
+    def test_read_past_end_raises(self):
+        r = BytesReader(b"abc")
+        with self.assertRaises(EOFError):
+            r.read(4)
+
+    def test_read_past_end_after_partial(self):
+        r = BytesReader(b"abc")
+        r.read(2)
+        with self.assertRaises(EOFError):
+            r.read(2)
+
+    def test_empty_data(self):
+        r = BytesReader(b"")
+        self.assertEqual(r.read(), b"")
+        self.assertEqual(r.read(0), b"")
+        with self.assertRaises(EOFError):
+            r.read(1)
+
+    def test_memoryview_input(self):
+        data = b"hello world"
+        r = BytesReader(memoryview(data))
+        result = r.read(5)
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(result, b"hello")
+
+    def test_return_type_is_bytes(self):
+        r = BytesReader(b"\x00\x01\x02")
+        result = r.read(3)
+        self.assertIsInstance(result, bytes)
+
+    def test_remaining_buffer(self):
+        r = BytesReader(b"header_row_data")
+        r.read(7)  # consume "header_"
+        buf, pos = r.remaining_buffer()
+        self.assertEqual(buf, b"header_row_data")
+        self.assertEqual(pos, 7)
+        self.assertEqual(buf[pos:], b"row_data")
+
+    def test_remaining_buffer_at_start(self):
+        r = BytesReader(b"all_data")
+        buf, pos = r.remaining_buffer()
+        self.assertEqual(pos, 0)
+        self.assertEqual(buf, b"all_data")
+
+
+class DecodeMessageTest(unittest.TestCase):
+    """
+    End-to-end tests for ProtocolHandler.decode_message using BytesReader.
+
+    These verify that real message types round-trip through the decode path
+    that now uses BytesReader instead of io.BytesIO.
+    """
+
+    def _decode(self, opcode, body):
+        return ProtocolHandler.decode_message(
+            protocol_version=ProtocolVersion.MAX_SUPPORTED,
+            protocol_features=None,
+            user_type_map={},
+            stream_id=0,
+            flags=0,
+            opcode=opcode,
+            body=body,
+            decompressor=None,
+            result_metadata=None,
+        )
+
+    def test_ready_message_empty_body(self):
+        """ReadyMessage has an empty body (opcode 0x02)."""
+        msg = self._decode(0x02, b"")
+        self.assertIsInstance(msg, ReadyMessage)
+        self.assertEqual(msg.stream_id, 0)
+        self.assertIsNone(msg.trace_id)
+        self.assertIsNone(msg.custom_payload)
+
+    def test_supported_message_with_body(self):
+        """SupportedMessage reads a stringmultimap from body (opcode 0x06)."""
+        buf = BytesIO()
+        write_stringmultimap(
+            buf,
+            {
+                "CQL_VERSION": ["3.4.5"],
+                "COMPRESSION": ["lz4", "snappy"],
+            },
+        )
+        body = buf.getvalue()
+        msg = self._decode(0x06, body)
+        self.assertIsInstance(msg, SupportedMessage)
+        self.assertEqual(msg.cql_versions, ["3.4.5"])
+        self.assertEqual(msg.options["COMPRESSION"], ["lz4", "snappy"])
+
+    def test_decode_with_memoryview_body(self):
+        """decode_message should accept a memoryview body (BytesReader materializes it)."""
+        buf = BytesIO()
+        write_stringmultimap(buf, {"CQL_VERSION": ["3.0.0"]})
+        body = memoryview(buf.getvalue())
+        msg = self._decode(0x06, body)
+        self.assertIsInstance(msg, SupportedMessage)
+        self.assertEqual(msg.cql_versions, ["3.0.0"])

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -15,6 +15,7 @@
 import io
 import struct
 import unittest
+from io import BytesIO
 
 from typing import ClassVar
 from unittest.mock import Mock
@@ -24,15 +25,25 @@ from cassandra.protocol import (
     PrepareMessage, QueryMessage, ExecuteMessage,
     BatchMessage, StartupMessage, OptionsMessage, RegisterMessage,
     AuthResponseMessage, ProtocolHandler, _MessageType,
-    ResultMessage, RESULT_KIND_ROWS
+    ResultMessage, RESULT_KIND_ROWS,
+    UnsupportedOperation,
+    _PAGING_OPTIONS_FLAG,
+    _WITH_SERIAL_CONSISTENCY_FLAG,
+    _PAGE_SIZE_FLAG,
+    _WITH_PAGING_STATE_FLAG,
+    BytesReader,
+    SupportedMessage,
+    ReadyMessage,
+    write_stringmultimap,
+    TRACING_FLAG,
 )
+from cassandra.connection import ProtocolError
 from cassandra.protocol_features import ProtocolFeatures
 from cassandra.query import BatchType
 import pytest
 
 
 class MessageTest(unittest.TestCase):
-
     def test_prepare_message(self):
         """
         Test to check the appropriate calls are made
@@ -59,16 +70,26 @@ class MessageTest(unittest.TestCase):
         io = Mock()
 
         message.send_body(io, 4)
-        self._check_calls(io, [(b'\x00\x01',), (b'1',), (b'\x00\x04',), (b'\x01',), (b'\x00\x00',)])
+        self._check_calls(
+            io, [(b"\x00\x01",), (b"1",), (b"\x00\x04",), (b"\x01",), (b"\x00\x00",)]
+        )
 
         io.reset_mock()
         message.result_metadata_id = 'foo'
         message.send_body(io, 5)
 
-        self._check_calls(io, [(b'\x00\x01',), (b'1',),
-                               (b'\x00\x03',), (b'foo',),
-                               (b'\x00\x04',),
-                               (b'\x00\x00\x00\x01',), (b'\x00\x00',)])
+        self._check_calls(
+            io,
+            [
+                (b"\x00\x01",),
+                (b"1",),
+                (b'\x00\x03',),
+                (b"foo",),
+                (b'\x00\x04',),
+                (b'\x00\x00\x00\x01',),
+                (b"\x00\x00",),
+            ],
+        )
 
     def test_execute_message_skip_meta_flag_with_extension(self):
         """
@@ -331,11 +352,16 @@ class MessageTest(unittest.TestCase):
         io = Mock()
 
         message.send_body(io, 4)
-        self._check_calls(io, [(b'\x00\x00\x00\x01',), (b'a',), (b'\x00\x03',), (b'\x00',)])
+        self._check_calls(
+            io, [(b"\x00\x00\x00\x01",), (b"a",), (b"\x00\x03",), (b"\x00",)]
+        )
 
         io.reset_mock()
         message.send_body(io, 5)
-        self._check_calls(io, [(b'\x00\x00\x00\x01',), (b'a',), (b'\x00\x03',), (b'\x00\x00\x00\x00',)])
+        self._check_calls(
+            io,
+            [(b"\x00\x00\x00\x01",), (b"a",), (b"\x00\x03",), (b"\x00\x00\x00\x00",)],
+        )
 
     def _check_calls(self, io, expected):
         assert tuple(c[1] for c in io.write.mock_calls) == tuple(expected)
@@ -367,13 +393,16 @@ class MessageTest(unittest.TestCase):
         for version in ProtocolVersion.SUPPORTED_VERSIONS:
             if ProtocolVersion.uses_keyspace_flag(version):
                 message.send_body(io, version)
-                self._check_calls(io, [
-                    (b'\x00\x00\x00\x01',),
-                    (b'a',),
-                    (b'\x00\x00\x00\x01',),
-                    (b'\x00\x02',),
-                    (b'ks',),
-                ])
+                self._check_calls(
+                    io,
+                    [
+                        (b'\x00\x00\x00\x01',),
+                        (b'a',),
+                        (b'\x00\x00\x00\x01',),
+                        (b'\x00\x02',),
+                        (b'ks',),
+                    ],
+                )
             else:
                 with pytest.raises(UnsupportedOperation):
                     message.send_body(io, version)
@@ -399,44 +428,71 @@ class MessageTest(unittest.TestCase):
         QueryMessage('a', consistency_level=3, keyspace='ks').send_body(
             io, protocol_version=5
         )
-        self._check_calls(io, base_expected + [
-            (b'\x00\x02',),  # length of keyspace string
-            (b'ks',),
-        ])
+        self._check_calls(
+            io,
+            base_expected
+            + [
+                (b'\x00\x02',),  # length of keyspace string
+                (b'ks',),
+            ],
+        )
 
         io.reset_mock()
 
         QueryMessage('a', consistency_level=3, keyspace='keyspace').send_body(
             io, protocol_version=5
         )
-        self._check_calls(io, base_expected + [
-            (b'\x00\x08',),  # length of keyspace string
-            (b'keyspace',),
-        ])
+        self._check_calls(
+            io,
+            base_expected
+            + [
+                (b'\x00\x08',),  # length of keyspace string
+                (b'keyspace',),
+            ],
+        )
 
     def test_batch_message_with_keyspace(self):
         self.maxDiff = None
         io = Mock(name='io')
         batch = BatchMessage(
             batch_type=BatchType.LOGGED,
-            queries=((False, 'stmt a', ('param a',)),
-                     (False, 'stmt b', ('param b',)),
-                     (False, 'stmt c', ('param c',))
-                     ),
+            queries=(
+                (False, "stmt a", ("param a",)),
+                (False, 'stmt b', ('param b',)),
+                (False, "stmt c", ("param c",)),
+            ),
             consistency_level=3,
-            keyspace='ks'
+            keyspace="ks",
         )
         batch.send_body(io, protocol_version=5)
-        self._check_calls(io,
-            ((b'\x00',), (b'\x00\x03',), (b'\x00',),
-             (b'\x00\x00\x00\x06',), (b'stmt a',),
-             (b'\x00\x01',), (b'\x00\x00\x00\x07',), ('param a',),
-             (b'\x00',), (b'\x00\x00\x00\x06',), (b'stmt b',),
-             (b'\x00\x01',), (b'\x00\x00\x00\x07',), ('param b',),
-             (b'\x00',), (b'\x00\x00\x00\x06',), (b'stmt c',),
-             (b'\x00\x01',), (b'\x00\x00\x00\x07',), ('param c',),
-             (b'\x00\x03',),
-             (b'\x00\x00\x00\x80',), (b'\x00\x02',), (b'ks',))
+        self._check_calls(
+            io,
+            (
+                (b"\x00",),
+                (b"\x00\x03",),
+                (b"\x00",),
+                (b"\x00\x00\x00\x06",),
+                (b"stmt a",),
+                (b"\x00\x01",),
+                (b"\x00\x00\x00\x07",),
+                ("param a",),
+                (b"\x00",),
+                (b"\x00\x00\x00\x06",),
+                (b"stmt b",),
+                (b"\x00\x01",),
+                (b"\x00\x00\x00\x07",),
+                ("param b",),
+                (b"\x00",),
+                (b"\x00\x00\x00\x06",),
+                (b"stmt c",),
+                (b"\x00\x01",),
+                (b"\x00\x00\x00\x07",),
+                ("param c",),
+                (b"\x00\x03",),
+                (b"\x00\x00\x00\x80",),
+                (b"\x00\x02",),
+                (b"ks",),
+            ),
         )
 
 
@@ -555,3 +611,181 @@ class FrameByteIdentityTest(unittest.TestCase):
 
     def test_frames_with_default_features(self):
         self._assert_frames(ProtocolFeatures())
+
+
+class BytesReaderTest(unittest.TestCase):
+    """Tests for the BytesReader class used in decode_message."""
+
+    def test_read_exact(self):
+        r = BytesReader(b"abcdef")
+        self.assertEqual(r.read(3), b"abc")
+        self.assertEqual(r.read(3), b"def")
+
+    def test_read_sequential(self):
+        r = BytesReader(b"\x00\x01\x02\x03")
+        self.assertEqual(r.read(1), b"\x00")
+        self.assertEqual(r.read(2), b"\x01\x02")
+        self.assertEqual(r.read(1), b"\x03")
+
+    def test_read_zero_bytes(self):
+        r = BytesReader(b"abc")
+        self.assertEqual(r.read(0), b"")
+        self.assertEqual(r.read(3), b"abc")
+
+    def test_read_all_no_args(self):
+        r = BytesReader(b"hello")
+        self.assertEqual(r.read(), b"hello")
+
+    def test_read_all_negative(self):
+        r = BytesReader(b"hello")
+        self.assertEqual(r.read(-1), b"hello")
+
+    def test_read_all_after_partial(self):
+        r = BytesReader(b"hello world")
+        r.read(6)
+        self.assertEqual(r.read(), b"world")
+
+    def test_read_past_end_raises(self):
+        r = BytesReader(b"abc")
+        with self.assertRaises(EOFError):
+            r.read(4)
+
+    def test_read_past_end_after_partial(self):
+        r = BytesReader(b"abc")
+        r.read(2)
+        with self.assertRaises(EOFError):
+            r.read(2)
+
+    def test_empty_data(self):
+        r = BytesReader(b"")
+        self.assertEqual(r.read(), b"")
+        self.assertEqual(r.read(0), b"")
+        with self.assertRaises(EOFError):
+            r.read(1)
+
+    def test_memoryview_input(self):
+        data = b"hello world"
+        r = BytesReader(memoryview(data))
+        result = r.read(5)
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(result, b"hello")
+
+    def test_return_type_is_bytes(self):
+        r = BytesReader(b"\x00\x01\x02")
+        result = r.read(3)
+        self.assertIsInstance(result, bytes)
+
+    def test_remaining_buffer(self):
+        r = BytesReader(b"header_row_data")
+        r.read(7)  # consume "header_"
+        buf, pos = r.remaining_buffer()
+        self.assertEqual(buf, b"header_row_data")
+        self.assertEqual(pos, 7)
+        self.assertEqual(buf[pos:], b"row_data")
+
+    def test_remaining_buffer_at_start(self):
+        r = BytesReader(b"all_data")
+        buf, pos = r.remaining_buffer()
+        self.assertEqual(pos, 0)
+        self.assertEqual(buf, b"all_data")
+
+
+class DecodeMessageTest(unittest.TestCase):
+    """
+    End-to-end tests for ProtocolHandler.decode_message using BytesReader.
+
+    These verify that real message types round-trip through the decode path
+    that now uses BytesReader instead of io.BytesIO.
+    """
+
+    def _decode(self, opcode, body):
+        return ProtocolHandler.decode_message(
+            protocol_version=ProtocolVersion.MAX_SUPPORTED,
+            protocol_features=None,
+            user_type_map={},
+            stream_id=0,
+            flags=0,
+            opcode=opcode,
+            body=body,
+            decompressor=None,
+            result_metadata=None,
+        )
+
+    def test_ready_message_empty_body(self):
+        """ReadyMessage has an empty body (opcode 0x02)."""
+        msg = self._decode(0x02, b"")
+        self.assertIsInstance(msg, ReadyMessage)
+        self.assertEqual(msg.stream_id, 0)
+        self.assertIsNone(msg.trace_id)
+        self.assertIsNone(msg.custom_payload)
+
+    def test_supported_message_with_body(self):
+        """SupportedMessage reads a stringmultimap from body (opcode 0x06)."""
+        buf = BytesIO()
+        write_stringmultimap(
+            buf,
+            {
+                "CQL_VERSION": ["3.4.5"],
+                "COMPRESSION": ["lz4", "snappy"],
+            },
+        )
+        body = buf.getvalue()
+        msg = self._decode(0x06, body)
+        self.assertIsInstance(msg, SupportedMessage)
+        self.assertEqual(msg.cql_versions, ["3.4.5"])
+        self.assertEqual(msg.options["COMPRESSION"], ["lz4", "snappy"])
+
+    def test_decode_with_memoryview_body(self):
+        """decode_message should accept a memoryview body (BytesReader materializes it)."""
+        buf = BytesIO()
+        write_stringmultimap(buf, {"CQL_VERSION": ["3.0.0"]})
+        body = memoryview(buf.getvalue())
+        msg = self._decode(0x06, body)
+        self.assertIsInstance(msg, SupportedMessage)
+        self.assertEqual(msg.cql_versions, ["3.0.0"])
+
+    def test_truncated_body_raises_protocol_error_not_eof_error(self):
+        """
+        decode_message() is a public entry point; a truncated/incomplete frame
+        body must surface as the driver's canonical ProtocolError (as other
+        malformed-frame conditions do), not as a raw EOFError leaking out of
+        the internal BytesReader implementation.
+        """
+        # 5 bytes is not enough for the 16-byte trace_id read that
+        # decode_message performs first when TRACING_FLAG is set.
+        with self.assertRaises(ProtocolError) as ctx:
+            ProtocolHandler.decode_message(
+                protocol_version=ProtocolVersion.MAX_SUPPORTED,
+                protocol_features=None,
+                user_type_map={},
+                stream_id=0,
+                flags=TRACING_FLAG,
+                opcode=0x02,  # ReadyMessage
+                body=b"short",
+                decompressor=None,
+                result_metadata=None,
+            )
+        # The original EOFError must still be reachable via exception chaining.
+        self.assertIsInstance(ctx.exception.__cause__, EOFError)
+
+    def test_truncated_result_message_body_raises_protocol_error(self):
+        """
+        Same as above, but for a truncation that happens deeper, inside a
+        message type's recv_body() (rather than in decode_message's own
+        flag-prefix parsing), to confirm the try/except boundary covers the
+        whole BytesReader-consuming call graph, not just the prefix.
+        """
+        with self.assertRaises(ProtocolError):
+            ProtocolHandler.decode_message(
+                protocol_version=ProtocolVersion.MAX_SUPPORTED,
+                protocol_features=None,
+                user_type_map={},
+                stream_id=0,
+                flags=0,
+                opcode=SupportedMessage.opcode,
+                # SupportedMessage.recv_body reads a stringmultimap; claiming
+                # one entry but supplying zero bytes for it is truncated.
+                body=b"\x00\x01",
+                decompressor=None,
+                result_metadata=None,
+            )


### PR DESCRIPTION
This patch set aims to reduce the memory copies we perform in the read path, to improve overall performance - mainly reduce latency on the processing side of the driver receiving the payload.
This is more effective on larger payloads of course.

## ⚠️ Updated benchmark note

Re-benchmarked against master (same tool as below - `benchmarks/decode_benchmark.py`, Cython path, isolated core, 25 iterations + 3 warmup). **Most of the originally-claimed 1.5-3.7x speedups did not reproduce:**

| Scenario | Body Size | master (median) | this PR (median) | Original claim | Re-measured |
|--------|--------|--------|--------|--------|--------|
| small_100 | 7.3 KB | 17.1 us | 18.8 us | 3.7x | **0.91x (slower)** |
| medium_1k_256B | 273.5 KB | 139.5 us | 140.3 us | 3.6x | **0.99x (none)** |
| medium_1k_1KB | 1.0 MB | 904.7 us | 573.2 us | 3.5x | 1.58x |
| large_5k_1KB | 5.0 MB | 5343.2 us | 3666.4 us | 2.6x | 1.46x |
| large_1k_4KB | 3.9 MB | 482.7 us | 425.0 us | 1.9x | 1.14x |
| wide_5k_doubles | 586.1 KB | 1605.8 us | 1637.7 us | 1.9x | **0.98x (none)** |
| wide_1k_20cols | 762.0 KB | 951.0 us | 973.0 us | 1.5x | **0.98x (none)** |
| blob_1k_16KB | 15.6 MB | 14781.7 us | 7184.0 us | 1.8x | 2.06x |

Only `blob_1k_16KB` matches/exceeds its original claim. Four scenarios show no measurable improvement (or a slight regression); the remaining three show a real but smaller 1.1-1.6x. This is the same pattern found on PR #630 (Optimize column_encryption_policy checks in recv_results_rows) — claimed multipliers not holding under careful re-measurement in this environment. **The original benchmark table below is retained for history but should not be relied on as-is.**

The correctness/robustness value of this PR (reducing allocations and copies on the read path, adding `BytesReader` test coverage) still stands independent of the exact multiplier.

## Original benchmark (see note above)

Comparison to master (Cython path, 10 iterations, CPU pinned, all times in microseconds):

| Scenario | Body Size | master (median) | remove_copies (median) | Speedup |
|--------|--------|--------|--------|--------|
| small_100 | 7.3 KB | 273.8 us | 75.0 us | 3.7x |
| medium_1k_256B | 273.5 KB | 1906.7 us | 536.4 us | 3.6x |
| medium_1k_1KB | 1.0 MB | 6166.6 us | 1740.1 us | 3.5x |
| large_5k_1KB | 5.0 MB | 24822.5 us | 9482.1 us | 2.6x |
| large_1k_4KB | 3.9 MB | 4575.3 us | 2346.7 us | 1.9x |
| wide_5k_doubles | 586.1 KB | 13539.2 us | 7163.0 us | 1.9x |
| wide_1k_20cols | 762.0 KB | 5858.3 us | 3831.4 us | 1.5x |
| blob_1k_16KB | 15.6 MB | 62233.0 us | 34668.1 us | 1.8x |

(note - we can see that wide_5k_doubles is bottlenecked on something else - CPU processing of this payload - unpacking it. This may be optimized in a different PR)

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
