### PR TITLE
(fix) test: Fix KeyError in test_idle_heartbeat with connection repla…

### DIFF
--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -783,15 +783,55 @@ class ClusterTests(unittest.TestCase):
 
         connections = [c for holders in cluster.get_connection_holders() for c in holders.get_connections()]
 
-        # make sure requests were sent on all connections
-        for c in connections:
+        # _wait_for_all_shard_connections() above prevents the common KeyError caused by
+        # shard connections still being opened during pool warm-up. It does not cover a
+        # narrower, still-possible race: HostConnection can swap an existing connection
+        # for a new object in the same shard slot independently of the connection count,
+        # e.g. via _open_connection_to_missing_shard() once orphaned_threshold_reached, or
+        # via return_connection()/_replace() when a connection is defunct/closed. The
+        # latter has a genuine asynchronous gap: return_connection() pops the old
+        # connection out of the pool's dict synchronously, but _replace() (which inserts
+        # the replacement) runs later on another thread via session.submit(). A snapshot
+        # taken during that gap sees fewer *current* connections than were recorded, and
+        # every one of them is still "known" (nothing new has been inserted yet) - so
+        # checking only "is every current connection known" can't distinguish "fewer
+        # connections than snapshotted" from "same connections, none replaced". Compare
+        # both directions of the snapshot/current intersection so partial removals (as
+        # well as outright replacements) stay visible, and log loudly if either side
+        # actually differs so a recurrence stays visible in CI instead of being silently
+        # absorbed.
+        current_ids = {id(c) for c in connections}
+        snapshot_ids = set(connection_request_ids)
+        # snapshotted connections no longer present at all (removed, replacement may
+        # not have landed yet)
+        missing_from_current = snapshot_ids - current_ids
+        # connections present now that weren't in the snapshot (replacement landed)
+        unknown_in_current = current_ids - snapshot_ids
+        known_connections = [c for c in connections if id(c) in connection_request_ids]
+        if missing_from_current or unknown_in_current:
+            log.warning(
+                "test_idle_heartbeat: connections changed between the snapshot and "
+                "validation (%d snapshotted connections missing, %d new connections "
+                "observed, out of %d snapshotted / %d current); validating only the "
+                "%d connections common to both",
+                len(missing_from_current), len(unknown_in_current),
+                len(snapshot_ids), len(current_ids), len(known_connections)
+            )
+        assert len(known_connections) > 0, (
+            "All connections were replaced during the test; "
+            "no heartbeats could be validated"
+        )
+
+        # make sure heartbeat requests were sent on all known connections
+        for c in known_connections:
             expected_ids = connection_request_ids[id(c)]
             expected_ids.rotate(-1)
             with c.lock:
                 assertListEqual(list(c.request_ids), list(expected_ids))
 
-        # assert idle status
-        assert all(c.is_idle for c in connections)
+        # assert idle status on known connections only (replaced connections
+        # may not have had their idle state set yet)
+        assert all(c.is_idle for c in known_connections)
 
         # send enough messages to ensure all connections are used
         # (with shard-aware routing, each query only hits one shard per host,

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -776,22 +776,64 @@ class ClusterTests(unittest.TestCase):
                 # make sure none are idle (should have startup messages
                 assert not c.is_idle
                 with c.lock:
-                    connection_request_ids[id(c)] = deque(c.request_ids)  # copy of request ids
+                    # keyed by the connection object itself (not id(c)) so the
+                    # reference stays alive and a freed id can't be reused
+                    connection_request_ids[c] = deque(c.request_ids)  # copy of request ids
 
         # let two heatbeat intervals pass (first one had startup messages in it)
         time.sleep(2 * interval + interval/2)
 
         connections = [c for holders in cluster.get_connection_holders() for c in holders.get_connections()]
 
