### PR TITLE
perf: use pre-allocated constant for null sentinel in collection serialization (10's of ns if null elements are used)

### DIFF
--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -52,6 +52,7 @@ from cassandra.marshal import (int8_pack, int8_unpack, int16_pack, int16_unpack,
 from cassandra import util
 
 _little_endian_flag = 1  # we always serialize LE
+_INT32_NULL = int32_pack(-1)  # pre-allocated null sentinel for collection serialization
 import ipaddress
 
 apache_cassandra_type_prefix = 'org.apache.cassandra.db.marshal.'
@@ -841,7 +842,7 @@ class _SimpleParameterizedType(_ParameterizedType):
         inner_proto = max(3, protocol_version)
         for item in items:
             if item is None:
-                buf.write(int32_pack(-1))
+                buf.write(_INT32_NULL)
             else:
                 itembytes = subtype.to_binary(item, inner_proto)
                 buf.write(int32_pack(len(itembytes)))
@@ -912,13 +913,13 @@ class MapType(_ParameterizedType):
                 buf.write(int32_pack(len(keybytes)))
                 buf.write(keybytes)
             else:
-                buf.write(int32_pack(-1))
+                buf.write(_INT32_NULL)
             if val is not None:
                 valbytes = value_type.to_binary(val, inner_proto)
                 buf.write(int32_pack(len(valbytes)))
                 buf.write(valbytes)
             else:
-                buf.write(int32_pack(-1))
+                buf.write(_INT32_NULL)
         return buf.getvalue()
 
 
@@ -964,7 +965,7 @@ class TupleType(_ParameterizedType):
                 buf.write(int32_pack(len(packed_item)))
                 buf.write(packed_item)
             else:
-                buf.write(int32_pack(-1))
+                buf.write(_INT32_NULL)
         return buf.getvalue()
 
     @classmethod
@@ -1041,7 +1042,7 @@ class UserType(TupleType):
                 buf.write(int32_pack(len(packed_item)))
                 buf.write(packed_item)
             else:
-                buf.write(int32_pack(-1))
+                buf.write(_INT32_NULL)
         return buf.getvalue()
 
     @classmethod

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -26,7 +26,7 @@ from cassandra.cqltypes import (
     EmptyValue, LongType, SetType, UTF8Type,
     cql_typename, int8_pack, int64_pack, int64_unpack, lookup_casstype,
     lookup_casstype_simple, parse_casstype_args,
-    int32_pack, Int32Type, ListType, MapType, VectorType,
+    int32_pack, Int32Type, ListType, MapType, TupleType, UserType, VectorType,
     FloatType
 )
 from cassandra.encoder import cql_quote
@@ -1117,3 +1117,72 @@ class TestOrdering(unittest.TestCase):
         tokens_equal = [Token(1), Token(1)]
         check_sequence_consistency(tokens)
         check_sequence_consistency(tokens_equal, equal=True)
+
+
+class CollectionNullSentinelTests(unittest.TestCase):
+    """
+    Tests that collection types correctly round-trip None/null elements
+    using the pre-allocated _INT32_NULL sentinel.
+    """
+
+    def test_list_with_none_roundtrip(self):
+        proto = 4
+        parameterized = ListType.apply_parameters([Int32Type])
+        original = [1, None, 3]
+        serialized = parameterized.serialize(original, proto)
+        deserialized = parameterized.deserialize(serialized, proto)
+        self.assertEqual(deserialized, original)
+
+    def test_set_with_none_roundtrip(self):
+        proto = 4
+        parameterized = SetType.apply_parameters([Int32Type])
+        original = [1, None, 3]
+        serialized = parameterized.serialize(original, proto)
+        deserialized = parameterized.deserialize(serialized, proto)
+        self.assertEqual(set(deserialized), set(original))
+
+    def test_map_with_none_values_roundtrip(self):
+        proto = 4
+        parameterized = MapType.apply_parameters([Int32Type, Int32Type])
+        original = {1: None, 2: 10}
+        serialized = parameterized.serialize(original, proto)
+        deserialized = parameterized.deserialize(serialized, proto)
+        self.assertEqual(dict(deserialized.items()), original)
+
+    def test_map_with_none_key_roundtrip(self):
+        # Exercises the null-key sentinel write in MapType.serialize_safe,
+        # independent of the null-value sentinel covered above.
+        #
+        # OrderedMapSerializedKey (the type returned by MapType.deserialize)
+        # re-serializes each key on __getitem__ -- and therefore on .items()
+        # and .values(), which are built on top of it -- to look up its
+        # position. That re-serialization can't handle a None key (a
+        # pre-existing limitation unrelated to this change), so this test
+        # asserts against the raw ._items list instead, matching the
+        # pattern used by test_collection_null_support above.
+        proto = 4
+        parameterized = MapType.apply_parameters([Int32Type, Int32Type])
+        original = {None: 10, 2: None}
+        serialized = parameterized.serialize(original, proto)
+        deserialized = parameterized.deserialize(serialized, proto)
+        self.assertEqual(deserialized._items, list(original.items()))
+
+    def test_tuple_with_none_roundtrip(self):
+        proto = 4
+        parameterized = TupleType.apply_parameters([Int32Type, UTF8Type, Int32Type])
+        original = (1, None, 3)
+        serialized = parameterized.serialize(original, proto)
+        deserialized = parameterized.deserialize(serialized, proto)
+        self.assertEqual(deserialized, original)
+
+    def test_usertype_with_none_roundtrip(self):
+        proto = 4
+        udt_class = UserType.make_udt_class(
+            'test_ks', 'test_udt',
+            ('field_a', 'field_b', 'field_c'),
+            (Int32Type, UTF8Type, Int32Type)
+        )
+        original = (1, None, 3)
+        serialized = udt_class.serialize(original, proto)
+        deserialized = udt_class.deserialize(serialized, proto)
+        self.assertEqual(deserialized, original)


### PR DESCRIPTION
## Summary

- Replace per-call `int32_pack(-1)` with a module-level `_INT32_NULL` constant in 5 collection serialize methods
- Avoids a `struct.pack()` call on every null element during collection serialization

## Details

The CQL protocol represents `null` collection elements as a 4-byte `int32` with value `-1`. Previously, every null element triggered a fresh `struct.pack('>i', -1)` call. This PR pre-computes the result once at module load time and reuses the `bytes` object.

`_INT32_NULL` is a plain `bytes` object (the return value of `struct.Struct.pack`), which is immutable. It is only ever passed to `buf.write(...)`, which reads from it without mutating it, so sharing/reusing the single module-level instance across concurrent serialization calls is safe.

### Affected sites

| Type | Method | Null path |
|------|--------|-----------|
| `ListType` / `SetType` | `_SimpleParameterizedType.serialize_safe` | null elements |
| `MapType` | `MapType.serialize_safe` | null keys, null values (2 sites) |
| `TupleType` | `TupleType.serialize_safe` | null fields |
| `UserType` | `UserType.serialize_safe` | null fields |

### Benchmark results

All benchmarks: CPython 3.14, median of 3-5 runs, results in nanoseconds.

**Isolated operation** (`int32_pack(-1)` call vs `_INT32_NULL` constant lookup, 10M iterations, median of 5 runs):

| Operation | Time (ns) | Speedup |
|-----------|-----------|---------|
| `int32_pack(-1)` (before) | 35.9 | — |
| `_INT32_NULL` lookup (after) | 4.8 | **7.4x** |
| **Savings per null element** | **31.1** | |

**End-to-end `serialize()` — before vs after** (200K iterations, median of 3 runs):

Each collection contains ~50% None elements to exercise the null path.

| Type | Before (ns) | After (ns) | Change |
|------|-------------|------------|--------|
| `ListType` (10 elements, 5 nulls) | 1,560 | 1,523 | -2.4% |
| `SetType` (10 elements, 5 nulls) | 1,575 | 1,476 | -6.3% |
| `MapType` (5 entries, 3 null values) | 1,882 | 1,933 | +2.7% |
| `TupleType` (5 fields, 2 nulls) | 1,136 | 1,123 | -1.1% |
| `UserType` (5 fields, 2 nulls) | 1,220 | 1,223 | +0.3% |

End-to-end improvement is within measurement noise (~1-6%) because the null sentinel write is a small fraction of total serialization cost (which includes `to_binary()` calls, `int32_pack(len(...))` for non-null elements, `BytesIO` writes, etc.). The benefit scales with null density — workloads with many sparse/null columns will see a larger improvement.

### Analysis

The isolated benchmark shows a clear **7.4x speedup** for the null-write operation itself (31 ns saved per null element). In end-to-end serialization, the improvement is diluted by the much larger cost of serializing non-null elements. The optimization is:

- **Zero-risk**: pure constant substitution, identical bytes produced
- **Free at runtime**: the constant is allocated once at module load
- **Thread-safe**: the constant is an immutable `bytes` object, never mutated, only read
- **Scales with null density**: more null elements = more savings
- **Eliminates unnecessary function call overhead** on every null element

### Testing

- Added `CollectionNullSentinelTests` with 6 round-trip tests covering List, Set, Map (null value and, separately, null key), Tuple, and UserType with `None` elements
- Rebased on current `master`; full `tests/unit/` suite: 726 passed, 88 skipped, 0 failed
