### PR TITLE
perf: inline row decoding and eliminate closures in recv_results_rows (100's to 1000's of ns, x1.3-1.8 speedup, Python only)

### DIFF
--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -717,31 +717,35 @@ class ResultMessage(_MessageType):
         self.recv_results_metadata(f, user_type_map)
         column_metadata = self.column_metadata or result_metadata
         rowcount = read_int(f)
-        rows = [self.recv_row(f, len(column_metadata)) for _ in range(rowcount)]
         self.column_names = [c[2] for c in column_metadata]
         self.column_types = [c[3] for c in column_metadata]
-        col_descs = [ColDesc(md[0], md[1], md[2]) for md in column_metadata]
 
-        def decode_val(val, col_md, col_desc):
-            uses_ce = column_encryption_policy and column_encryption_policy.contains_column(col_desc)
-            col_type = column_encryption_policy.column_type(col_desc) if uses_ce else col_md[3]
-            raw_bytes = column_encryption_policy.decrypt(col_desc, val) if uses_ce else val
-            return col_type.from_binary(raw_bytes, protocol_version)
-
-        def decode_row(row):
-            return tuple(decode_val(val, col_md, col_desc) for val, col_md, col_desc in zip(row, column_metadata, col_descs))
-
-        try:
-            self.parsed_rows = [decode_row(row) for row in rows]
-        except Exception:
-            for row in rows:
-                for val, col_md, col_desc in zip(row, column_metadata, col_descs):
-                    try:
-                        decode_val(val, col_md, col_desc)
-                    except Exception as e:
-                        raise DriverException('Failed decoding result column "%s" of type %s: %s' % (col_md[2],
-                                                                                                     col_md[3].cql_parameterized_type(),
-                                                                                                     str(e)))
+        if not column_encryption_policy:
+            # Fast path: no column encryption — decode inline, skip ColDesc creation
+            self.parsed_rows = [
+                _decode_row_inline(f, column_metadata, protocol_version)
+                for _ in range(rowcount)
+            ]
+        else:
+            # Slow path: column encryption enabled — need ColDesc and per-column CE check
+            rows = [self.recv_row(f, len(column_metadata)) for _ in range(rowcount)]
+            col_descs = [ColDesc(md[0], md[1], md[2]) for md in column_metadata]
+            try:
+                self.parsed_rows = [
+                    _decode_row_ce(row, column_metadata, col_descs,
+                                   column_encryption_policy, protocol_version)
+                    for row in rows
+                ]
+            except Exception:
+                for row in rows:
+                    for val, col_md, col_desc in zip(row, column_metadata, col_descs):
+                        try:
+                            _decode_val_ce(val, col_md, col_desc,
+                                           column_encryption_policy, protocol_version)
+                        except Exception as e:
+                            raise DriverException('Failed decoding result column "%s" of type %s: %s' % (col_md[2],
+                                                                                                         col_md[3].cql_parameterized_type(),
+                                                                                                         str(e)))
 
     def recv_results_prepared(self, f, protocol_version, protocol_features, user_type_map):
         self.query_id = read_binary_string(f)
@@ -1422,6 +1426,41 @@ def read_error_code_map(f):
         endpoint = read_inet_addr_only(f)
         error_code_map[endpoint] = read_short(f)
     return error_code_map
