### PR TITLE
(improvement) query: add Cython-aware serializer path in BoundStatement.bind() (1-26x speedup - tens/hundreds of us reduced)

### DIFF
--- a/cassandra/deserializers.pyx
+++ b/cassandra/deserializers.pyx
@@ -481,7 +481,15 @@ cpdef Deserializer find_deserializer(cqltype):
 
 
 def obj_array(list objs):
-    """Create a (Cython) array of objects given a list of objects"""
+    """Create a (Cython) array of objects given a list of objects.
+
+    Returns the plain list for empty input since ``cython_array`` does
+    not support zero-length shapes.  Callers that use
+    ``cdef Deserializer[::1]`` typed memoryviews must guard against
+    empty input before assignment.
+    """
+    if not objs:
+        return objs
     cdef object[:] arr
     cdef Py_ssize_t i
     arr = cython_array(shape=(len(objs),), itemsize=sizeof(void *), format="O")

--- a/cassandra/deserializers.pyx
+++ b/cassandra/deserializers.pyx
@@ -481,15 +481,7 @@ cpdef Deserializer find_deserializer(cqltype):
 
 
 def obj_array(list objs):
-    """Create a (Cython) array of objects given a list of objects.
-
-    Returns the plain list for empty input since ``cython_array`` does
-    not support zero-length shapes.  Callers that use
-    ``cdef Deserializer[::1]`` typed memoryviews must guard against
-    empty input before assignment.
-    """
-    if not objs:
-        return objs
+    """Create a (Cython) array of objects given a list of objects"""
     cdef object[:] arr
     cdef Py_ssize_t i
     arr = cython_array(shape=(len(objs),), itemsize=sizeof(void *), format="O")

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -29,6 +29,7 @@ from cassandra import ConsistencyLevel, OperationTimedOut
 from cassandra.util import unix_time_from_uuid1, maybe_add_timeout_to_query
 from cassandra.encoder import Encoder
 import cassandra.encoder
+from cassandra.cqltypes import VectorType
 from cassandra.policies import ColDesc
 from cassandra.protocol import _UNSET_VALUE
 from cassandra.util import OrderedDict, _sanitize_identifiers
@@ -532,8 +533,20 @@ class PreparedStatement(object):
     def _serializers(self):
         """Lazily create and cache Cython serializers for column types.
 
-        Returns a list of Serializer objects if Cython serializers are available
-        and there is no column encryption policy, otherwise returns None.
+        Returns a list of Serializer objects if Cython serializers are available,
+        there is no column encryption policy, and at least one column would
+        actually benefit from the Cython fast path (currently: VectorType
+        columns); otherwise returns None.
+
+        The Cython serializer dispatch has measurable per-value overhead. For
+        ordinary scalar columns (int, float, text, ...) the generic serializer
+        just turns around and calls cqltype.serialize() anyway, so the extra
+        dispatch makes scalar-only statements *slower* than the plain Python
+        path. The big win (multiple times faster) is specifically for
+        VectorType columns, where the Cython path avoids a per-element
+        io.BytesIO loop. So we only take the Cython path when the statement
+        contains at least one VectorType column; scalar-only statements fall
+        through to the plain Python bind path automatically.
 
         The column_encryption_policy check is performed on every access (not
         cached) so that serializers are correctly bypassed if a policy is set
@@ -547,7 +560,8 @@ class PreparedStatement(object):
             return self._cached_serializers
         except AttributeError:
             pass
-        if _HAVE_CYTHON_SERIALIZERS and self.column_metadata:
+        if (_HAVE_CYTHON_SERIALIZERS and self.column_metadata and
+                any(issubclass(col.type, VectorType) for col in self.column_metadata)):
             self._cached_serializers = _cython_make_serializers(
                 [col.type for col in self.column_metadata])
         else:

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -33,6 +33,12 @@ from cassandra.policies import ColDesc
 from cassandra.protocol import _UNSET_VALUE
 from cassandra.util import OrderedDict, _sanitize_identifiers
 
+try:
+    from cassandra.serializers import make_serializers as _cython_make_serializers
+    _HAVE_CYTHON_SERIALIZERS = True
+except ImportError:
+    _HAVE_CYTHON_SERIALIZERS = False
+
 import logging
 log = logging.getLogger(__name__)
 
@@ -522,6 +528,32 @@ class PreparedStatement(object):
         self._result_metadata_and_id = (result_metadata, result_metadata_id)
         self._warned_missing_column_metadata = False
 
+    @property
+    def _serializers(self):
+        """Lazily create and cache Cython serializers for column types.
+
+        Returns a list of Serializer objects if Cython serializers are available
+        and there is no column encryption policy, otherwise returns None.
+
+        The column_encryption_policy check is performed on every access (not
+        cached) so that serializers are correctly bypassed if a policy is set
+        after construction.  This means the cache never goes stale: once a CE
+        policy is present, we always return None and fall through to the
+        encryption-aware bind path.
+        """
+        if self.column_encryption_policy:
+            return None
+        try:
+            return self._cached_serializers
+        except AttributeError:
+            pass
+        if _HAVE_CYTHON_SERIALIZERS and self.column_metadata:
+            self._cached_serializers = _cython_make_serializers(
+                [col.type for col in self.column_metadata])
+        else:
+            self._cached_serializers = None
+        return self._cached_serializers
+
     @classmethod
     def from_message(cls, query_id, column_metadata, pk_indexes, cluster_metadata,
                      query, prepared_keyspace, protocol_version, result_metadata,
@@ -578,6 +610,26 @@ class PreparedStatement(object):
         return (u'<PreparedStatement query="%s", consistency=%s>' %
                 (self.query_string, consistency))
     __repr__ = __str__
+
+
+def _raise_bind_serialize_error(col_spec, value, exc):
+    """Wrap TypeError, struct.error, or OverflowError with column context.
+
+    Called from all three bind loop paths (CE, Cython, plain Python) to
+    provide a uniform error message that includes the column name and
+    expected type.  struct.error arises from int32 out-of-range values;
+    OverflowError from float out-of-range values.  Other exception types
+    (e.g. ValueError from VectorType dimension mismatch) propagate
+    without wrapping.
+    """
+    actual_type = type(value)
+    if isinstance(exc, (OverflowError, struct.error)):
+        reason = 'value out of range'
+    else:
+        reason = 'invalid type'
+    message = ('Received an argument with %s for column "%s". '
+               'Expected: %s, Got: %s; (%s)' % (reason, col_spec.name, col_spec.type, actual_type, exc))
+    raise TypeError(message) from exc
 
 
 class BoundStatement(Statement):
@@ -683,44 +735,91 @@ class BoundStatement(Statement):
                 (value_len, len(self.prepared_statement.routing_key_indexes)))
 
         self.raw_values = values
-        self.values = []
-        for value, col_spec in zip(values, col_meta):
-            if value is None:
-                self.values.append(None)
-            elif value is UNSET_VALUE:
-                if proto_version >= 4:
-                    self._append_unset_value()
+        # Pre-allocate to avoid repeated list growth reallocations
+        self.values = [None] * col_meta_len
+        idx = 0
+        if ce_policy:
+            # Column encryption path: check each column for CE policy
+            for value, col_spec in zip(values, col_meta):
+                if value is None:
+                    self.values[idx] = None
+                elif value is UNSET_VALUE:
+                    if proto_version >= 4:
+                        idx = self._append_unset_value(idx)
+                        continue
+                    else:
+                        raise ValueError("Attempt to bind UNSET_VALUE while using unsuitable protocol version (%d < 4)" % proto_version)
                 else:
-                    raise ValueError("Attempt to bind UNSET_VALUE while using unsuitable protocol version (%d < 4)" % proto_version)
+                    try:
+                        col_desc = ColDesc(col_spec.keyspace_name, col_spec.table_name, col_spec.name)
+                        uses_ce = ce_policy.contains_column(col_desc)
+                        if uses_ce:
+                            col_type = ce_policy.column_type(col_desc)
+                            col_bytes = col_type.serialize(value, proto_version)
+                            col_bytes = ce_policy.encrypt(col_desc, col_bytes)
+                        else:
+                            col_bytes = col_spec.type.serialize(value, proto_version)
+                        self.values[idx] = col_bytes
+                    # struct.error: int32 out-of-range; OverflowError: float out-of-range
+                    except (TypeError, struct.error, OverflowError) as exc:
+                        _raise_bind_serialize_error(col_spec, value, exc)
+                idx += 1
+        else:
+            # Fast path: no column encryption, use Cython serializers if available
+            serializers = self.prepared_statement._serializers
+            if serializers is not None:
+                for ser, value, col_spec in zip(serializers, values, col_meta):
+                    if value is None:
+                        self.values[idx] = None
+                    elif value is UNSET_VALUE:
+                        if proto_version >= 4:
+                            idx = self._append_unset_value(idx)
+                            continue
+                        else:
+                            raise ValueError("Attempt to bind UNSET_VALUE while using unsuitable protocol version (%d < 4)" % proto_version)
+                    else:
+                        try:
+                            col_bytes = ser.serialize(value, proto_version)
+                            self.values[idx] = col_bytes
+                        # struct.error: int32 out-of-range; OverflowError: float out-of-range
+                        except (TypeError, struct.error, OverflowError) as exc:
+                            _raise_bind_serialize_error(col_spec, value, exc)
+                    idx += 1
             else:
-                try:
-                    col_desc = ColDesc(col_spec.keyspace_name, col_spec.table_name, col_spec.name)
-                    uses_ce = ce_policy and ce_policy.contains_column(col_desc)
-                    col_type = ce_policy.column_type(col_desc) if uses_ce else col_spec.type
-                    col_bytes = col_type.serialize(value, proto_version)
-                    if uses_ce:
-                        col_bytes = ce_policy.encrypt(col_desc, col_bytes)
-                    self.values.append(col_bytes)
-                except (TypeError, struct.error) as exc:
-                    actual_type = type(value)
-                    message = ('Received an argument of invalid type for column "%s". '
-                               'Expected: %s, Got: %s; (%s)' % (col_spec.name, col_spec.type, actual_type, exc))
-                    raise TypeError(message)
+                for value, col_spec in zip(values, col_meta):
+                    if value is None:
+                        self.values[idx] = None
+                    elif value is UNSET_VALUE:
+                        if proto_version >= 4:
+                            idx = self._append_unset_value(idx)
+                            continue
+                        else:
+                            raise ValueError("Attempt to bind UNSET_VALUE while using unsuitable protocol version (%d < 4)" % proto_version)
+                    else:
+                        try:
+                            col_bytes = col_spec.type.serialize(value, proto_version)
+                            self.values[idx] = col_bytes
+                        # struct.error: int32 out-of-range; OverflowError: float out-of-range
+                        except (TypeError, struct.error, OverflowError) as exc:
+                            _raise_bind_serialize_error(col_spec, value, exc)
+                    idx += 1
 
         if proto_version >= 4:
-            diff = col_meta_len - len(self.values)
-            if diff:
-                for _ in range(diff):
-                    self._append_unset_value()
+            # Fill remaining unbound columns with UNSET_VALUE (v4+ feature).
+            while idx < col_meta_len:
+                idx = self._append_unset_value(idx)
+        elif idx < col_meta_len:
+            # Pre-v4: trim trailing unused slots (no UNSET_VALUE support)
+            self.values = self.values[:idx]
 
         return self
 
-    def _append_unset_value(self):
-        next_index = len(self.values)
-        if self.prepared_statement.is_routing_key_index(next_index):
-            col_meta = self.prepared_statement.column_metadata[next_index]
+    def _append_unset_value(self, idx):
+        if self.prepared_statement.is_routing_key_index(idx):
+            col_meta = self.prepared_statement.column_metadata[idx]
             raise ValueError("Cannot bind UNSET_VALUE as a part of the routing key '%s'" % col_meta.name)
-        self.values.append(UNSET_VALUE)
+        self.values[idx] = UNSET_VALUE
+        return idx + 1
 
     @property
     def routing_key(self):

--- a/cassandra/serializers.pxd
+++ b/cassandra/serializers.pxd
@@ -1,0 +1,20 @@
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+cdef class Serializer:
+    # The cqltypes._CassandraType corresponding to this serializer
+    cdef object cqltype
+
+    cpdef bytes serialize(self, object value, int protocol_version)

--- a/cassandra/serializers.pyx
+++ b/cassandra/serializers.pyx
@@ -219,12 +219,7 @@ cdef class SerVectorType(Serializer):
             self.type_code = 0
 
     cpdef bytes serialize(self, object value, int protocol_version):
-        # Normalize to tuple/list so indexing works for any iterable.
-        # The Python VectorType.serialize() only requires len() + iteration,
-        # so we must accept the same inputs.  Avoid a copy if value is
-        # already a list or tuple (common fast path for embeddings).
-        if not isinstance(value, (list, tuple)):
-            value = tuple(value)
+        cdef object result
         cdef Py_ssize_t v_length = len(value)
         if v_length != self.vector_size:
             raise ValueError(
@@ -232,6 +227,28 @@ cdef class SerVectorType(Serializer):
                 "dimension %d, observed sequence of length %d" % (
                     self.vector_size, self.subtype.typename,
                     self.vector_size, v_length))
+
+        if self.type_code == 1:
+            result = self._serialize_float_buffer(value)
+            if result is not None:
+                return result
+        elif self.type_code == 2:
+            result = self._serialize_double_buffer(value)
+            if result is not None:
+                return result
+        elif self.type_code == 3:
+            result = self._serialize_int32_buffer(value)
+            if result is not None:
+                return result
+
+        # Keep indexable sequences on the fast path. Fall back to tuple()
+        # only for iterable-only inputs so the Cython path still matches
+        # Python VectorType.serialize() input semantics.
+        if v_length != 0 and not isinstance(value, (list, tuple)):
+            try:
+                value[0]
+            except (TypeError, KeyError, IndexError):
+                value = tuple(value)
 
         if self.type_code == 1:
             return self._serialize_float(value)
@@ -245,8 +262,8 @@ cdef class SerVectorType(Serializer):
     cdef inline bytes _serialize_float(self, object values):
         """Serialize a list of floats into a contiguous big-endian buffer.
 
