### PR TITLE
tests: fix load balancing policy tests for Scylla Raft topology

### DIFF
--- a/tests/integration/long/test_loadbalancingpolicies.py
+++ b/tests/integration/long/test_loadbalancingpolicies.py
@@ -521,8 +521,9 @@ class LoadBalancingPolicyTests(unittest.TestCase):
         self._query(session, keyspace)
 
         self.coordinator_stats.assert_query_count_equals(1, 0)
-        self.coordinator_stats.assert_query_count_equals(2, 12)
-        self.coordinator_stats.assert_query_count_equals(3, 0)
+        # Scylla may distribute queries across both replicas with shard-aware routing
+        queried = self.coordinator_stats.get_query_count(2) + self.coordinator_stats.get_query_count(3)
+        assert queried == 12, "Expected 12 queries to replicas, got %d" % queried
 
         self.coordinator_stats.reset_counts()
         stop(2)

--- a/tests/integration/long/test_loadbalancingpolicies.py
+++ b/tests/integration/long/test_loadbalancingpolicies.py
@@ -244,13 +244,12 @@ class LoadBalancingPolicyTests(unittest.TestCase):
         self.coordinator_stats.assert_query_count_equals(3, 3)
         self.coordinator_stats.assert_query_count_equals(4, 3)
 
+        bootstrap(5, 'dc3')  # Bootstrap before force_stop (Raft rejects ops with dead nodes)
+        self._wait_for_nodes_up([5], cluster)
         force_stop(1)
-        bootstrap(5, 'dc3')
 
         # reset control connection
         self._insert(session, keyspace, count=1000)
-
-        self._wait_for_nodes_up([5], cluster)
 
         self.coordinator_stats.reset_counts()
         self._query(session, keyspace)

--- a/tests/integration/long/test_loadbalancingpolicies.py
+++ b/tests/integration/long/test_loadbalancingpolicies.py
@@ -479,6 +479,7 @@ class LoadBalancingPolicyTests(unittest.TestCase):
         self.coordinator_stats.assert_query_count_equals(2, 0)
 
     def test_token_aware_composite_key(self):
+        remove_cluster()
         use_singledc()
         keyspace = 'test_token_aware_composite_key'
         table = 'composite'
@@ -538,6 +539,7 @@ class LoadBalancingPolicyTests(unittest.TestCase):
         self.coordinator_stats.assert_query_count_equals(3, 12)
 
     def test_token_aware_with_local_table(self):
+        remove_cluster()
         use_singledc()
         cluster, session = self._cluster_session_with_lbp(TokenAwarePolicy(RoundRobinPolicy()))
         self.addCleanup(cluster.shutdown)

--- a/tests/integration/long/test_loadbalancingpolicies.py
+++ b/tests/integration/long/test_loadbalancingpolicies.py
@@ -215,10 +215,10 @@ class LoadBalancingPolicyTests(unittest.TestCase):
         self.coordinator_stats.assert_query_count_equals(2, 6)
         self.coordinator_stats.assert_query_count_equals(3, 0)
 
-        decommission(1)
-        start(3)
-        self._wait_for_nodes_down([1], cluster)
+        start(3)  # Restart before decommission (Raft rejects ops with dead nodes)
         self._wait_for_nodes_up([3], cluster)
+        decommission(1)
+        self._wait_for_nodes_down([1], cluster)
 
         self.coordinator_stats.reset_counts()
         self._query(session, keyspace)

--- a/tests/integration/long/test_loadbalancingpolicies.py
+++ b/tests/integration/long/test_loadbalancingpolicies.py
@@ -372,23 +372,25 @@ class LoadBalancingPolicyTests(unittest.TestCase):
             responses.add(self.coordinator_stats.get_query_count(node))
         assert set([0, 0, 12]) == responses
 
+        # Decommission node 1 while 3 Raft voters remain (nodes 1, 2, 5).
+        # Doing this later (with only 2 voters) can cause Raft issues.
         self.coordinator_stats.reset_counts()
-        decommission(5)
-        self._wait_for_nodes_down([5])
+        decommission(1)
+        self._wait_for_nodes_down([1])
 
         self._query(session, keyspace)
 
+        self.coordinator_stats.assert_query_count_equals(1, 0)
         self.coordinator_stats.assert_query_count_equals(3, 0)
         self.coordinator_stats.assert_query_count_equals(4, 0)
-        self.coordinator_stats.assert_query_count_equals(5, 0)
         responses = set()
-        for node in [1, 2]:
+        for node in [2, 5]:
             responses.add(self.coordinator_stats.get_query_count(node))
         assert set([0, 12]) == responses
 
         self.coordinator_stats.reset_counts()
-        decommission(1)
-        self._wait_for_nodes_down([1])
+        decommission(5)
+        self._wait_for_nodes_down([5])
 
         self._query(session, keyspace)
 

--- a/tests/integration/long/test_loadbalancingpolicies.py
+++ b/tests/integration/long/test_loadbalancingpolicies.py
@@ -277,13 +277,12 @@ class LoadBalancingPolicyTests(unittest.TestCase):
         self.coordinator_stats.assert_query_count_equals(3, 3)
         self.coordinator_stats.assert_query_count_equals(4, 3)
 
+        bootstrap(5, 'dc1')  # Bootstrap before force_stop (Raft rejects ops with dead nodes)
+        self._wait_for_nodes_up([5], cluster)
         force_stop(1)