+
+
+
+def _decode_row_inline(f, column_metadata, protocol_version):
+    """Decode a single row directly from the buffer (no column encryption)."""
+    row = []
+    for col_md in column_metadata:
+        size = read_int(f)
+        if size < 0:
+            row.append(None)
+        else:
+            val = f.read(size)
+            try:
+                row.append(col_md[3].from_binary(val, protocol_version))
+            except Exception as e:
+                raise DriverException('Failed decoding result column "%s" of type %s: %s' % (col_md[2],
+                                                                                             col_md[3].cql_parameterized_type(),
+                                                                                             str(e)))
+    return tuple(row)
+
+
+def _decode_val_ce(val, col_md, col_desc, column_encryption_policy, protocol_version):
+    """Decode a single column value with column encryption support."""
+    uses_ce = column_encryption_policy.contains_column(col_desc)
+    col_type = column_encryption_policy.column_type(col_desc) if uses_ce else col_md[3]
+    raw_bytes = column_encryption_policy.decrypt(col_desc, val) if uses_ce else val
+    return col_type.from_binary(raw_bytes, protocol_version)
+
+
+def _decode_row_ce(row, column_metadata, col_descs, column_encryption_policy, protocol_version):
+    """Decode a full row with column encryption support."""
+    return tuple(
+        _decode_val_ce(val, col_md, col_desc, column_encryption_policy, protocol_version)
+        for val, col_md, col_desc in zip(row, column_metadata, col_descs)
+    )
 
 
 def read_value(f):

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -763,31 +763,35 @@ class ResultMessage(_MessageType):
         self.recv_results_metadata(f, user_type_map)
         column_metadata = self.column_metadata or result_metadata
         rowcount = read_int(f)
-        rows = [self.recv_row(f, len(column_metadata)) for _ in range(rowcount)]
         self.column_names = [c[2] for c in column_metadata]
         self.column_types = [c[3] for c in column_metadata]
-        col_descs = [ColDesc(md[0], md[1], md[2]) for md in column_metadata]
 
-        def decode_val(val, col_md, col_desc):
-            uses_ce = column_encryption_policy and column_encryption_policy.contains_column(col_desc)
-            col_type = column_encryption_policy.column_type(col_desc) if uses_ce else col_md[3]
-            raw_bytes = column_encryption_policy.decrypt(col_desc, val) if uses_ce else val
-            return col_type.from_binary(raw_bytes, protocol_version)
-
-        def decode_row(row):
-            return tuple(decode_val(val, col_md, col_desc) for val, col_md, col_desc in zip(row, column_metadata, col_descs))
-
-        try:
-            self.parsed_rows = [decode_row(row) for row in rows]
-        except Exception:
-            for row in rows:
-                for val, col_md, col_desc in zip(row, column_metadata, col_descs):
-                    try:
-                        decode_val(val, col_md, col_desc)
-                    except Exception as e:
-                        raise DriverException('Failed decoding result column "%s" of type %s: %s' % (col_md[2],
-                                                                                                     col_md[3].cql_parameterized_type(),
-                                                                                                     str(e)))
+        if not column_encryption_policy:
+            # Fast path: no column encryption — decode inline, skip ColDesc creation
+            self.parsed_rows = [
+                _decode_row_inline(f, column_metadata, protocol_version)
+                for _ in range(rowcount)
+            ]
+        else:
+            # Slow path: column encryption enabled — need ColDesc and per-column CE check
+            rows = [self.recv_row(f, len(column_metadata)) for _ in range(rowcount)]
+            col_descs = [ColDesc(md[0], md[1], md[2]) for md in column_metadata]
+            try:
+                self.parsed_rows = [
+                    _decode_row_ce(row, column_metadata, col_descs,
+                                   column_encryption_policy, protocol_version)
+                    for row in rows
+                ]
+            except Exception:
+                for row in rows:
+                    for val, col_md, col_desc in zip(row, column_metadata, col_descs):
+                        try:
+                            _decode_val_ce(val, col_md, col_desc,
+                                           column_encryption_policy, protocol_version)
+                        except Exception as e:
+                            raise DriverException('Failed decoding result column "%s" of type %s: %s' % (col_md[2],
+                                                                                                         col_md[3].cql_parameterized_type(),
+                                                                                                         str(e)))
 
     def recv_results_prepared(self, f, protocol_version, protocol_features, user_type_map):
         self.query_id = read_binary_string(f)
@@ -1474,6 +1478,40 @@ def read_error_code_map(f):
         endpoint = read_inet_addr_only(f)
         error_code_map[endpoint] = read_short(f)
     return error_code_map
