### PR TITLE
fix: test_successful_wait_for_connection test: make HashableMock thread-safe to fix flaky Windows CI

### DIFF
--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -32,6 +32,34 @@ def _check_order_consistency(smaller, bigger, equal=False):
 
 
 class HashableMock(NonCallableMagicMock):
+    """A Mock subclass that is safely hashable and usable in sets/dicts.
 
-    def __hash__(self):
+    NonCallableMagicMock's __init__ (via MagicMixin) replaces __hash__
+    on the *type* with a MagicMock object.  That MagicMock is not
+    thread-safe, so concurrent hash() calls on the same instance —
+    e.g. ``connection in self._trash`` in pool.py — can raise
+    ``TypeError: __hash__ method should return an integer`` on Windows.
+
+    We fix this by restoring a plain function as the class-level
+    __hash__ after super().__init__ runs, so hash() always resolves to
+    a real function (id-based) instead of a MagicMock callable.
+
+    Note: NonCallableMock.__new__ already gives every mock instance its
+    own private subclass (see cpython unittest/mock.py) specifically so
+    that per-instance magic-method patching doesn't leak across mocks.
+    ``type(self)`` here is therefore that private, instance-specific
+    subclass rather than the shared ``HashableMock`` class, so this
+    assignment can't race with another ``HashableMock`` instance's
+    __init__ call. Once __init__ returns, __hash__ is a plain function
+    for the remaining lifetime of the instance, so it is safe to call
+    from multiple threads with no further synchronization needed.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Restore a real __hash__ after MagicMixin overwrites it.
+        type(self).__hash__ = HashableMock._id_hash
+
+    @staticmethod
+    def _id_hash(self):
         return id(self)


### PR DESCRIPTION
## Summary

Fixes flaky `test_successful_wait_for_connection` failure on Windows CI:
```
TypeError: __hash__ method should return an integer
```
at `cassandra/pool.py:582` (`connection in self._trash`).

## Root cause

`HashableMock` subclasses `NonCallableMagicMock` and overrides `__hash__` to return `id(self)`. However, `MagicMixin.__init__` replaces `__hash__` **on the type** with a `MagicMock` object before any test runs — making the original override dead code that never executes.

The `MagicMock` standing in for `__hash__` happens to return a hash-compatible value in single-threaded use, but `MagicMock.__call__` is not thread-safe. In `test_successful_wait_for_connection`, two threads call `pool.return_connection()` on the same `HashableMock` concurrently, which triggers `hash()` via `connection in self._trash` (a `set` membership check). Under Windows thread scheduling, the concurrent `MagicMock.__call__` can return a non-integer, causing the `TypeError`.

## Fix

Restore a plain function as the class-level `__hash__` in `HashableMock.__init__`, after `MagicMixin` has finished its work. This ensures `hash()` always resolves to a real, thread-safe function returning `id(self)`.

## Verification

- All 10 pool tests pass
- `test_successful_wait_for_connection` passes 100/100 runs in a loop

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.