-        ``values`` is already a tuple (normalized in ``serialize()``), so
-        indexing is always safe and fast.
+        ``values`` is already an indexable sequence (normalized in
+        ``serialize()``), so integer indexing is safe and fast.
         """
         cdef Py_ssize_t i
         cdef Py_ssize_t buf_size = self.vector_size * 4
@@ -277,11 +294,54 @@ cdef class SerVectorType(Serializer):
 
         return result
 
+    cdef inline object _serialize_float_buffer(self, object values):
+        """Fast path for contiguous float32 buffers (e.g. numpy float32 arrays).
+
+        No ``_check_float_range`` is needed: the typed memoryview
+        ``float[::1]`` constrains values to C float (IEEE 754 float32),
+        so overflow is impossible by definition.  Returns ``None`` when
+        *values* does not support the buffer protocol with the required
+        format, letting the caller fall through to the element-wise path.
+        """
+        cdef float[::1] view
+        cdef Py_ssize_t buf_size = self.vector_size * 4
+        cdef Py_ssize_t i
+        cdef object result
+        cdef char *buf
+        cdef char *dst
+        cdef char *src
+        cdef float val
+
+        try:
+            view = values
+        except (TypeError, ValueError):
+            return None
+
+        if buf_size == 0:
+            return b""
+
+        result = PyBytes_FromStringAndSize(NULL, buf_size)
+        buf = PyBytes_AS_STRING(result)
+
+        if is_little_endian:
+            for i in range(self.vector_size):
+                val = view[i]
+                src = <char *>&val
+                dst = buf + i * 4
+                dst[0] = src[3]
+                dst[1] = src[2]
+                dst[2] = src[1]
+                dst[3] = src[0]
+        else:
+            memcpy(buf, &view[0], buf_size)
+
+        return result
+
     cdef inline bytes _serialize_double(self, object values):
         """Serialize a list of doubles into a contiguous big-endian buffer.
 
-        ``values`` is already a tuple (normalized in ``serialize()``), so
-        indexing is always safe and fast.
+        ``values`` is already an indexable sequence (normalized in
+        ``serialize()``), so integer indexing is safe and fast.
         """
         cdef Py_ssize_t i
         cdef Py_ssize_t buf_size = self.vector_size * 8
@@ -313,11 +373,55 @@ cdef class SerVectorType(Serializer):
 
         return result
 
+    cdef inline object _serialize_double_buffer(self, object values):
+        """Fast path for contiguous float64 buffers (e.g. numpy float64 arrays).
+
+        Returns ``None`` when *values* does not expose a compatible
+        buffer, letting the caller fall through to the element-wise path.
+        """
+        cdef double[::1] view
+        cdef Py_ssize_t buf_size = self.vector_size * 8
+        cdef Py_ssize_t i
+        cdef object result
+        cdef char *buf
+        cdef char *dst
+        cdef char *src
+        cdef double val
+
+        try:
+            view = values
+        except (TypeError, ValueError):
+            return None
+
+        if buf_size == 0:
+            return b""
+
+        result = PyBytes_FromStringAndSize(NULL, buf_size)
+        buf = PyBytes_AS_STRING(result)
+
+        if is_little_endian:
+            for i in range(self.vector_size):
+                val = view[i]
+                src = <char *>&val
+                dst = buf + i * 8
+                dst[0] = src[7]
+                dst[1] = src[6]
+                dst[2] = src[5]
+                dst[3] = src[4]
+                dst[4] = src[3]
+                dst[5] = src[2]
+                dst[6] = src[1]
+                dst[7] = src[0]
+        else:
+            memcpy(buf, &view[0], buf_size)
+
+        return result
+
     cdef inline bytes _serialize_int32(self, object values):
         """Serialize a list of int32 values into a contiguous big-endian buffer.
 