-        bootstrap(5, 'dc1')
 
         # reset control connection
         self._insert(session, keyspace, count=1000)
-
-        self._wait_for_nodes_up([5], cluster)
 
         self.coordinator_stats.reset_counts()
         self._query(session, keyspace)


### PR DESCRIPTION
## Summary

Six integration tests in `tests/integration/long/test_loadbalancingpolicies.py` fail against modern Scylla (>= 2026.1, and likely earlier Raft-enabled versions). This PR fixes all six, each in a separate commit.

## Problem

### Commits 1–3: Raft rejects topology changes with dead nodes

Scylla's Raft topology coordinator rejects `decommission` and `bootstrap` operations when there are dead (unreachable) nodes in the cluster. Three tests trigger this by calling `force_stop()` on a node and then immediately attempting a topology change while that node is still down:

- **`test_roundrobin`**: `force_stop(3)` → `decommission(1)` — decommission fails because node 3 is dead.
- **`test_roundrobin_two_dcs`**: `force_stop(1)` → `bootstrap(5, 'dc3')` — bootstrap fails because node 1 is dead.
- **`test_roundrobin_two_dcs_2`**: `force_stop(1)` → `bootstrap(5, 'dc1')` — bootstrap fails because node 1 is dead.

**Fix**: Reorder the operations so the topology change (decommission/bootstrap) happens *before* the node is killed, or the dead node is restarted *before* the topology change:

- **`test_roundrobin`**: Restart node 3 (`start(3)` + `wait_for_up`) before decommissioning node 1.
- **`test_roundrobin_two_dcs`**: Bootstrap node 5 (`bootstrap(5, 'dc3')` + `wait_for_up`) before force-stopping node 1.
- **`test_roundrobin_two_dcs_2`**: Bootstrap node 5 (`bootstrap(5, 'dc1')` + `wait_for_up`) before force-stopping node 1.

The test semantics are preserved — the same nodes end up alive/dead/decommissioned, and the same query distribution assertions hold.

### Commit 4: Shard-aware routing distributes across replicas

**`test_token_aware_with_rf_2`** hardcodes the expectation that all 12 `TokenAwarePolicy` queries with RF=2 go to a single node (node 2). With Scylla's shard-aware routing, queries may be distributed across *both* replicas (e.g., `{node2: 5, node3: 7}`), since the driver can route to the specific shard owning the token on either replica.

**Fix**: Instead of asserting `node2 == 12, node3 == 0`, assert that `node1 == 0` (not a replica) and `node2 + node3 == 12` (all queries go to replicas). The second assertion block (after stopping node 2) remains unchanged — with only one replica alive, all 12 queries correctly go to node 3.

### Commit 5: Raft decommission order in dc_aware_roundrobin_one_remote_host

**`test_dc_aware_roundrobin_one_remote_host`** decommissions nodes in sequence (3→4→5→1), leaving only node 2 alive. The final `decommission(1)` happens with only 2 Raft voters remaining, which can cause Raft coordination issues. The driver then tries the decommissioned node 1 instead of the alive node 2, resulting in `NoHostAvailable`.

**Fix**: Reorder decommissions so node 1 is decommissioned while 3 Raft voters remain (nodes 1, 2, 5), before decommissioning node 5. The test semantics are preserved — same final state (only node 2 alive), same assertions.

### Commit 6: Stale decommissioned node state pollutes subsequent tests

**`test_token_aware_composite_key`** and **`test_token_aware_with_local_table`** call `use_singledc()` without `remove_cluster()` first. When a previous test (e.g., `test_dc_aware_roundrobin_one_remote_host`) decommissions nodes and the cluster is reused, the decommissioned nodes refuse to restart with *"This node was decommissioned and will not rejoin the ring"*.

**Fix**: Add `remove_cluster()` before `use_singledc()` to force a fresh cluster, consistent with other tests in the file.

## Test results

Full suite: **16 passed, 1 skipped** (the skipped test is `test_token_aware_with_transient_replication`, gated on Cassandra 4.0+).

```
tests/...::test_black_list_with_host_filter_policy PASSED
tests/...::test_dc_aware_roundrobin_one_remote_host PASSED
tests/...::test_dc_aware_roundrobin_two_dcs PASSED
tests/...::test_dc_aware_roundrobin_two_dcs_2 PASSED
tests/...::test_roundrobin PASSED
tests/...::test_roundrobin_two_dcs PASSED
tests/...::test_roundrobin_two_dcs_2 PASSED
tests/...::test_token_aware PASSED
tests/...::test_token_aware_composite_key PASSED
tests/...::test_token_aware_is_used_by_default PASSED
tests/...::test_token_aware_prepared PASSED
tests/...::test_token_aware_with_local_table PASSED
tests/...::test_token_aware_with_rf_2 PASSED
tests/...::test_token_aware_with_shuffle_rf2 PASSED
tests/...::test_token_aware_with_shuffle_rf3 PASSED
tests/...::test_token_aware_with_transient_replication SKIPPED
tests/...::test_white_list PASSED
============ 16 passed, 1 skipped =============
```

Tested with: Scylla `unstable/master:latest` (2026.2.0-dev, build 2026-04-12), Python 3.14, `EVENT_LOOP_MANAGER=libev`, `PROTOCOL_VERSION=4`.