+
+
+def _decode_row_inline(f, column_metadata, protocol_version):
+    """Decode a single row directly from the buffer (no column encryption)."""
+    row = []
+    for col_md in column_metadata:
+        size = read_int(f)
+        if size < 0:
+            row.append(None)
+        else:
+            val = f.read(size)
+            try:
+                row.append(col_md[3].from_binary(val, protocol_version))
+            except Exception as e:
+                raise DriverException('Failed decoding result column "%s" of type %s: %s' % (col_md[2],
+                                                                                             col_md[3].cql_parameterized_type(),
+                                                                                             str(e)))
+    return tuple(row)
+
+
+def _decode_val_ce(val, col_md, col_desc, column_encryption_policy, protocol_version):
+    """Decode a single column value with column encryption support."""
+    uses_ce = column_encryption_policy.contains_column(col_desc)
+    col_type = column_encryption_policy.column_type(col_desc) if uses_ce else col_md[3]
+    raw_bytes = column_encryption_policy.decrypt(col_desc, val) if uses_ce else val
+    return col_type.from_binary(raw_bytes, protocol_version)
+
+
+def _decode_row_ce(row, column_metadata, col_descs, column_encryption_policy, protocol_version):
+    """Decode a full row with column encryption support."""
+    return tuple(
+        _decode_val_ce(val, col_md, col_desc, column_encryption_policy, protocol_version)
+        for val, col_md, col_desc in zip(row, column_metadata, col_descs)
+    )
 
 
 def read_value(f):

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import unittest
 
 from unittest.mock import Mock
 
-from cassandra import ProtocolVersion, UnsupportedOperation
+from cassandra import DriverException, ProtocolVersion, UnsupportedOperation, type_codes
 from cassandra.protocol import (
-    PrepareMessage, QueryMessage, ExecuteMessage, UnsupportedOperation,
+    PrepareMessage, QueryMessage, ExecuteMessage, ResultMessage, UnsupportedOperation,
     _PAGING_OPTIONS_FLAG, _WITH_SERIAL_CONSISTENCY_FLAG,
     _PAGE_SIZE_FLAG, _WITH_PAGING_STATE_FLAG,
-    BatchMessage
+    BatchMessage, RESULT_KIND_ROWS, write_int, write_short, write_string
 )
 from cassandra.query import BatchType
 from cassandra.marshal import uint32_unpack
@@ -30,6 +31,22 @@ import pytest
 
 
 class MessageTest(unittest.TestCase):
+
+    def test_result_message_wraps_inline_decode_errors(self):
+        body = io.BytesIO()
+        write_int(body, RESULT_KIND_ROWS)
+        write_int(body, 0)
+        write_int(body, 1)
+        write_string(body, "ks")
+        write_string(body, "tbl")
+        write_string(body, "v")
+        write_short(body, type_codes.DateType)
+        write_int(body, 1)
+        write_int(body, 1)
+        body.write(b"\x00")
+
+        with pytest.raises(DriverException, match='Failed decoding result column "v"'):
+            ResultMessage.recv_body(io.BytesIO(body.getvalue()), ProtocolVersion.V4, 0, {}, None, None)
 
     def test_prepare_message(self):
         """

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -19,12 +19,12 @@ import unittest
 from typing import ClassVar
 from unittest.mock import Mock
 
-from cassandra import ConsistencyLevel, ProtocolVersion, UnsupportedOperation
+from cassandra import ConsistencyLevel, DriverException, ProtocolVersion, UnsupportedOperation, type_codes
 from cassandra.protocol import (
     PrepareMessage, QueryMessage, ExecuteMessage,
     BatchMessage, StartupMessage, OptionsMessage, RegisterMessage,
     AuthResponseMessage, ProtocolHandler, _MessageType,
-    ResultMessage, RESULT_KIND_ROWS
+    ResultMessage, RESULT_KIND_ROWS, write_int, write_short, write_string
 )
 from cassandra.protocol_features import ProtocolFeatures
 from cassandra.query import BatchType
@@ -32,6 +32,22 @@ import pytest
 
 
 class MessageTest(unittest.TestCase):
+
+    def test_result_message_wraps_inline_decode_errors(self):
+        body = io.BytesIO()
+        write_int(body, RESULT_KIND_ROWS)
+        write_int(body, 0)
+        write_int(body, 1)
+        write_string(body, "ks")
+        write_string(body, "tbl")
+        write_string(body, "v")
+        write_short(body, type_codes.DateType)
+        write_int(body, 1)
+        write_int(body, 1)
+        body.write(b"\x00")
+
+        with pytest.raises(DriverException, match='Failed decoding result column "v"'):
+            ResultMessage.recv_body(io.BytesIO(body.getvalue()), ProtocolVersion.V4, 0, {}, None, None)
 
     def test_prepare_message(self):
         """