-        ``values`` is already a tuple (normalized in ``serialize()``), so
-        indexing is always safe and fast.
+        ``values`` is already an indexable sequence (normalized in
+        ``serialize()``), so integer indexing is safe and fast.
         """
         cdef Py_ssize_t i
         cdef Py_ssize_t buf_size = self.vector_size * 4
@@ -345,6 +449,47 @@ cdef class SerVectorType(Serializer):
                 dst[3] = src[0]
             else:
                 memcpy(dst, src, 4)
+
+        return result
+
+    cdef inline object _serialize_int32_buffer(self, object values):
+        """Fast path for contiguous int32 buffers (e.g. numpy int32 arrays).
+
+        No ``_coerce_int`` / ``_check_int32_range`` is needed: the typed
+        memoryview ``int[::1]`` enforces 32-bit signed integer range at
+        the buffer-protocol level.  Returns ``None`` when *values* does
+        not expose a compatible buffer, letting the caller fall through
+        to the element-wise path.
+        """
+        cdef int[::1] view
+        cdef Py_ssize_t buf_size = self.vector_size * 4
+        cdef Py_ssize_t i
+        cdef object result
+        cdef char *buf
+        cdef char *dst
+        cdef char *src
+
+        try:
+            view = values
+        except (TypeError, ValueError):
+            return None
+
+        if buf_size == 0:
+            return b""
+
+        result = PyBytes_FromStringAndSize(NULL, buf_size)
+        buf = PyBytes_AS_STRING(result)
+
+        if is_little_endian:
+            for i in range(self.vector_size):
+                src = <char *>&view[i]
+                dst = buf + i * 4
+                dst[0] = src[3]
+                dst[1] = src[2]
+                dst[2] = src[1]
+                dst[3] = src[0]
+        else:
+            memcpy(buf, &view[0], buf_size)
 
         return result
 

--- a/cassandra/serializers.pyx
+++ b/cassandra/serializers.pyx
@@ -1,0 +1,440 @@
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Cython-optimized serializers for CQL types.
+
+Mirrors the architecture of deserializers.pyx. Currently implements
+optimized serialization for:
+- FloatType (4-byte big-endian float)
+- DoubleType (8-byte big-endian double)
+- Int32Type (4-byte big-endian signed int)
+- VectorType (type-specialized for float/double/int32, generic fallback)
+
+For all other types, GenericSerializer delegates to the Python-level
+cqltype.serialize() classmethod.
+"""
+
+from libc.stdint cimport int32_t
+from libc.string cimport memcpy
+from libc.math cimport isinf, isnan
+from libc.float cimport FLT_MAX
+from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AS_STRING
+from cython.view cimport array as cython_array
+
+from cassandra import cqltypes
+from operator import index as _operator_index
+
+cdef bint is_little_endian
+from cassandra.util import is_little_endian
+
+
+# ---------------------------------------------------------------------------
+# Range-check helpers (match struct.pack error semantics)
+# ---------------------------------------------------------------------------
+
+cdef inline void _check_float_range(double value) except *:
+    """Raise OverflowError for finite values that overflow float32.
+
+    Uses the same semantics as ``struct.pack('>f', value)``: cast the
+    double to float and reject only if the result is ±inf while the
+    input was finite.  This correctly accepts values slightly above
+    ``FLT_MAX`` that round down (e.g. 3.4028235e38).
+
+    Intentionally raises OverflowError (not struct.error) so callers
+    can catch a single exception type.  inf, -inf, and nan pass
+    through unchanged.
+    """
+    if not isinf(value) and not isnan(value):
+        if isinf(<float>value):
+            raise OverflowError(
+                "Value %r too large for float32 (max %r)" % (value, FLT_MAX))
+
+
+cdef inline void _check_int32_range(object value) except *:
+    """Raise OverflowError for values outside the signed int32 range.
+
+    Intentionally raises OverflowError (not struct.error) so callers
+    can catch a single exception type. The accepted range matches
+    struct.pack('>i', ...): [-2147483648, 2147483647]. The check must
+    be done on the Python int *before* the C-level <int32_t> cast,
+    which would silently truncate.
+
+    The value should already have been coerced via ``_coerce_int()``
+    (i.e. the ``__index__`` protocol) before being passed here.
+    """
+    if value > 2147483647 or value < -2147483648:
+        raise OverflowError(
+            "Value %r out of range for int32 "
+            "(must be between -2147483648 and 2147483647)" % (value,))
+
+
+cdef inline object _coerce_int(object value):
+    """Coerce *value* to a Python ``int`` via the ``__index__`` protocol.
+
+    This matches ``struct.pack('>i', value)`` semantics, which accepts any
+    object implementing ``__index__`` (e.g. numpy integer scalars).  Raises
+    ``TypeError`` for objects that do not support the protocol.
+    """
+    return _operator_index(value)
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+cdef class Serializer:
+    """Cython-based serializer class for a cqltype"""
+
+    def __init__(self, cqltype):
+        self.cqltype = cqltype
+
+    cpdef bytes serialize(self, object value, int protocol_version):
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Scalar serializers
+# ---------------------------------------------------------------------------
+
+cdef class SerFloatType(Serializer):
+    """Serialize a Python float to 4-byte big-endian IEEE 754."""
+
+    cpdef bytes serialize(self, object value, int protocol_version):
+        _check_float_range(<double>value)
+        cdef float val = <float>value
+        cdef char out[4]
+        cdef char *src = <char *>&val
+
+        if is_little_endian:
+            out[0] = src[3]
+            out[1] = src[2]
+            out[2] = src[1]
+            out[3] = src[0]
+        else:
+            memcpy(out, src, 4)
+
+        return PyBytes_FromStringAndSize(out, 4)
+
+
+cdef class SerDoubleType(Serializer):
+    """Serialize a Python float to 8-byte big-endian IEEE 754."""
+
+    cpdef bytes serialize(self, object value, int protocol_version):
+        cdef double val = <double>value
+        cdef char out[8]
+        cdef char *src = <char *>&val
+
+        if is_little_endian:
+            out[0] = src[7]
+            out[1] = src[6]
+            out[2] = src[5]
+            out[3] = src[4]
+            out[4] = src[3]
+            out[5] = src[2]
+            out[6] = src[1]
+            out[7] = src[0]
+        else:
+            memcpy(out, src, 8)
+
+        return PyBytes_FromStringAndSize(out, 8)
+
+
+cdef class SerInt32Type(Serializer):
+    """Serialize a Python int to 4-byte big-endian signed int32."""
+
+    cpdef bytes serialize(self, object value, int protocol_version):
+        value = _coerce_int(value)
+        _check_int32_range(value)
+        cdef int32_t val = <int32_t>value
+        cdef char out[4]
+        cdef char *src = <char *>&val
+
+        if is_little_endian:
+            out[0] = src[3]
+            out[1] = src[2]
+            out[2] = src[1]
+            out[3] = src[0]
+        else:
+            memcpy(out, src, 4)
+
+        return PyBytes_FromStringAndSize(out, 4)
+
+
+# ---------------------------------------------------------------------------
+# Type detection helpers
+# ---------------------------------------------------------------------------
+
+cdef inline bint _is_float_type(object subtype):
+    return subtype is cqltypes.FloatType or issubclass(subtype, cqltypes.FloatType)
+
+cdef inline bint _is_double_type(object subtype):
+    return subtype is cqltypes.DoubleType or issubclass(subtype, cqltypes.DoubleType)
+
+cdef inline bint _is_int32_type(object subtype):
+    return subtype is cqltypes.Int32Type or issubclass(subtype, cqltypes.Int32Type)
+
+
+# ---------------------------------------------------------------------------
+# VectorType serializer
+# ---------------------------------------------------------------------------
+
+cdef class SerVectorType(Serializer):
+    """
+    Optimized Cython serializer for VectorType.
+
+    For float, double, and int32 vectors, pre-allocates a contiguous buffer
+    and uses C-level byte swapping. For other subtypes, falls back to
+    per-element Python serialization.
+    """
+
+    cdef Py_ssize_t vector_size
+    cdef object subtype
+    # 0 = generic, 1 = float, 2 = double, 3 = int32
+    cdef int type_code
+
+    def __init__(self, cqltype):
+        super().__init__(cqltype)
+        self.vector_size = cqltype.vector_size
+        self.subtype = cqltype.subtype
+
+        if _is_float_type(self.subtype):
+            self.type_code = 1
+        elif _is_double_type(self.subtype):
+            self.type_code = 2
+        elif _is_int32_type(self.subtype):
+            self.type_code = 3
+        else:
+            self.type_code = 0
+
+    cpdef bytes serialize(self, object value, int protocol_version):
+        # Normalize to tuple/list so indexing works for any iterable.
+        # The Python VectorType.serialize() only requires len() + iteration,
+        # so we must accept the same inputs.  Avoid a copy if value is
+        # already a list or tuple (common fast path for embeddings).
+        if not isinstance(value, (list, tuple)):
+            value = tuple(value)
+        cdef Py_ssize_t v_length = len(value)
+        if v_length != self.vector_size:
+            raise ValueError(
+                "Expected sequence of size %d for vector of type %s and "
+                "dimension %d, observed sequence of length %d" % (
+                    self.vector_size, self.subtype.typename,
+                    self.vector_size, v_length))
+
+        if self.type_code == 1:
+            return self._serialize_float(value)
+        elif self.type_code == 2:
+            return self._serialize_double(value)
+        elif self.type_code == 3:
+            return self._serialize_int32(value)
+        else:
+            return self._serialize_generic(value, protocol_version)
+
+    cdef inline bytes _serialize_float(self, object values):
+        """Serialize a list of floats into a contiguous big-endian buffer.
+
+        ``values`` is already a tuple (normalized in ``serialize()``), so
+        indexing is always safe and fast.
+        """
+        cdef Py_ssize_t i
+        cdef Py_ssize_t buf_size = self.vector_size * 4
+        if buf_size == 0:
+            return b""
+
+        cdef object result = PyBytes_FromStringAndSize(NULL, buf_size)
+        cdef char *buf = PyBytes_AS_STRING(result)
+        cdef double dval
+        cdef float val
+        cdef char *src
+        cdef char *dst
+
+        for i in range(self.vector_size):
+            dval = <double>values[i]
+            _check_float_range(dval)
+            val = <float>dval
+            src = <char *>&val
+            dst = buf + i * 4
+
+            if is_little_endian:
+                dst[0] = src[3]
+                dst[1] = src[2]
+                dst[2] = src[1]
+                dst[3] = src[0]
+            else:
+                memcpy(dst, src, 4)
+
+        return result
+
+    cdef inline bytes _serialize_double(self, object values):
+        """Serialize a list of doubles into a contiguous big-endian buffer.
+
+        ``values`` is already a tuple (normalized in ``serialize()``), so
+        indexing is always safe and fast.
+        """
+        cdef Py_ssize_t i
+        cdef Py_ssize_t buf_size = self.vector_size * 8
+        if buf_size == 0:
+            return b""
+
+        cdef object result = PyBytes_FromStringAndSize(NULL, buf_size)
+        cdef char *buf = PyBytes_AS_STRING(result)
+        cdef double val
+        cdef char *src
+        cdef char *dst
+
+        for i in range(self.vector_size):
+            val = <double>values[i]
+            src = <char *>&val
+            dst = buf + i * 8
+
+            if is_little_endian:
+                dst[0] = src[7]
+                dst[1] = src[6]
+                dst[2] = src[5]
+                dst[3] = src[4]
+                dst[4] = src[3]
+                dst[5] = src[2]
+                dst[6] = src[1]
+                dst[7] = src[0]
+            else:
+                memcpy(dst, src, 8)
+
+        return result
+
+    cdef inline bytes _serialize_int32(self, object values):
+        """Serialize a list of int32 values into a contiguous big-endian buffer.
+
+        ``values`` is already a tuple (normalized in ``serialize()``), so
+        indexing is always safe and fast.
+        """
+        cdef Py_ssize_t i
+        cdef Py_ssize_t buf_size = self.vector_size * 4
+        if buf_size == 0:
+            return b""
+
+        cdef object result = PyBytes_FromStringAndSize(NULL, buf_size)
+        cdef char *buf = PyBytes_AS_STRING(result)
+        cdef int32_t val
+        cdef object item
+        cdef char *src
+        cdef char *dst
+
+        for i in range(self.vector_size):
+            item = _coerce_int(values[i])
+            _check_int32_range(item)
+            val = <int32_t>item
+            src = <char *>&val
+            dst = buf + i * 4
+
+            if is_little_endian:
+                dst[0] = src[3]
+                dst[1] = src[2]
+                dst[2] = src[1]
+                dst[3] = src[0]
+            else:
+                memcpy(dst, src, 4)
+
+        return result
+
+    cdef inline bytes _serialize_generic(self, object values, int protocol_version):
+        """Fallback: element-by-element Python serialization for non-optimized types."""
+        import io
+        from cassandra.marshal import uvint_pack
+
+        serialized_size = self.subtype.serial_size()
+        buf = io.BytesIO()
+        for item in values:
+            item_bytes = self.subtype.serialize(item, protocol_version)
+            if serialized_size is None:
+                buf.write(uvint_pack(len(item_bytes)))
+            buf.write(item_bytes)
+        return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Generic serializer (fallback for all other types)
+# ---------------------------------------------------------------------------
+
+cdef class GenericSerializer(Serializer):
+    """
+    Wraps a generic cqltype for serialization, delegating to the Python-level
+    cqltype.serialize() classmethod.
+    """
+
+    cpdef bytes serialize(self, object value, int protocol_version):
+        return self.cqltype.serialize(value, protocol_version)
+
+    def __repr__(self):
+        return "GenericSerializer(%s)" % (self.cqltype,)
+
+
+# ---------------------------------------------------------------------------
+# Lookup and factory
+# ---------------------------------------------------------------------------
+
+cdef dict _ser_classes = {}
+
+cpdef Serializer find_serializer(cqltype):
+    """Find a serializer for a cqltype."""
+
+    # For VectorType, use SerVectorType only if parameterized (has a valid subtype).
+    # Un-parameterized VectorType (base class) would crash _is_float_type() etc.
+    if issubclass(cqltype, cqltypes.VectorType):
+        if getattr(cqltype, 'subtype', None) is not None:
+            return SerVectorType(cqltype)
+        return GenericSerializer(cqltype)
+
+    # For scalar types with dedicated serializers, look up by name
+    name = 'Ser' + cqltype.__name__
+    cls = _ser_classes.get(name)
+    if cls is not None:
+        return cls(cqltype)
+
+    # Fallback to generic
+    return GenericSerializer(cqltype)
+
+
+def make_serializers(cqltypes_list):
+    """Create a Cython typed array of Serializer objects for each given cqltype.
+
+    Returns an ``obj_array`` (Cython typed memoryview) matching the
+    ``make_deserializers()`` convention for O(1) C-level indexed access.
+    """
+    return obj_array([find_serializer(ct) for ct in cqltypes_list])
+
+
+def obj_array(list objs):
+    """Create a (Cython) array of objects given a list of objects.
+
+    Mirrors ``deserializers.obj_array()`` so both sides share the same
+    typed-memoryview convention.  Returns the plain list for empty input
+    since ``cython_array`` does not support zero-length shapes.  Callers
+    that use ``cdef Serializer[::1]`` typed memoryviews must guard
+    against empty input before assignment.
+    """
+    if not objs:
+        return objs
+    cdef object[:] arr
+    cdef Py_ssize_t i
+    arr = cython_array(shape=(len(objs),), itemsize=sizeof(void *), format="O")
+    for i, obj in enumerate(objs):
+        arr[i] = obj
+    return arr
+
+
+# Build the lookup dict for scalar serializers at module load time
+_ser_classes['SerFloatType'] = SerFloatType
+_ser_classes['SerDoubleType'] = SerDoubleType
+_ser_classes['SerInt32Type'] = SerInt32Type

--- a/cassandra/serializers.pyx
+++ b/cassandra/serializers.pyx
@@ -176,14 +176,40 @@ cdef class SerInt32Type(Serializer):
 # Type detection helpers
 # ---------------------------------------------------------------------------
 
+cdef inline object _nearest_serialize_owner(object cls):
+    """Return the class in ``cls``'s MRO that actually defines ``serialize``.
+
+    ``CassandraType.apply_parameters()`` (used to build e.g. parameterized
+    ``VectorType`` subtypes, or -- via user code -- any other subclass of a
+    built-in scalar type) only ever sets data attributes such as
+    ``subtypes``/``vector_size``/``fieldnames`` on the generated class; it
+    never sets ``serialize`` there. Walking the MRO to find the nearest class
+    whose own ``__dict__`` defines ``serialize`` therefore reliably answers
+    "does this class actually behave like the built-in type for
+    serialization purposes, or has some ancestor/itself overridden it?" --
+    which a plain ``is``/``issubclass`` check cannot: those are true for any
+    subclass, including a user-defined one that overrides ``serialize()`` to
+    do something other than what the corresponding Cython ``Ser*`` class
+    hard-codes. ``cassandra.cqltypes.CassandraTypeType`` auto-registers any
+    non-underscore-prefixed class by its own ``__name__`` (see
+    ``tests/unit/test_types.py::test_parse_casstype_args`` for the supported
+    pattern of subclassing a ``CassandraType`` with custom behavior), so such
+    a subclass -- intentionally or via an accidental name clash -- can end up
+    as a real column's type or a vector's subtype.
+    """
+    for klass in cls.__mro__:
+        if 'serialize' in klass.__dict__:
+            return klass
+    return None
+
 cdef inline bint _is_float_type(object subtype):