-        # make sure requests were sent on all connections
-        for c in connections:
-            expected_ids = connection_request_ids[id(c)]
+        # _wait_for_all_shard_connections() above prevents the common KeyError caused by
+        # shard connections still being opened during pool warm-up. It does not cover a
+        # narrower, still-possible race: HostConnection can swap an existing connection
+        # for a new object in the same shard slot independently of the connection count,
+        # e.g. via _open_connection_to_missing_shard() once orphaned_threshold_reached, or
+        # via return_connection()/_replace() when a connection is defunct/closed. The
+        # latter has a genuine asynchronous gap: return_connection() pops the old
+        # connection out of the pool's dict synchronously, but _replace() (which inserts
+        # the replacement) runs later on another thread via session.submit(). A snapshot
+        # taken during that gap sees fewer *current* connections than were recorded, and
+        # every one of them is still "known" (nothing new has been inserted yet) - so
+        # checking only "is every current connection known" can't distinguish "fewer
+        # connections than snapshotted" from "same connections, none replaced". Compare
+        # both directions of the snapshot/current intersection so partial removals (as
+        # well as outright replacements) stay visible, and log loudly if either side
+        # actually differs so a recurrence stays visible in CI instead of being silently
+        # absorbed.
+        current_conns = set(connections)
+        snapshot_conns = set(connection_request_ids)
+        # snapshotted connections no longer present at all (removed, replacement may
+        # not have landed yet)
+        missing_from_current = snapshot_conns - current_conns
+        # connections present now that weren't in the snapshot (replacement landed)
+        unknown_in_current = current_conns - snapshot_conns
+        known_connections = [c for c in connections if c in connection_request_ids]
+        if missing_from_current or unknown_in_current:
+            log.warning(
+                "test_idle_heartbeat: connections changed between the snapshot and "
+                "validation (%d snapshotted connections missing, %d new connections "
+                "observed, out of %d snapshotted / %d current); validating only the "
+                "%d connections common to both",
+                len(missing_from_current), len(unknown_in_current),
+                len(snapshot_conns), len(current_conns), len(known_connections)
+            )
+        assert len(known_connections) > 0, (
+            "No snapshotted connections remained in the current pools; "
+            "no heartbeats could be validated"
+        )
+
+        # make sure heartbeat requests were sent on all known connections
+        for c in known_connections:
+            expected_ids = connection_request_ids[c]
             expected_ids.rotate(-1)
             with c.lock:
                 assertListEqual(list(c.request_ids), list(expected_ids))
 
-        # assert idle status
-        assert all(c.is_idle for c in connections)
+        # assert idle status on known connections only (replaced connections
+        # may not have had their idle state set yet)
+        assert all(c.is_idle for c in known_connections)
 
         # send enough messages to ensure all connections are used
         # (with shard-aware routing, each query only hits one shard per host,


### PR DESCRIPTION
Fixes a `KeyError` in `test_idle_heartbeat` (`tests/integration/standard/test_cluster.py`) caused by shard-aware connection replacement racing with the test's connection-identity snapshot.

**Background:** `master` already fixed the main source of this via `_wait_for_all_shard_connections()` (added in 454f72742 / f34863730), which waits for shard pools to reach their full connection *count* before the snapshot is taken. That closed the common pool-warm-up race, and deliberately reverted an earlier silent "skip unknown connections" band-aid so the test's assertions stayed meaningful.

That fix doesn't cover a narrower race: `HostConnection` can still swap an *existing* connection object for a new one in the same shard slot without changing the pool's connection count — via `_open_connection_to_missing_shard()` (once `orphaned_threshold_reached`) or via `return_connection()` -> `_replace()` (on a defunct/closed connection). Either can fire during the test's own sleep window, and is more likely under CPU/IO contention (e.g. other tests running concurrently, delaying heartbeat responses).

This PR guards against the resulting `KeyError` by filtering to connections still present in the snapshot, while keeping the test meaningful:
- In the common case (no replacement), the filtered list equals the full connection list, so behavior/assertions are unchanged from current `master`.
- If the filter actually drops anything, it now logs a warning so a recurrence stays visible in CI instead of being silently absorbed.
- If every connection was replaced, the test still hard-fails instead of trivially passing.

See PR discussion for more analysis and the connection to the long-standing `test_idle_heartbeat` flakiness discussed on #653.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.