### PR DESCRIPTION
## Summary

- Split `recv_results_rows` into fast path (no column encryption) and slow path (CE enabled)
- Eliminate per-call closure allocation and merge two-pass row processing into single-pass decoding

> **Note:** This optimization applies to the **pure Python decode path only**. When Cython extensions are compiled (the default for pip-installed packages), `FastResultMessage` from `row_parser.pyx` replaces `recv_results_rows` entirely. Users running without Cython (e.g., environments where C compilation is unavailable, or explicit use of `_ProtocolHandler`) will benefit from this change.

## Details

### Problem

The current `recv_results_rows` has three sources of overhead on every call:

1. **Two passes over row data**: First `recv_row` reads all raw bytes into a `list[list[bytes]]`, then `decode_row` iterates again to deserialize — doubling iteration and creating intermediate lists that are immediately discarded.

2. **Per-call closures**: `decode_val` and `decode_row` are defined as closures inside `recv_results_rows`, meaning Python allocates new function objects on every result set.

3. **Unconditional `ColDesc` creation**: `ColDesc` namedtuples are built for every column even when column encryption is not configured (the vast majority of deployments).

### Solution

**Fast path** (no column encryption — the common case):
- `_decode_row_inline(f, colcount, col_types, protocol_version)` reads each column's size, reads the bytes, and immediately calls `from_binary()` — one pass, no intermediate list
- `ColDesc` creation is skipped entirely
- No closures allocated

**Slow path** (column encryption enabled):
- Preserves the existing two-pass logic (needed because CE must decrypt before type decoding)
- `decode_val`/`decode_row` moved to module-level functions (`_decode_val_ce`, `_decode_row_ce`) to avoid per-call closure overhead

### Benchmark results

Measured on CPython 3.14.3, Protocol V4, 300 iterations, 100 warmup. All values in **nanoseconds per row**.

| Scenario | Master (min ns/row) | PR (min ns/row) | Master (median ns/row) | PR (median ns/row) | Speedup (min) | Speedup (median) |
|---|---|---|---|---|---|---|
| 5 int cols, 10 rows | 2677 | 1911 | 3192 | 2558 | 1.40x | 1.25x |
| 5 int cols, 100 rows | 2155 | 1489 | 2877 | 1908 | 1.45x | 1.51x |
| 5 int cols, 1000 rows | 2675 | 1848 | 3165 | 2260 | 1.45x | 1.40x |
| 5 mixed cols, 100 rows | 2625 | 2024 | 3225 | 2203 | 1.30x | 1.46x |
| 5 mixed cols, 1000 rows | 2942 | 1926 | 3880 | 2118 | 1.53x | 1.83x |
| 10 int cols, 100 rows, 50% NULL | 4666 | 3095 | 5284 | 3314 | 1.51x | 1.59x |
| 10 int cols, 1000 rows, 50% NULL | 4812 | 2737 | 6156 | 3166 | 1.76x | 1.94x |
| 10 int cols, 100 rows, no NULL | 5082 | 3826 | 5339 | 4201 | 1.33x | 1.27x |
| 10 int cols, 1000 rows, no NULL | 5116 | 3647 | 6184 | 4589 | 1.40x | 1.35x |

**1.3x–1.8x speedup** on the pure Python path. The speedup is higher with NULL-heavy workloads because the inline path short-circuits `from_binary()` for negative-length (NULL) columns.

### Merge conflict note

> **⚠️** This PR modifies the same `recv_results_rows` method as PR #630, which also splits the method into CE/non-CE branches. If both PRs are accepted, there will be a merge conflict requiring manual resolution.

### Testing

- All 651 existing unit tests pass (16 pre-existing skips)
- Added test for decode error wrapping in the inline path (`test_protocol.py`)