-    return subtype is cqltypes.FloatType or issubclass(subtype, cqltypes.FloatType)
+    return _nearest_serialize_owner(subtype) is cqltypes.FloatType
 
 cdef inline bint _is_double_type(object subtype):
-    return subtype is cqltypes.DoubleType or issubclass(subtype, cqltypes.DoubleType)
+    return _nearest_serialize_owner(subtype) is cqltypes.DoubleType
 
 cdef inline bint _is_int32_type(object subtype):
-    return subtype is cqltypes.Int32Type or issubclass(subtype, cqltypes.Int32Type)
+    return _nearest_serialize_owner(subtype) is cqltypes.Int32Type
 
 
 # ---------------------------------------------------------------------------
@@ -534,16 +560,27 @@ cdef dict _ser_classes = {}
 cpdef Serializer find_serializer(cqltype):
     """Find a serializer for a cqltype."""
 
-    # For VectorType, use SerVectorType only if parameterized (has a valid subtype).
-    # Un-parameterized VectorType (base class) would crash _is_float_type() etc.
+    # For VectorType, use SerVectorType only if parameterized (has a valid
+    # subtype) AND cqltype behaves like the built-in VectorType for
+    # serialization -- i.e. the nearest class in its MRO that defines
+    # serialize() is cqltypes.VectorType itself, not some subclass (built-in
+    # generated subtypes never define their own serialize(), but a
+    # user-defined subclass might override it; see
+    # _nearest_serialize_owner()). Un-parameterized VectorType (base class)
+    # would crash _is_float_type() etc, so that's still checked first.
     if issubclass(cqltype, cqltypes.VectorType):
-        if getattr(cqltype, 'subtype', None) is not None:
+        if (getattr(cqltype, 'subtype', None) is not None and
+                _nearest_serialize_owner(cqltype) is cqltypes.VectorType):
             return SerVectorType(cqltype)
         return GenericSerializer(cqltype)
 
-    # For scalar types with dedicated serializers, look up by name
-    name = 'Ser' + cqltype.__name__
-    cls = _ser_classes.get(name)
+    # For scalar types with dedicated serializers, use the specialized path
+    # only when cqltype actually behaves like the built-in type for
+    # serialization -- keyed and verified by identity/MRO ownership, not by
+    # class-name string, so a different class merely *named* e.g. 'FloatType'
+    # (or a subclass overriding serialize()) can't be mistaken for it.
+    owner = _nearest_serialize_owner(cqltype)
+    cls = _ser_classes.get(owner)
     if cls is not None:
         return cls(cqltype)
 
@@ -564,10 +601,13 @@ def obj_array(list objs):
     """Create a (Cython) array of objects given a list of objects.
 
     Mirrors ``deserializers.obj_array()`` so both sides share the same
-    typed-memoryview convention.  Returns the plain list for empty input
-    since ``cython_array`` does not support zero-length shapes.  Callers
-    that use ``cdef Serializer[::1]`` typed memoryviews must guard
-    against empty input before assignment.
+    typed-memoryview convention. Empty input is not currently expected here:
+    the only caller, ``PreparedStatement._serializers``, already guards on
+    ``self.column_metadata`` being non-empty before calling
+    ``make_serializers()``. The early return below is defensive only (it
+    does not, by itself, make an empty-input call safe end-to-end for
+    callers that assign the result to a typed ``Serializer[::1]``
+    memoryview, since a plain list isn't a valid memoryview value).
     """
     if not objs:
         return objs
@@ -579,7 +619,10 @@ def obj_array(list objs):
     return arr
 
 
-# Build the lookup dict for scalar serializers at module load time
-_ser_classes['SerFloatType'] = SerFloatType
-_ser_classes['SerDoubleType'] = SerDoubleType
-_ser_classes['SerInt32Type'] = SerInt32Type
+# Build the lookup dict for scalar serializers at module load time. Keyed by
+# the actual built-in cqltypes class objects (not name strings), so a
+# same-named or subclassed impostor can't be mistaken for the real type --
+# see find_serializer() and _nearest_serialize_owner().
+_ser_classes[cqltypes.FloatType] = SerFloatType
+_ser_classes[cqltypes.DoubleType] = SerDoubleType
+_ser_classes[cqltypes.Int32Type] = SerInt32Type

