### PR TITLE
ci: update Scylla test version from 2025.2 to 2026.1

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,7 +38,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, 'disable-integration-tests')"
     runs-on: ubuntu-24.04
     env:
-      SCYLLA_VERSION: release:2025.2
+      SCYLLA_VERSION: release:2026.1
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Update `SCYLLA_VERSION` in integration test CI from `release:2025.2` to `release:2026.1`
- Tests gated by `@skip_scylla_version_lt(2026.1.0)` (e.g. client_routes tests) will now execute in CI
- No code changes — CI-only

## Context

The integration test suite was pinned to `release:2025.2`. Updating to `release:2026.1` ensures CI covers the latest ScyllaDB features and catches regressions earlier.

**Known issues on 2026.1:** Two tests in `test_client_routes.py` (`TestSslThroughNlb` and `TestFullNodeReplacementThroughNlb`) have pre-existing failures that will be addressed in separate PRs:
- `TestFullNodeReplacementThroughNlb`: bootstrap crash due to missing rackdc properties (fix ready on `fix/nlb-test-bootstrap-rackdc`)
- `TestSslThroughNlb`: SSL connection timeout after cluster reconfiguration (under investigation)