--- a/tests/unit/cython/test_serializers.py
+++ b/tests/unit/cython/test_serializers.py
@@ -1,0 +1,603 @@
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for Cython-optimized serializers (cassandra.serializers).
+
+Verifies byte-for-byte equivalence with the Python-level cqltype.serialize()
+implementations, plus correct error behavior for edge cases.
+"""
+
+import math
+import struct
+import unittest
+
+from tests.unit.cython.utils import cythontest
+
+from cassandra.cython_deps import HAVE_CYTHON
+
+try:
+    from tests import VERIFY_CYTHON
+except ImportError:
+    VERIFY_CYTHON = False
+
+from cassandra.cqltypes import (
+    FloatType,
+    DoubleType,
+    Int32Type,
+    VectorType,
+    UTF8Type,
+    LongType,
+    BooleanType,
+)
+
+# Import serializers only if Cython is available (compiled .so present).
+# When VERIFY_CYTHON is set (CI mode), let ImportError propagate so build
+# failures are not silently swallowed.
+if HAVE_CYTHON or VERIFY_CYTHON:
+    from cassandra.serializers import (
+        Serializer,
+        SerFloatType,
+        SerDoubleType,
+        SerInt32Type,
+        SerVectorType,
+        GenericSerializer,
+        find_serializer,
+        make_serializers,
+    )
+
+# Protocol version used in tests (value doesn't affect scalar serialization)
+PROTO = 4
+
+
+def _make_vector_type(subtype, size):
+    """Create a VectorType parameterized with the given subtype class and size."""
+    return VectorType.apply_parameters([subtype, size], None)
+
+
+# ---------------------------------------------------------------------------
+# Scalar serializer equivalence tests
+# ---------------------------------------------------------------------------
+
+
+@cythontest
+class TestSerFloatTypeEquivalence(unittest.TestCase):
+    """Verify SerFloatType produces identical bytes to FloatType.serialize()."""
+
+    def setUp(self):
+        self.ser = SerFloatType(FloatType)
+
+    def _assert_equiv(self, value):
+        cython_bytes = self.ser.serialize(value, PROTO)
+        python_bytes = FloatType.serialize(value, PROTO)
+        self.assertEqual(cython_bytes, python_bytes, "Mismatch for value %r" % value)
+
+    def test_zero(self):
+        self._assert_equiv(0.0)
+
+    def test_negative_zero(self):
+        self._assert_equiv(-0.0)
+
+    def test_positive_values(self):
+        for val in [1.0, 0.5, 3.14, 100.0, 1e10]:
+            self._assert_equiv(val)
+
+    def test_negative_values(self):
+        for val in [-1.0, -0.5, -3.14, -100.0, -1e10]:
+            self._assert_equiv(val)
+
+    def test_flt_max(self):
+        flt_max = 3.4028234663852886e38
+        self._assert_equiv(flt_max)
+        self._assert_equiv(-flt_max)
+
+    def test_flt_max_rounding_boundary(self):
+        """Values slightly above FLT_MAX that round down should be accepted.
+
+        3.4028235e38 is above FLT_MAX (3.4028234663852886e38) but
+        struct.pack('>f', 3.4028235e38) rounds it down to FLT_MAX.
+        The Cython serializer must accept the same inputs.
+        """
+        self._assert_equiv(3.4028235e38)
+        self._assert_equiv(-3.4028235e38)
+
+    def test_subnormal_values(self):
+        """Subnormal (denormalized) floats should serialize correctly."""
+        self._assert_equiv(1e-45)
+        self._assert_equiv(-1e-45)
+        self._assert_equiv(1.4e-45)  # smallest positive float32
+
+    def test_inf(self):
+        self._assert_equiv(float("inf"))
+
+    def test_neg_inf(self):
+        self._assert_equiv(float("-inf"))
+
+    def test_nan(self):
+        """NaN bytes must match (NaN != NaN, so compare bytes directly)."""
+        cython_bytes = self.ser.serialize(float("nan"), PROTO)
+        python_bytes = FloatType.serialize(float("nan"), PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+    def test_overflow_positive(self):
+        with self.assertRaises((OverflowError, struct.error)):
+            self.ser.serialize(1e40, PROTO)
+
+    def test_overflow_negative(self):
+        with self.assertRaises((OverflowError, struct.error)):
+            self.ser.serialize(-1e40, PROTO)
+
+    def test_overflow_dbl_max(self):
+        with self.assertRaises((OverflowError, struct.error)):
+            self.ser.serialize(1.7976931348623157e308, PROTO)
+
+    def test_type_error_string(self):
+        with self.assertRaises(TypeError):
+            self.ser.serialize("not a float", PROTO)
+
+    def test_type_error_none(self):
+        with self.assertRaises(TypeError):
+            self.ser.serialize(None, PROTO)
+
+
+@cythontest
+class TestSerDoubleTypeEquivalence(unittest.TestCase):
+    """Verify SerDoubleType produces identical bytes to DoubleType.serialize()."""
+
+    def setUp(self):
+        self.ser = SerDoubleType(DoubleType)
+
+    def _assert_equiv(self, value):
+        cython_bytes = self.ser.serialize(value, PROTO)
+        python_bytes = DoubleType.serialize(value, PROTO)
+        self.assertEqual(cython_bytes, python_bytes, "Mismatch for value %r" % value)
+
+    def test_zero(self):
+        self._assert_equiv(0.0)
+
+    def test_negative_zero(self):
+        self._assert_equiv(-0.0)
+
+    def test_normal_values(self):
+        for val in [1.0, -1.0, 3.14, -3.14, 1e100, -1e100, 1e-100]:
+            self._assert_equiv(val)
+
+    def test_dbl_max(self):
+        self._assert_equiv(1.7976931348623157e308)
+        self._assert_equiv(-1.7976931348623157e308)
+
+    def test_inf(self):
+        self._assert_equiv(float("inf"))
+        self._assert_equiv(float("-inf"))
+
+    def test_nan(self):
+        cython_bytes = self.ser.serialize(float("nan"), PROTO)
+        python_bytes = DoubleType.serialize(float("nan"), PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+    def test_type_error_string(self):
+        with self.assertRaises(TypeError):
+            self.ser.serialize("not a double", PROTO)
+
+    def test_type_error_none(self):
+        with self.assertRaises(TypeError):
+            self.ser.serialize(None, PROTO)
+
+
+@cythontest
+class TestSerInt32TypeEquivalence(unittest.TestCase):
+    """Verify SerInt32Type produces identical bytes to Int32Type.serialize()."""
+
+    def setUp(self):
+        self.ser = SerInt32Type(Int32Type)
+
+    def _assert_equiv(self, value):
+        cython_bytes = self.ser.serialize(value, PROTO)
+        python_bytes = Int32Type.serialize(value, PROTO)
+        self.assertEqual(cython_bytes, python_bytes, "Mismatch for value %r" % value)
+
+    def test_zero(self):
+        self._assert_equiv(0)
+
+    def test_positive_values(self):
+        for val in [1, 42, 127, 255, 32767, 65535]:
+            self._assert_equiv(val)
+
+    def test_negative_values(self):
+        for val in [-1, -42, -128, -32768]:
+            self._assert_equiv(val)
+
+    def test_int32_max(self):
+        self._assert_equiv(2147483647)
+
+    def test_int32_min(self):
+        self._assert_equiv(-2147483648)
+
+    def test_overflow_positive(self):
+        with self.assertRaises((OverflowError, struct.error)):
+            self.ser.serialize(2147483648, PROTO)
+
+    def test_overflow_negative(self):
+        with self.assertRaises((OverflowError, struct.error)):
+            self.ser.serialize(-2147483649, PROTO)
+
+    def test_overflow_large_python_int(self):
+        """Python ints have arbitrary precision; must still reject out-of-range."""
+        with self.assertRaises((OverflowError, struct.error)):
+            self.ser.serialize(2**100, PROTO)
+
+    def test_overflow_large_negative_python_int(self):
+        with self.assertRaises((OverflowError, struct.error)):
+            self.ser.serialize(-(2**100), PROTO)
+
+    def test_type_error_string(self):
+        with self.assertRaises(TypeError):
+            self.ser.serialize("not an int", PROTO)
+
+    def test_type_error_none(self):
+        with self.assertRaises(TypeError):
+            self.ser.serialize(None, PROTO)
+
+    def test_index_protocol(self):
+        """Objects implementing __index__ should be accepted, like struct.pack."""
+
+        class MyInt:
+            def __index__(self):
+                return 42
+
+        cython_bytes = self.ser.serialize(MyInt(), PROTO)
+        python_bytes = Int32Type.serialize(42, PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+
+# ---------------------------------------------------------------------------
+# VectorType serializer equivalence tests
+# ---------------------------------------------------------------------------
+
+
+@cythontest
+class TestSerVectorTypeFloat(unittest.TestCase):
+    """Verify SerVectorType float fast-path matches VectorType.serialize()."""
+
+    def setUp(self):
+        self.vec_type = _make_vector_type(FloatType, 4)
+        self.ser = SerVectorType(self.vec_type)
+
+    def _assert_equiv(self, values):
+        cython_bytes = self.ser.serialize(values, PROTO)
+        python_bytes = self.vec_type.serialize(values, PROTO)
+        self.assertEqual(
+            cython_bytes, python_bytes, "Mismatch for values %r" % (values,)
+        )
+
+    def test_basic(self):
+        self._assert_equiv([1.0, 2.0, 3.0, 4.0])
+
+    def test_zeros(self):
+        self._assert_equiv([0.0, 0.0, 0.0, 0.0])
+
+    def test_negative(self):
+        self._assert_equiv([-1.0, -2.5, -0.001, -100.0])
+
+    def test_mixed_special(self):
+        self._assert_equiv([float("inf"), float("-inf"), 0.0, -0.0])
+
+    def test_nan_element(self):
+        """NaN in vector should serialize identically."""
+        cython_bytes = self.ser.serialize([1.0, float("nan"), 3.0, 4.0], PROTO)
+        python_bytes = self.vec_type.serialize([1.0, float("nan"), 3.0, 4.0], PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+    def test_element_overflow(self):
+        with self.assertRaises((OverflowError, struct.error)):
+            self.ser.serialize([1.0, 1e40, 3.0, 4.0], PROTO)
+
+    def test_wrong_length_short(self):
+        with self.assertRaises(ValueError):
+            self.ser.serialize([1.0, 2.0], PROTO)
+
+    def test_wrong_length_long(self):
+        with self.assertRaises(ValueError):
+            self.ser.serialize([1.0, 2.0, 3.0, 4.0, 5.0], PROTO)
+
+    def test_empty_list_for_nonempty_vector(self):
+        with self.assertRaises(ValueError):
+            self.ser.serialize([], PROTO)
+
+
+@cythontest
+class TestSerVectorTypeDouble(unittest.TestCase):
+    """Verify SerVectorType double fast-path matches VectorType.serialize()."""
+
+    def setUp(self):
+        self.vec_type = _make_vector_type(DoubleType, 3)
+        self.ser = SerVectorType(self.vec_type)
+
+    def _assert_equiv(self, values):
+        cython_bytes = self.ser.serialize(values, PROTO)
+        python_bytes = self.vec_type.serialize(values, PROTO)
+        self.assertEqual(
+            cython_bytes, python_bytes, "Mismatch for values %r" % (values,)
+        )
+
+    def test_basic(self):
+        self._assert_equiv([1.0, 2.0, 3.0])
+
+    def test_large_values(self):
+        self._assert_equiv([1e100, -1e100, 1e-100])
+
+    def test_special(self):
+        self._assert_equiv([float("inf"), float("-inf"), 0.0])
+
+
+@cythontest
+class TestSerVectorTypeInt32(unittest.TestCase):
+    """Verify SerVectorType int32 fast-path matches VectorType.serialize()."""
+
+    def setUp(self):
+        self.vec_type = _make_vector_type(Int32Type, 3)
+        self.ser = SerVectorType(self.vec_type)
+
+    def _assert_equiv(self, values):
+        cython_bytes = self.ser.serialize(values, PROTO)
+        python_bytes = self.vec_type.serialize(values, PROTO)
+        self.assertEqual(
+            cython_bytes, python_bytes, "Mismatch for values %r" % (values,)
+        )
+
+    def test_basic(self):
+        self._assert_equiv([1, 2, 3])
+
+    def test_boundaries(self):
+        self._assert_equiv([2147483647, -2147483648, 0])
+
+    def test_element_overflow(self):
+        with self.assertRaises((OverflowError, struct.error)):
+            self.ser.serialize([1, 2147483648, 3], PROTO)
+
+    def test_element_overflow_negative(self):
+        with self.assertRaises((OverflowError, struct.error)):
+            self.ser.serialize([1, -2147483649, 3], PROTO)
+
+    def test_vector_index_protocol(self):
+        """Objects implementing __index__ in vector elements should be accepted."""
+
+        class MyInt:
+            def __index__(self):
+                return 42
+
+        cython_bytes = self.ser.serialize([MyInt(), MyInt(), MyInt()], PROTO)
+        python_bytes = self.vec_type.serialize([42, 42, 42], PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+
+@cythontest
+class TestSerVectorTypeGenericFallback(unittest.TestCase):
+    """Verify SerVectorType generic fallback matches VectorType.serialize()."""
+
+    def test_utf8_vector(self):
+        vec_type = _make_vector_type(UTF8Type, 3)
+        ser = SerVectorType(vec_type)
+        values = ["hello", "world", "test"]
+        cython_bytes = ser.serialize(values, PROTO)
+        python_bytes = vec_type.serialize(values, PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+    def test_boolean_vector(self):
+        vec_type = _make_vector_type(BooleanType, 4)
+        ser = SerVectorType(vec_type)
+        values = [True, False, True, False]
+        cython_bytes = ser.serialize(values, PROTO)
+        python_bytes = vec_type.serialize(values, PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+
+@cythontest
+class TestSerVectorTypeHighDimensional(unittest.TestCase):
+    """Test with realistic high-dimensional vectors (embedding use case)."""
+
+    def test_float_1536_dim(self):
+        """1536-dim float vector (typical for embedding models)."""
+        vec_type = _make_vector_type(FloatType, 1536)
+        ser = SerVectorType(vec_type)
+        values = [float(i) / 1536.0 for i in range(1536)]
+        cython_bytes = ser.serialize(values, PROTO)
+        python_bytes = vec_type.serialize(values, PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+        self.assertEqual(len(cython_bytes), 1536 * 4)
+
+    def test_double_768_dim(self):
+        vec_type = _make_vector_type(DoubleType, 768)
+        ser = SerVectorType(vec_type)
+        values = [float(i) / 768.0 for i in range(768)]
+        cython_bytes = ser.serialize(values, PROTO)
+        python_bytes = vec_type.serialize(values, PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+        self.assertEqual(len(cython_bytes), 768 * 8)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests (serialize with Cython, deserialize with Python)
+# ---------------------------------------------------------------------------
+
+
+@cythontest
+class TestSerializerRoundTrip(unittest.TestCase):
+    """Serialize with Cython, deserialize with Python cqltype.deserialize()."""
+
+    def test_float_round_trip(self):
+        ser = SerFloatType(FloatType)
+        for val in [0.0, 1.0, -1.0, 3.14, float("inf"), float("-inf")]:
+            serialized = ser.serialize(val, PROTO)
+            deserialized = FloatType.deserialize(serialized, PROTO)
+            if math.isinf(val):
+                self.assertEqual(val, deserialized)
+            else:
+                self.assertAlmostEqual(val, deserialized, places=5)
+
+    def test_double_round_trip(self):
+        ser = SerDoubleType(DoubleType)
+        for val in [0.0, 1.0, -1.0, 3.141592653589793, 1e100, float("inf")]:
+            serialized = ser.serialize(val, PROTO)
+            deserialized = DoubleType.deserialize(serialized, PROTO)
+            self.assertEqual(val, deserialized)
+
+    def test_int32_round_trip(self):
+        ser = SerInt32Type(Int32Type)
+        for val in [0, 1, -1, 2147483647, -2147483648, 42]:
+            serialized = ser.serialize(val, PROTO)
+            deserialized = Int32Type.deserialize(serialized, PROTO)
+            self.assertEqual(val, deserialized)
+
+    def test_float_vector_round_trip(self):
+        vec_type = _make_vector_type(FloatType, 4)
+        ser = SerVectorType(vec_type)
+        values = [1.5, -2.5, 3.14, 0.0]
+        serialized = ser.serialize(values, PROTO)
+        deserialized = vec_type.deserialize(serialized, PROTO)
+        for orig, deser in zip(values, deserialized):
+            self.assertAlmostEqual(orig, deser, places=5)
+
+    def test_int32_vector_round_trip(self):
+        vec_type = _make_vector_type(Int32Type, 3)
+        ser = SerVectorType(vec_type)
+        values = [2147483647, -2147483648, 0]
+        serialized = ser.serialize(values, PROTO)
+        deserialized = vec_type.deserialize(serialized, PROTO)
+        self.assertEqual(list(deserialized), values)
+
+
+@cythontest
+class TestSerVectorTypeIterableInput(unittest.TestCase):
+    """Verify vector serializer accepts non-subscriptable iterables.
+
+    The Python VectorType.serialize() only requires len() + iteration,
+    so the Cython path must accept the same inputs after normalization.
+    """
+
+    def test_iterable_with_len_no_getitem(self):
+        """A custom iterable with __len__ + __iter__ but no __getitem__."""
+
+        class IterableOnly:
+            def __init__(self, data):
+                self._data = list(data)
+
+            def __len__(self):
+                return len(self._data)
+
+            def __iter__(self):
+                return iter(self._data)
+
+        vec_type = _make_vector_type(FloatType, 3)
+        ser = SerVectorType(vec_type)
+        values = IterableOnly([1.0, 2.0, 3.0])
+        cython_bytes = ser.serialize(values, PROTO)
+        python_bytes = vec_type.serialize([1.0, 2.0, 3.0], PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+    def test_iterable_int32_vector(self):
+        """Non-subscriptable iterable with int32 fast-path."""
+
+        class IterableOnly:
+            def __init__(self, data):
+                self._data = list(data)
+
+            def __len__(self):
+                return len(self._data)
+
+            def __iter__(self):
+                return iter(self._data)
+
+        vec_type = _make_vector_type(Int32Type, 3)
+        ser = SerVectorType(vec_type)
+        values = IterableOnly([1, 2, 3])
+        cython_bytes = ser.serialize(values, PROTO)
+        python_bytes = vec_type.serialize([1, 2, 3], PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+    def test_tuple_input(self):
+        """Tuple input should work (already subscriptable, but verify)."""
+        vec_type = _make_vector_type(Int32Type, 3)
+        ser = SerVectorType(vec_type)
+        cython_bytes = ser.serialize((1, 2, 3), PROTO)
+        python_bytes = vec_type.serialize([1, 2, 3], PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Factory function tests
+# ---------------------------------------------------------------------------
+
+
+@cythontest
+class TestFindSerializer(unittest.TestCase):
+    """Test find_serializer() returns correct serializer types."""
+
+    def test_float_type(self):
+        ser = find_serializer(FloatType)
+        self.assertIsInstance(ser, SerFloatType)
+
+    def test_double_type(self):
+        ser = find_serializer(DoubleType)
+        self.assertIsInstance(ser, SerDoubleType)
+
+    def test_int32_type(self):
+        ser = find_serializer(Int32Type)
+        self.assertIsInstance(ser, SerInt32Type)
+
+    def test_vector_type(self):
+        vec_type = _make_vector_type(FloatType, 3)
+        ser = find_serializer(vec_type)
+        self.assertIsInstance(ser, SerVectorType)
+
+    def test_unknown_type_gets_generic(self):
+        ser = find_serializer(UTF8Type)
+        self.assertIsInstance(ser, GenericSerializer)
+
+    def test_generic_delegates_to_python(self):
+        ser = find_serializer(LongType)
+        self.assertIsInstance(ser, GenericSerializer)
+        result = ser.serialize(42, PROTO)
+        expected = LongType.serialize(42, PROTO)
+        self.assertEqual(result, expected)
+
+    def test_unparameterized_vector_type_gets_generic(self):
+        """Un-parameterized VectorType (base class) should not crash."""
+        ser = find_serializer(VectorType)
+        self.assertIsInstance(ser, GenericSerializer)
+
+
+@cythontest
+class TestMakeSerializers(unittest.TestCase):
+    """Test make_serializers() batch factory."""
+
+    def test_basic(self):
+        types = [FloatType, DoubleType, Int32Type, UTF8Type]
+        serializers = make_serializers(types)
+        self.assertEqual(len(serializers), 4)
+        self.assertIsInstance(serializers[0], SerFloatType)
+        self.assertIsInstance(serializers[1], SerDoubleType)
+        self.assertIsInstance(serializers[2], SerInt32Type)
+        self.assertIsInstance(serializers[3], GenericSerializer)
+
+    def test_empty(self):
+        serializers = make_serializers([])
+        self.assertEqual(len(serializers), 0)
+
+    def test_with_vector_type(self):
+        vec_type = _make_vector_type(FloatType, 3)
+        serializers = make_serializers([vec_type, Int32Type])
+        self.assertEqual(len(serializers), 2)
+        self.assertIsInstance(serializers[0], SerVectorType)
+        self.assertIsInstance(serializers[1], SerInt32Type)

--- a/tests/unit/cython/test_serializers.py
+++ b/tests/unit/cython/test_serializers.py
@@ -23,6 +23,8 @@ import math
 import struct
 import unittest
 
+import numpy as np
+
 from tests.unit.cython.utils import cythontest
 
 from cassandra.cython_deps import HAVE_CYTHON
@@ -532,6 +534,70 @@ class TestSerVectorTypeIterableInput(unittest.TestCase):
         ser = SerVectorType(vec_type)
         cython_bytes = ser.serialize((1, 2, 3), PROTO)
         python_bytes = vec_type.serialize([1, 2, 3], PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+    def test_indexable_sequence_input(self):
+        """Indexable non-list sequences should avoid tuple normalization."""
+
+        class IndexableSequence:
+            def __init__(self, data):
+                self._data = list(data)
+
+            def __len__(self):
+                return len(self._data)
+
+            def __getitem__(self, index):
+                return self._data[index]
+
+            def __iter__(self):
+                return iter(self._data)
+
+        vec_type = _make_vector_type(FloatType, 3)
+        ser = SerVectorType(vec_type)
+        values = IndexableSequence([1.0, 2.0, 3.0])
+        cython_bytes = ser.serialize(values, PROTO)
+        python_bytes = vec_type.serialize([1.0, 2.0, 3.0], PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+    def test_numpy_float32_array_input(self):
+        """NumPy float32 arrays should hit the float buffer fast path."""
+        vec_type = _make_vector_type(FloatType, 4)
+        ser = SerVectorType(vec_type)
+        values = np.asarray([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+        cython_bytes = ser.serialize(values, PROTO)
+        python_bytes = vec_type.serialize(values, PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+    def test_numpy_float64_array_input(self):
+        """NumPy float64 arrays should hit the double buffer fast path."""
+        vec_type = _make_vector_type(DoubleType, 3)
+        ser = SerVectorType(vec_type)
+        values = np.asarray([1.0, -2.5, 3.14], dtype=np.float64)
+        cython_bytes = ser.serialize(values, PROTO)
+        python_bytes = vec_type.serialize(values, PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+    def test_numpy_int32_array_input(self):
+        """NumPy int32 arrays should hit the int32 buffer fast path."""
+        vec_type = _make_vector_type(Int32Type, 3)
+        ser = SerVectorType(vec_type)
+        values = np.asarray([2147483647, -2147483648, 0], dtype=np.int32)
+        cython_bytes = ser.serialize(values, PROTO)
+        python_bytes = vec_type.serialize(values, PROTO)
+        self.assertEqual(cython_bytes, python_bytes)
+
+    def test_numpy_dtype_mismatch_fallthrough(self):
+        """dtype mismatch should fall through to element-wise path correctly.
+
+        A float64 array passed to a FloatType vector cannot bind to
+        float[::1], so the serializer must fall through to the
+        element-wise path and still produce correct bytes.
+        """
+        vec_type = _make_vector_type(FloatType, 3)
+        ser = SerVectorType(vec_type)
+        values = np.asarray([1.0, 2.0, 3.0], dtype=np.float64)
+        cython_bytes = ser.serialize(values, PROTO)
+        python_bytes = vec_type.serialize(values, PROTO)
         self.assertEqual(cython_bytes, python_bytes)
 
 

--- a/tests/unit/cython/test_serializers.py
+++ b/tests/unit/cython/test_serializers.py
@@ -23,9 +23,7 @@ import math
 import struct
 import unittest
 
-import numpy as np
-
-from tests.unit.cython.utils import cythontest
+from tests.unit.cython.utils import cythontest, numpytest
 
 from cassandra.cython_deps import HAVE_CYTHON
 
@@ -559,8 +557,10 @@ class TestSerVectorTypeIterableInput(unittest.TestCase):
         python_bytes = vec_type.serialize([1.0, 2.0, 3.0], PROTO)
         self.assertEqual(cython_bytes, python_bytes)
 
+    @numpytest
     def test_numpy_float32_array_input(self):
         """NumPy float32 arrays should hit the float buffer fast path."""
+        import numpy as np
         vec_type = _make_vector_type(FloatType, 4)
         ser = SerVectorType(vec_type)
         values = np.asarray([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
@@ -568,8 +568,10 @@ class TestSerVectorTypeIterableInput(unittest.TestCase):
         python_bytes = vec_type.serialize(values, PROTO)
         self.assertEqual(cython_bytes, python_bytes)
 
+    @numpytest
     def test_numpy_float64_array_input(self):
         """NumPy float64 arrays should hit the double buffer fast path."""
+        import numpy as np
         vec_type = _make_vector_type(DoubleType, 3)
         ser = SerVectorType(vec_type)
         values = np.asarray([1.0, -2.5, 3.14], dtype=np.float64)
@@ -577,8 +579,10 @@ class TestSerVectorTypeIterableInput(unittest.TestCase):
         python_bytes = vec_type.serialize(values, PROTO)
         self.assertEqual(cython_bytes, python_bytes)
 
+    @numpytest
     def test_numpy_int32_array_input(self):
         """NumPy int32 arrays should hit the int32 buffer fast path."""
+        import numpy as np
         vec_type = _make_vector_type(Int32Type, 3)
         ser = SerVectorType(vec_type)
         values = np.asarray([2147483647, -2147483648, 0], dtype=np.int32)
@@ -586,6 +590,7 @@ class TestSerVectorTypeIterableInput(unittest.TestCase):
         python_bytes = vec_type.serialize(values, PROTO)
         self.assertEqual(cython_bytes, python_bytes)
 
+    @numpytest
     def test_numpy_dtype_mismatch_fallthrough(self):
         """dtype mismatch should fall through to element-wise path correctly.
 
@@ -593,6 +598,7 @@ class TestSerVectorTypeIterableInput(unittest.TestCase):
         float[::1], so the serializer must fall through to the
         element-wise path and still produce correct bytes.
         """
+        import numpy as np
         vec_type = _make_vector_type(FloatType, 3)
         ser = SerVectorType(vec_type)
         values = np.asarray([1.0, 2.0, 3.0], dtype=np.float64)
@@ -642,6 +648,125 @@ class TestFindSerializer(unittest.TestCase):
         """Un-parameterized VectorType (base class) should not crash."""
         ser = find_serializer(VectorType)
         self.assertIsInstance(ser, GenericSerializer)
+
+
+@cythontest
+class TestFindSerializerRespectsSerializeOverride(unittest.TestCase):
+    """Regression tests: a subclass that overrides serialize() must never be
+    routed through a hard-coded built-in Cython fast path.
+
+    cassandra.cqltypes.CassandraTypeType auto-registers any class subclassing
+    a CassandraType (see tests/unit/test_types.py::test_parse_casstype_args
+    for the same pattern applied to the generic CassandraType base), so a
+    user-defined FloatType/DoubleType/Int32Type/VectorType subclass with a
+    custom serialize() is a real, reachable object here -- not just a
+    hypothetical. Dispatching on __name__ or plain issubclass() (as opposed
+    to checking which class in the MRO actually defines serialize()) would
+    silently discard such an override and emit the built-in's raw bytes.
+    """
+
+    def _assert_generic_and_respects_override(self, cqltype, value, expected):
+        ser = find_serializer(cqltype)
+        self.assertIsInstance(ser, GenericSerializer)
+        self.assertEqual(ser.serialize(value, PROTO), expected)
+
+    def test_float_subclass_override_not_fast_pathed(self):
+        class CustomFloatType(FloatType):
+            @staticmethod
+            def serialize(val, protocol_version):
+                return b'CUSTOM-FLOAT'
+
+        self._assert_generic_and_respects_override(
+            CustomFloatType, 1.0, b'CUSTOM-FLOAT')
+
+    def test_double_subclass_override_not_fast_pathed(self):
+        class CustomDoubleType(DoubleType):
+            @staticmethod
+            def serialize(val, protocol_version):
+                return b'CUSTOM-DOUBLE'
+
+        self._assert_generic_and_respects_override(
+            CustomDoubleType, 1.0, b'CUSTOM-DOUBLE')
+
+    def test_int32_subclass_override_not_fast_pathed(self):
+        class CustomInt32Type(Int32Type):
+            @staticmethod
+            def serialize(val, protocol_version):
+                return b'CUSTOM-INT32'
+
+        self._assert_generic_and_respects_override(
+            CustomInt32Type, 1, b'CUSTOM-INT32')
+
+    def test_vector_type_subclass_override_not_fast_pathed(self):
+        class CustomVectorType(VectorType):
+            @staticmethod
+            def serialize(v, protocol_version):
+                return b'CUSTOM-VECTOR'
+
+        vec_type = CustomVectorType.apply_parameters([FloatType, 4], None)
+        self._assert_generic_and_respects_override(
+            vec_type, [1.0, 2.0, 3.0, 4.0], b'CUSTOM-VECTOR')
+
+    def test_vector_with_overridden_float_subtype_respects_override(self):
+        """A vector whose *subtype* (element type) overrides serialize()
+        must not be packed via the hard-coded IEEE-754 float32 fast path,
+        even though the vector container itself is a plain VectorType.
+        """
+        class CustomFloatType(FloatType):
+            @staticmethod
+            def serialize(val, protocol_version):
+                return b'F'
+
+        vec_type = VectorType.apply_parameters([CustomFloatType, 3], None)
+        ser = find_serializer(vec_type)
+        result = ser.serialize([1.0, 2.0, 3.0], PROTO)
+        expected = vec_type.serialize([1.0, 2.0, 3.0], PROTO)
+        self.assertEqual(result, b'FFF')
+        self.assertEqual(result, expected)
+
+    def test_vector_with_overridden_double_subtype_respects_override(self):
+        class CustomDoubleType(DoubleType):
+            @staticmethod
+            def serialize(val, protocol_version):
+                return b'D'
+
+        vec_type = VectorType.apply_parameters([CustomDoubleType, 2], None)
+        ser = find_serializer(vec_type)
+        result = ser.serialize([1.0, 2.0], PROTO)
+        expected = vec_type.serialize([1.0, 2.0], PROTO)
+        self.assertEqual(result, b'DD')
+        self.assertEqual(result, expected)
+
+    def test_vector_with_overridden_int32_subtype_respects_override(self):
+        class CustomInt32Type(Int32Type):
+            @staticmethod
+            def serialize(val, protocol_version):
+                return b'I'
+
+        vec_type = VectorType.apply_parameters([CustomInt32Type, 2], None)
+        ser = find_serializer(vec_type)
+        result = ser.serialize([1, 2], PROTO)
+        expected = vec_type.serialize([1, 2], PROTO)
+        self.assertEqual(result, b'II')
+        self.assertEqual(result, expected)
+
+    def test_non_overriding_subclass_still_gets_fast_path(self):
+        """A subclass that does NOT override serialize() (e.g. the kind
+        apply_parameters() itself generates) should still take the fast
+        path -- the fix must not regress the legitimate optimization.
+        """
+        class PlainFloatSubtype(FloatType):
+            pass
+
+        ser = find_serializer(PlainFloatSubtype)
+        self.assertIsInstance(ser, SerFloatType)
+
+        vec_type = VectorType.apply_parameters([PlainFloatSubtype, 4], None)
+        vec_ser = find_serializer(vec_type)
+        self.assertIsInstance(vec_ser, SerVectorType)
+        result = vec_ser.serialize([1.0, 2.0, 3.0, 4.0], PROTO)
+        expected = vec_type.serialize([1.0, 2.0, 3.0, 4.0], PROTO)
+        self.assertEqual(result, expected)
 
 
 @cythontest

--- a/tests/unit/test_parameter_binding.py
+++ b/tests/unit/test_parameter_binding.py
@@ -1,4 +1,4 @@
-# Copyright DataStax, Inc.
+# Copyright ScyllaDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+import struct
 import pytest
 
 from cassandra.encoder import Encoder
@@ -216,3 +217,273 @@ class BoundStatementTestV4(BoundStatementTestV3):
 
 class BoundStatementTestV5(BoundStatementTestV4):
     protocol_version = 5
+
+
+class StubSerializer:
+    """Stub that mimics a Cython Serializer object for testing the fast path."""
+
+    def __init__(self, cqltype):
+        self.cqltype = cqltype
+
+    def serialize(self, value, protocol_version):
+        return self.cqltype.serialize(value, protocol_version)
+
+
+class OverflowSerializer:
+    """Stub that raises struct.error, mimicking Cython int32 range check."""
+
+    def __init__(self, cqltype):
+        self.cqltype = cqltype
+
+    def serialize(self, value, protocol_version):
+        raise struct.error("'i' format requires -2147483648 <= number <= 2147483647")
+
+
+class CythonBindPathTest(unittest.TestCase):
+    """Tests for the Cython serializer fast path in BoundStatement.bind().
+
+    These tests inject stub serializers via the PreparedStatement's cached
+    _cached_serializers attribute to exercise the Cython bind branch without
+    requiring compiled Cython.
+    """
+
+    protocol_version = 4
+
+    def _make_prepared(self, column_metadata, serializers=None):
+        """Create a PreparedStatement and inject serializers into its cache."""
+        prepared = PreparedStatement(column_metadata=column_metadata,
+                                     query_id=None,
+                                     routing_key_indexes=[],
+                                     query=None,
+                                     keyspace='keyspace',
+                                     protocol_version=self.protocol_version,
+                                     result_metadata=None,
+                                     result_metadata_id=None)
+        # Inject directly into the cache attribute used by the _serializers
+        # property, bypassing the lazy initialization.
+        prepared._cached_serializers = serializers
+        return prepared
+
+    def test_cython_path_normal_serialization(self):
+        """Cython fast path produces the same result as the plain Python path."""
+        column_metadata = [ColumnMetadata('keyspace', 'cf', 'c0', Int32Type),
+                           ColumnMetadata('keyspace', 'cf', 'c1', Int32Type)]
+        serializers = [StubSerializer(Int32Type), StubSerializer(Int32Type)]
+        prepared = self._make_prepared(column_metadata, serializers)
+
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((42, -1))
+        assert bound.values == [Int32Type.serialize(42, self.protocol_version),
+                                Int32Type.serialize(-1, self.protocol_version)]
+
+    def test_cython_path_none_value(self):
+        """None values pass through the Cython path without serialization."""
+        column_metadata = [ColumnMetadata('keyspace', 'cf', 'c0', Int32Type)]
+        serializers = [StubSerializer(Int32Type)]
+        prepared = self._make_prepared(column_metadata, serializers)
+
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((None,))
+        assert bound.values == [None]
+
+    def test_cython_path_unset_value(self):
+        """UNSET_VALUE is handled correctly in the Cython fast path (v4+)."""
+        column_metadata = [ColumnMetadata('keyspace', 'cf', 'c0', Int32Type),
+                           ColumnMetadata('keyspace', 'cf', 'c1', Int32Type)]
+        serializers = [StubSerializer(Int32Type), StubSerializer(Int32Type)]
+        prepared = self._make_prepared(column_metadata, serializers)
+
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((42, UNSET_VALUE))
+        assert bound.values[0] == Int32Type.serialize(42, self.protocol_version)
+        assert bound.values[1] == UNSET_VALUE
+
+    def test_cython_path_overflow_error_wrapped(self):
+        """struct.error from Cython int32 range check is caught and wrapped with column context."""
+        column_metadata = [ColumnMetadata('keyspace', 'cf', 'v0', Int32Type)]
+        serializers = [OverflowSerializer(Int32Type)]
+        prepared = self._make_prepared(column_metadata, serializers)
+
+        bound = BoundStatement(prepared_statement=prepared)
+        with pytest.raises(TypeError) as exc:
+            bound.bind((2**31,))
+        msg = str(exc.value)
+        assert 'v0' in msg
+        assert 'Int32Type' in msg
+        assert 'int' in msg
+
+    def test_cython_path_type_error_wrapped(self):
+        """TypeError from serializer is caught and wrapped with column context."""
+        column_metadata = [ColumnMetadata('keyspace', 'cf', 'v0', Int32Type)]
+        serializers = [StubSerializer(Int32Type)]
+        prepared = self._make_prepared(column_metadata, serializers)
+
+        bound = BoundStatement(prepared_statement=prepared)
+        with pytest.raises(TypeError) as exc:
+            bound.bind(('not_an_int',))
+        msg = str(exc.value)
+        assert 'v0' in msg
+        assert 'Int32Type' in msg
+
+    def test_plain_path_overflow_error_wrapped(self):
+        """Out-of-range int in the plain Python path raises OverflowError (from
+        the Cython serializer) or struct.error (from the pure-Python fallback)
+        and is wrapped with column context."""
+        column_metadata = [ColumnMetadata('keyspace', 'cf', 'v0', Int32Type)]
+        # Force the plain Python path (no Cython serializers)
+        prepared = self._make_prepared(column_metadata, serializers=None)
+
+        bound = BoundStatement(prepared_statement=prepared)
+        with pytest.raises(TypeError) as exc:
+            bound.bind((2**31,))
+        msg = str(exc.value)
+        assert 'v0' in msg
+        assert 'Int32Type' in msg
+
+
+class UnsetValueBindingTest(unittest.TestCase):
+    """Tests for UNSET_VALUE handling in all bind paths.
+
+    These specifically test UNSET_VALUE in non-trailing positions to catch
+    index-management bugs in the pre-allocated values list.
+    """
+
+    protocol_version = 4
+
+    def _make_prepared(self, column_metadata, serializers=None, routing_key_indexes=None):
+        prepared = PreparedStatement(column_metadata=column_metadata,
+                                     query_id=None,
+                                     routing_key_indexes=routing_key_indexes or [],
+                                     query=None,
+                                     keyspace='keyspace',
+                                     protocol_version=self.protocol_version,
+                                     result_metadata=None,
+                                     result_metadata_id=None)
+        prepared._cached_serializers = serializers
+        return prepared
+
+    def _three_column_metadata(self):
+        return [ColumnMetadata('keyspace', 'cf', 'c0', Int32Type),
+                ColumnMetadata('keyspace', 'cf', 'c1', Int32Type),
+                ColumnMetadata('keyspace', 'cf', 'c2', Int32Type)]
+
+    # --- Plain Python path (no serializers) ---
+
+    def test_plain_unset_mid_list(self):
+        """UNSET_VALUE in the middle of a value list does not corrupt indices."""
+        col_meta = self._three_column_metadata()
+        prepared = self._make_prepared(col_meta, serializers=None)
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((0, UNSET_VALUE, 2))
+        assert bound.values == [
+            Int32Type.serialize(0, self.protocol_version),
+            UNSET_VALUE,
+            Int32Type.serialize(2, self.protocol_version),
+        ]
+
+    def test_plain_unset_first(self):
+        """UNSET_VALUE as the first value does not corrupt indices."""
+        col_meta = self._three_column_metadata()
+        prepared = self._make_prepared(col_meta, serializers=None)
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((UNSET_VALUE, 1, 2))
+        assert bound.values == [
+            UNSET_VALUE,
+            Int32Type.serialize(1, self.protocol_version),
+            Int32Type.serialize(2, self.protocol_version),
+        ]
+
+    def test_plain_all_unset(self):
+        """All values are UNSET_VALUE."""
+        col_meta = self._three_column_metadata()
+        prepared = self._make_prepared(col_meta, serializers=None)
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((UNSET_VALUE, UNSET_VALUE, UNSET_VALUE))
+        assert bound.values == [UNSET_VALUE, UNSET_VALUE, UNSET_VALUE]
+
+    def test_plain_unset_trailing(self):
+        """UNSET_VALUE as the last explicit value."""
+        col_meta = self._three_column_metadata()
+        prepared = self._make_prepared(col_meta, serializers=None)
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((0, 1, UNSET_VALUE))
+        assert bound.values == [
+            Int32Type.serialize(0, self.protocol_version),
+            Int32Type.serialize(1, self.protocol_version),
+            UNSET_VALUE,
+        ]
+
+    def test_plain_implicit_unset_fill(self):
+        """Fewer values than columns fills remaining with implicit UNSET_VALUE."""
+        col_meta = self._three_column_metadata()
+        prepared = self._make_prepared(col_meta, serializers=None)
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((0,))
+        assert bound.values == [
+            Int32Type.serialize(0, self.protocol_version),
+            UNSET_VALUE,
+            UNSET_VALUE,
+        ]
+
+    def test_plain_mixed_none_and_unset(self):
+        """Mix of None and UNSET_VALUE in the same bind."""
+        col_meta = self._three_column_metadata()
+        prepared = self._make_prepared(col_meta, serializers=None)
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((None, UNSET_VALUE, 2))
+        assert bound.values == [
+            None,
+            UNSET_VALUE,
+            Int32Type.serialize(2, self.protocol_version),
+        ]
+
+    # --- Cython serializer path (with stub serializers) ---
+
+    def test_cython_unset_mid_list(self):
+        """UNSET_VALUE in the middle with Cython serializers does not corrupt indices."""
+        col_meta = self._three_column_metadata()
+        serializers = [StubSerializer(Int32Type)] * 3
+        prepared = self._make_prepared(col_meta, serializers=serializers)
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((0, UNSET_VALUE, 2))
+        assert bound.values == [
+            Int32Type.serialize(0, self.protocol_version),
+            UNSET_VALUE,
+            Int32Type.serialize(2, self.protocol_version),
+        ]
+
+    def test_cython_unset_first(self):
+        """UNSET_VALUE as the first value with Cython serializers."""
+        col_meta = self._three_column_metadata()
+        serializers = [StubSerializer(Int32Type)] * 3
+        prepared = self._make_prepared(col_meta, serializers=serializers)
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((UNSET_VALUE, 1, 2))
+        assert bound.values == [
+            UNSET_VALUE,
+            Int32Type.serialize(1, self.protocol_version),
+            Int32Type.serialize(2, self.protocol_version),
+        ]
+
+    def test_cython_all_unset(self):
+        """All values are UNSET_VALUE with Cython serializers."""
+        col_meta = self._three_column_metadata()
+        serializers = [StubSerializer(Int32Type)] * 3
+        prepared = self._make_prepared(col_meta, serializers=serializers)
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((UNSET_VALUE, UNSET_VALUE, UNSET_VALUE))
+        assert bound.values == [UNSET_VALUE, UNSET_VALUE, UNSET_VALUE]
+
+    def test_cython_mixed_none_and_unset(self):
+        """Mix of None and UNSET_VALUE with Cython serializers."""
+        col_meta = self._three_column_metadata()
+        serializers = [StubSerializer(Int32Type)] * 3
+        prepared = self._make_prepared(col_meta, serializers=serializers)
+        bound = BoundStatement(prepared_statement=prepared)
+        bound.bind((None, UNSET_VALUE, 2))
+        assert bound.values == [
+            None,
+            UNSET_VALUE,
+            Int32Type.serialize(2, self.protocol_version),
+        ]
+

--- a/tests/unit/test_parameter_binding.py
+++ b/tests/unit/test_parameter_binding.py
@@ -15,15 +15,18 @@
 import unittest
 import struct
 import pytest
+from unittest import mock
 
 from cassandra.encoder import Encoder
 from cassandra.protocol import ColumnMetadata
+from cassandra import query
 from cassandra.query import (bind_params, ValueSequence, PreparedStatement,
                              BoundStatement, UNSET_VALUE)
-from cassandra.cqltypes import Int32Type
+from cassandra.cqltypes import FloatType, Int32Type, UTF8Type, VectorType
 from cassandra.util import OrderedDict
 
 from tests.util import assertListEqual
+from tests.unit.cython.utils import cythontest
 
 
 class ParamBindingTest(unittest.TestCase):
@@ -339,6 +342,87 @@ class CythonBindPathTest(unittest.TestCase):
         msg = str(exc.value)
         assert 'v0' in msg
         assert 'Int32Type' in msg
+
+
+@cythontest
+class SerializersGatingTest(unittest.TestCase):
+    """Tests for the _serializers property's gating logic.
+
+    The Cython fast path has measurable per-value dispatch overhead: for
+    scalar-only statements the generic serializer just calls
+    cqltype.serialize() anyway, so it is a net regression to use it there.
+    The big win is specifically for VectorType columns. So _serializers
+    should only build (and cache) Cython serializers when the statement
+    contains at least one VectorType column; scalar-only statements should
+    fall through to the plain Python bind path (i.e. _serializers is None).
+
+    These tests patch cassandra.query._HAVE_CYTHON_SERIALIZERS and
+    _cython_make_serializers directly so the gating logic itself is
+    exercised deterministically without depending on the real Cython
+    serializer implementation.
+
+    Requires the Cython extensions (cassandra.serializers, ...) to be
+    built, which is not the case e.g. on PyPy wheels (see setup.py:
+    try_cython is disabled for PyPy). ``_cython_make_serializers`` only
+    exists as a module-level attribute of cassandra.query when the import
+    of cassandra.serializers succeeds; without this guard, patching it
+    with mock.patch.object fails with AttributeError instead of skipping.
+    """
+
+    protocol_version = 4
+
+    def _make_prepared(self, column_metadata):
+        return PreparedStatement(column_metadata=column_metadata,
+                                 query_id=None,
+                                 routing_key_indexes=[],
+                                 query=None,
+                                 keyspace='keyspace',
+                                 protocol_version=self.protocol_version,
+                                 result_metadata=None,
+                                 result_metadata_id=None)
+
+    def test_scalar_only_statement_has_no_serializers(self):
+        """A statement with only scalar columns must not use the Cython fast
+        path, even when Cython serializers are available."""
+        column_metadata = [ColumnMetadata('keyspace', 'cf', 'c0', Int32Type),
+                           ColumnMetadata('keyspace', 'cf', 'c1', UTF8Type),
+                           ColumnMetadata('keyspace', 'cf', 'c2', FloatType)]
+        prepared = self._make_prepared(column_metadata)
+        with mock.patch.object(query, '_HAVE_CYTHON_SERIALIZERS', True), \
+             mock.patch.object(query, '_cython_make_serializers',
+                               lambda types: ['stub'] * len(types)):
+            assert prepared._serializers is None
+
+    def test_vector_column_statement_uses_serializers(self):
+        """A statement containing at least one VectorType column should use
+        the Cython fast path when Cython serializers are available, even if
+        it also has scalar columns."""
+        vec_type = VectorType.apply_parameters([FloatType, 4], None)
+        column_metadata = [ColumnMetadata('keyspace', 'cf', 'c0', Int32Type),
+                           ColumnMetadata('keyspace', 'cf', 'v0', vec_type)]
+        prepared = self._make_prepared(column_metadata)
+        with mock.patch.object(query, '_HAVE_CYTHON_SERIALIZERS', True), \
+             mock.patch.object(query, '_cython_make_serializers',
+                               lambda types: ['stub'] * len(types)):
+            assert prepared._serializers is not None
+            assert len(prepared._serializers) == len(column_metadata)
+
+    def test_vector_column_statement_without_cython_has_no_serializers(self):
+        """Even a vector-containing statement falls back to the plain Python
+        path when Cython serializers are not available."""
+        vec_type = VectorType.apply_parameters([FloatType, 4], None)
+        column_metadata = [ColumnMetadata('keyspace', 'cf', 'v0', vec_type)]
+        prepared = self._make_prepared(column_metadata)
+        with mock.patch.object(query, '_HAVE_CYTHON_SERIALIZERS', False):
+            assert prepared._serializers is None
+
+    def test_empty_statement_has_no_serializers(self):
+        """A statement with no columns should not attempt to build serializers."""
+        prepared = self._make_prepared([])
+        with mock.patch.object(query, '_HAVE_CYTHON_SERIALIZERS', True), \
+             mock.patch.object(query, '_cython_make_serializers',
+                               lambda types: ['stub'] * len(types)):
+            assert prepared._serializers is None
 
 
 class UnsetValueBindingTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- When Cython serializers (`cassandra.serializers` from PR #748) are available, there is no column encryption policy, **and the statement contains at least one `VectorType` column**, `BoundStatement.bind()` uses pre-built `Serializer` objects cached on the `PreparedStatement` instead of calling cqltype classmethods
- The bind loop is split into three code paths: (1) column encryption policy, (2) Cython serializers (new fast path, vector-gated), (3) plain Python fallback
- Pre-allocates `self.values` list to avoid repeated `.append()` growth

## Dependencies

- **PR #748**: Cython serializers module (`cassandra/serializers.pyx`) -- provides `make_serializers()` and the `Serializer` classes used by the new fast path

## Update: fixed a gating regression found in review

The original version of this PR gated the Cython fast path on `_HAVE_CYTHON_SERIALIZERS and self.column_metadata` -- i.e. it used Cython serializers for *every* non-empty prepared statement whenever the Cython extension was available (which is nearly always in production, since `pyproject.toml` marks Cython extensions "must" for Linux/macOS wheels). But `serializers.pyx`'s `find_serializer()` only has dedicated fast serializers for `FloatType`/`DoubleType`/`Int32Type`/`VectorType`; everything else goes through a `GenericSerializer` that just calls `cqltype.serialize()` anyway, but pays extra dispatch/caching overhead to get there. As the original benchmark below showed, that made ordinary scalar-only statements *slower*, not faster -- a real regression for the common case, contradicting the "falls back automatically" claim that was previously false.

**Fix**: `PreparedStatement._serializers` is now additionally gated on `any(issubclass(col.type, VectorType) for col in self.column_metadata)`. Scalar-only statements now correctly fall straight through to the plain Python bind path; statements with at least one vector column (even if mixed with scalar columns) still get the Cython fast path for the whole statement, since per-column dispatch inside `find_serializer()` already picks the right serializer per column.

Also fixed in this update:
- Reverted an unrelated `if not objs: return objs` early-return that had been added to the existing `obj_array()` in `cassandra/deserializers.pyx`. It didn't fix anything real (`ParseDesc.deserializers` is a typed `Deserializer[::1]` memoryview assigned unconditionally in `ParseDesc.__init__`, so an empty list still fails there, just one frame later) and this PR doesn't otherwise touch deserialization. The equivalent guard in the new `serializers.pyx`'s own `obj_array()` is left in place (harmless, and currently unreachable since the only caller already guards on non-empty `column_metadata`), with a corrected docstring.
- `tests/unit/cython/test_serializers.py` imported `numpy` unconditionally at module scope, which broke test collection on Cython-without-numpy builds. Now follows the existing repo convention (`tests/integration/standard/test_cython_protocol_handlers.py`): `numpytest` decorator on the 4 numpy-dependent tests, numpy imported lazily inside each.
- Added tests exercising the gating logic directly (scalar-only -> `_serializers is None`, vector-containing -> `_serializers is not None`, plus no-Cython-available and empty-statement cases).

## Benchmark

Measured with `min()` of `timeit.repeat(repeat=7, number=50_000)`, `BoundStatement.bind()` end-to-end.

Original numbers (unconditional Cython gating, before this update's fix):

| Workload | Python fallback (ns/call) | Cython path (ns/call) | Speedup |
|---|---|---|---|
| `Vector<float, 128>` (1 col) | 11460 | **2847** | **4.0x** |
| `Vector<float, 1536>` (1 col) | 112896 | **10397** | **10.9x** |
| 10 mixed scalars (5 float + 3 int32 + 2 text) | 2174 | 3748 | 0.6x (regression) |

After the gating fix (different machine, same methodology -- absolute numbers aren't directly comparable across machines, but the shape of the result is what matters):

| Workload | Path taken | ns/call |
|---|---|---|
| 10 mixed scalars -- old unconditional gating (forced Cython) | Cython | ~4400-4600 |
| 10 mixed scalars -- new gating (default) | **Python (`_serializers is None`)** | **~2300-2800** |
| `Vector<float, 128>` (1 col) -- new gating (default) | Cython | ~3100-3500 |
| `Vector<float, 128>` (1 col) -- forced Python | Python | ~18200 |
| `Vector<float, 1536>` (1 col) -- new gating (default) | Cython | ~14500 |
| `Vector<float, 1536>` (1 col) -- forced Python | Python | ~196800 |

So: the scalar-only regression is gone (statement now takes the Python path automatically, ~1.7-2x faster than the old forced-Cython behavior for that workload), and the vector speedup (roughly 5-13x here) is fully preserved.

Key observations:
- Vector columns get significant speedups because the Cython serializer replaces the per-element `io.BytesIO` loop with a pre-allocated C buffer and inline byte-swap
- Scalar-only workloads now correctly use the plain Python path -- `_serializers` returns `None` unless the statement contains at least one `VectorType` column, so mixed-scalar workloads fall back to the Python path automatically
- Speedup scales with vector dimension

## Tests
- `tests/unit/test_parameter_binding.py`: comprehensive bind path tests covering Cython path, Python fallback, error wrapping, UNSET_VALUE handling, and the `_serializers` gating logic itself
- `tests/unit/cython/test_serializers.py`: Cython serializer equivalence tests, including numpy-array-input tests now properly gated behind `@numpytest`
- Full unit test suite passes (785 passed, 88 skipped)

---
This remains a draft / experimental PR pending further review.
