### PR TITLE
Fix SimpleStatement.is_lwt(): detect LWT from CQL query string

### DIFF
--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -23,6 +23,53 @@ from datetime import datetime, timedelta, timezone
 import re
 import struct
 import time
+
+# Regex to strip out the parts of a CQL string that must not be inspected for
+# LWT syntax: single-quoted string literals (CQL escapes an embedded quote as
+# ''), double-quoted identifiers (escaped as ""), and CQL comments (--, //,
+# and /* ... */). Without this, literal values or comments containing text
+# like "IF EXISTS" would produce false positives, and a leading comment would
+# hide the real first keyword and produce a false negative.
+_LWT_NOISE_RE = re.compile(
+    r"'(?:[^']|'')*'"      # single-quoted string literal
+    r'|"(?:[^"]|"")*"'     # double-quoted identifier
+    r"|--[^\n]*"           # -- line comment
+    r"|//[^\n]*"           # // line comment
+    r"|/\*.*?\*/",         # /* block comment */
+    re.DOTALL
+)
+
+
+def _lwt_strip_noise(match):
+    text = match.group(0)
+    if text[0] in ('"', "'"):
+        # Keep the surrounding quote characters (so an explicit
+        # IF "col" clause is still recognizable afterwards) but blank the
+        # interior so literal/identifier content can't be mistaken for
+        # CQL syntax.
+        return text[0] + (' ' * (len(text) - 2)) + text[0]
+    # Comments contribute nothing syntactically; collapse to a single space
+    # so tokens on either side of the comment don't get glued together.
+    return ' '
+
+
+# Regex to detect LWT (Lightweight Transaction) queries in CQL strings.
+# Matches: INSERT ... IF NOT EXISTS, UPDATE/DELETE ... IF EXISTS,
+# and conditional updates/deletes (e.g. UPDATE ... IF col = ...,
+# UPDATE ... IF "col" = ...).
+# Uses word boundaries and case-insensitive matching.
+# This is a best-effort heuristic for SimpleStatement; PreparedStatement
+# gets the authoritative is_lwt flag from the server.
+_LWT_PATTERN = re.compile(
+    r'\bIF\s+(?:NOT\s+)?EXISTS\b'   # IF [NOT] EXISTS
+    r'|\bIF\s+[a-zA-Z_"]',            # IF <column_name> or IF "<column_name>" (conditional)
+    re.IGNORECASE
+)
+
+# DML verbs that can be LWT queries. Only these statement types can contain
+# Paxos/LWT clauses. DDL statements (CREATE/ALTER/DROP) also use IF [NOT] EXISTS
+# but those are not LWT operations.
+_LWT_DML_VERBS = frozenset({'INSERT', 'UPDATE', 'DELETE', 'BEGIN'})
 import warnings
 
 from cassandra import ConsistencyLevel, OperationTimedOut
@@ -415,6 +462,37 @@ class SimpleStatement(Statement):
         return (u'<SimpleStatement query="%s", consistency=%s>' %
                 (self.query_string, consistency))
     __repr__ = __str__
+
+    def is_lwt(self):
+        """
+        Detect whether this query is a Lightweight Transaction (LWT) by
+        inspecting the query string for ``IF [NOT] EXISTS`` or ``IF <condition>``
+        clauses in DML statements (INSERT, UPDATE, DELETE, BEGIN BATCH).
+
+        DDL statements like ``CREATE TABLE IF NOT EXISTS`` are excluded.
+        String literals, quoted identifiers, and comments (``--``, ``//``,
+        ``/* ... */``) are ignored so that incidental ``IF``/``EXISTS`` text
+        in query data or comments doesn't cause a false match, and so a
+        leading comment doesn't hide the real statement keyword.
+
+        This is a best-effort heuristic. For authoritative LWT detection,
+        use :class:`.PreparedStatement` which gets the ``is_lwt`` flag from
+        the server during PREPARE.
+
+        The result is cached after the first call.
+        """
+        try:
+            return self._cached_is_lwt
+        except AttributeError:
+            # Strip string/identifier literals and comments before looking
+            # at the query, then check that only DML statements can be LWT.
+            query = _LWT_NOISE_RE.sub(_lwt_strip_noise, self._query_string).lstrip()
+            first_word = query.split(None, 1)[0].upper() if query else ''
+            if first_word not in _LWT_DML_VERBS:
+                self._cached_is_lwt = False
+            else:
+                self._cached_is_lwt = bool(_LWT_PATTERN.search(query))
+            return self._cached_is_lwt
 
 
 class PreparedStatement(object):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import patch
 
 import pytest
 
+from cassandra import query as query_module
 from cassandra.query import BatchStatement, PreparedStatement, SimpleStatement
 
 
@@ -105,17 +107,14 @@ class BatchStatementTest(unittest.TestCase):
         batch_with_bound.add(bound_lwt)
         assert batch_with_bound.is_lwt() is True
 
-        class LwtSimpleStatement(SimpleStatement):
-            def __init__(self):
-                super(LwtSimpleStatement, self).__init__(
-                    "INSERT INTO test.table (id) VALUES (2) IF NOT EXISTS"
-                )
-
-            def is_lwt(self):
-                return True
+        # SimpleStatement now detects LWT from query string (no subclass needed)
+        lwt_simple = SimpleStatement(
+            "INSERT INTO test.table (id) VALUES (2) IF NOT EXISTS"
+        )
+        self.assertIs(lwt_simple.is_lwt(), True)
 
         batch_with_simple = BatchStatement()
-        batch_with_simple.add(LwtSimpleStatement())
+        batch_with_simple.add(lwt_simple)
         assert batch_with_simple.is_lwt() is True
 
 
@@ -167,3 +166,266 @@ class PreparedStatementMetadataPairTest(unittest.TestCase):
             ps.result_metadata = []
 
         assert ps.result_metadata_and_id == (meta, b'hash')
+
+
+class SimpleStatementIsLwtTest(unittest.TestCase):
+    """Tests for SimpleStatement.is_lwt() CQL-based LWT detection."""
+
+    # --- INSERT IF NOT EXISTS ---
+
+    def test_insert_if_not_exists(self):
+        s = SimpleStatement("INSERT INTO ks.t (a) VALUES (1) IF NOT EXISTS")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_insert_if_not_exists_lowercase(self):
+        s = SimpleStatement("insert into ks.t (a) values (1) if not exists")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_insert_if_not_exists_mixed_case(self):
+        s = SimpleStatement("INSERT INTO ks.t (a) VALUES (1) If Not Exists")
+        self.assertIs(s.is_lwt(), True)
+
+    # --- UPDATE IF EXISTS ---
+
+    def test_update_if_exists(self):
+        s = SimpleStatement("UPDATE ks.t SET a=1 WHERE k=1 IF EXISTS")
+        self.assertIs(s.is_lwt(), True)
+
+    # --- DELETE IF EXISTS ---
+
+    def test_delete_if_exists(self):
+        s = SimpleStatement("DELETE FROM ks.t WHERE k=1 IF EXISTS")
+        self.assertIs(s.is_lwt(), True)
+
+    # --- Conditional UPDATE (IF <column> = <value>) ---
+
+    def test_conditional_update_equals(self):
+        s = SimpleStatement("UPDATE ks.t SET a=1 WHERE k=1 IF a = 2")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_conditional_update_not_equals(self):
+        s = SimpleStatement("UPDATE ks.t SET a=1 WHERE k=1 IF a != 2")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_conditional_update_greater_than(self):
+        s = SimpleStatement("UPDATE ks.t SET a=1 WHERE k=1 IF a > 2")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_conditional_update_multiple_conditions(self):
+        s = SimpleStatement(
+            "UPDATE ks.t SET a=1 WHERE k=1 IF a = 2 AND b = 3")
+        self.assertIs(s.is_lwt(), True)
+
+    # --- Conditional DELETE ---
+
+    def test_conditional_delete(self):
+        s = SimpleStatement("DELETE FROM ks.t WHERE k=1 IF a = 2")
+        self.assertIs(s.is_lwt(), True)
+
+    # --- Non-LWT queries (should return False) ---
+
+    def test_select_not_lwt(self):
+        s = SimpleStatement("SELECT * FROM ks.t WHERE k=1")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_insert_without_if(self):
+        s = SimpleStatement("INSERT INTO ks.t (a) VALUES (1)")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_update_without_if(self):
+        s = SimpleStatement("UPDATE ks.t SET a=1 WHERE k=1")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_delete_without_if(self):
+        s = SimpleStatement("DELETE FROM ks.t WHERE k=1")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_create_table_with_if_not_exists(self):
+        """DDL IF NOT EXISTS is correctly excluded — only DML can be LWT."""
+        s = SimpleStatement("CREATE TABLE IF NOT EXISTS ks.t (a int PRIMARY KEY)")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_create_index_if_not_exists(self):
+        s = SimpleStatement("CREATE INDEX IF NOT EXISTS idx ON ks.t (a)")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_create_keyspace_if_not_exists(self):
+        s = SimpleStatement(
+            "CREATE KEYSPACE IF NOT EXISTS ks WITH replication = "
+            "{'class': 'SimpleStrategy', 'replication_factor': 1}")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_drop_table_if_exists(self):
+        s = SimpleStatement("DROP TABLE IF EXISTS ks.t")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_alter_table_not_lwt(self):
+        s = SimpleStatement("ALTER TABLE ks.t ADD col int")
+        self.assertIs(s.is_lwt(), False)
+
+    # --- Caching ---
+    #
+    # These validate caching via an observable effect (the LWT-detection
+    # regexes are invoked at most once per statement instance, even across
+    # repeated is_lwt() calls) rather than asserting on the private
+    # _cached_is_lwt attribute, so the tests don't couple to that
+    # implementation detail and keep passing across refactors of the cache
+    # itself.
+
+    def test_result_is_cached(self):
+        """For a DML/LWT statement, is_lwt() takes the branch that calls
+        _LWT_PATTERN.search(); confirm that regex is only invoked once
+        across multiple is_lwt() calls, proving the result is cached."""
+        s = SimpleStatement("INSERT INTO ks.t (a) VALUES (1) IF NOT EXISTS")
+        with patch.object(query_module, '_LWT_PATTERN',
+                           wraps=query_module._LWT_PATTERN) as mock_pattern:
+            self.assertIs(s.is_lwt(), True)
+            self.assertIs(s.is_lwt(), True)  # should use cache, not re-match
+            self.assertEqual(mock_pattern.search.call_count, 1)
+
+    def test_non_lwt_result_is_cached(self):
+        """For a non-DML statement, is_lwt() short-circuits before ever
+        calling _LWT_PATTERN.search(), but it still runs the noise-stripping
+        regex to decide; confirm that regex is only invoked once across
+        multiple is_lwt() calls, proving the result is cached."""
+        s = SimpleStatement("SELECT * FROM ks.t")
+        with patch.object(query_module, '_LWT_NOISE_RE',
+                           wraps=query_module._LWT_NOISE_RE) as mock_noise_re:
+            self.assertIs(s.is_lwt(), False)
+            self.assertIs(s.is_lwt(), False)  # should use cache, not recompute
+            self.assertEqual(mock_noise_re.sub.call_count, 1)
+
+    def test_cached_attribute_is_set_after_first_call(self):
+        """Minimal direct check retained for debugging clarity: the tests
+        above are the primary proof of caching behavior via observable
+        effects, but a single check that the private cache attribute holds
+        the computed value is useful when diagnosing a failure here."""
+        s = SimpleStatement("INSERT INTO ks.t (a) VALUES (1) IF NOT EXISTS")
+        self.assertIs(s.is_lwt(), True)
+        self.assertIs(s._cached_is_lwt, True)
+
+    # --- Edge cases ---
+
+    def test_multiline_query(self):
+        s = SimpleStatement("""
+            INSERT INTO ks.t (a, b)
+            VALUES (1, 2)
+            IF NOT EXISTS
+        """)
+        self.assertIs(s.is_lwt(), True)
+
+    def test_extra_whitespace(self):
+        s = SimpleStatement("UPDATE ks.t SET a=1 WHERE k=1  IF   EXISTS")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_tab_separated(self):
+        s = SimpleStatement("DELETE FROM ks.t WHERE k=1\tIF\tEXISTS")
+        self.assertIs(s.is_lwt(), True)
+
+    # --- Quoted identifiers ---
+
+    def test_conditional_with_quoted_identifier(self):
+        s = SimpleStatement('UPDATE ks.t SET a=1 WHERE k=1 IF "my_col" = 2')
+        self.assertIs(s.is_lwt(), True)
+
+    def test_conditional_delete_quoted_identifier(self):
+        s = SimpleStatement('DELETE FROM ks.t WHERE k=1 IF "Col" = 2')
+        self.assertIs(s.is_lwt(), True)
+
+    # --- BEGIN BATCH ---
+
+    def test_begin_batch_with_lwt(self):
+        s = SimpleStatement(
+            "BEGIN BATCH "
+            "INSERT INTO ks.t (a) VALUES (1) IF NOT EXISTS "
+            "APPLY BATCH")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_begin_batch_without_lwt(self):
+        s = SimpleStatement(
+            "BEGIN BATCH "
+            "INSERT INTO ks.t (a) VALUES (1) "
+            "APPLY BATCH")
+        self.assertIs(s.is_lwt(), False)
+
+    # --- Leading whitespace ---
+
+    def test_leading_whitespace(self):
+        s = SimpleStatement("  \n  INSERT INTO ks.t (a) VALUES (1) IF NOT EXISTS")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_leading_whitespace_ddl(self):
+        s = SimpleStatement("  \n  CREATE TABLE IF NOT EXISTS ks.t (a int PRIMARY KEY)")
+        self.assertIs(s.is_lwt(), False)
+
+    # --- False positives: IF/EXISTS-like text inside string literals ---
+    # (must not be mistaken for a real LWT clause)
+
+    def test_string_literal_containing_if_not_exists(self):
+        s = SimpleStatement(
+            "INSERT INTO ks.t (a, note) VALUES (1, 'IF NOT EXISTS')")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_string_literal_containing_if_exists_sentence(self):
+        s = SimpleStatement(
+            "INSERT INTO ks.t (a, note) VALUES "
+            "(1, 'please check IF EXISTS in cache')")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_string_literal_looks_like_conditional(self):
+        s = SimpleStatement("UPDATE ks.t SET note = 'IF a = 2' WHERE k=1")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_string_literal_with_escaped_quote_containing_if_exists(self):
+        # CQL escapes a literal quote inside a string as ''.
+        s = SimpleStatement(
+            "INSERT INTO ks.t (a, note) VALUES (1, 'it''s a test IF EXISTS')")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_map_literal_value_containing_if_exists(self):
+        s = SimpleStatement(
+            "INSERT INTO ks.t (a, m) VALUES (1, {'k': 'IF EXISTS'})")
+        self.assertIs(s.is_lwt(), False)
+
+    # --- Column named similarly to "if"/"exists" is not itself a clause ---
+
+    def test_column_named_if_deleted_no_clause(self):
+        s = SimpleStatement("UPDATE ks.t SET if_deleted = true WHERE k=1")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_real_if_clause_referencing_if_deleted_column(self):
+        s = SimpleStatement(
+            "UPDATE ks.t SET a=1 WHERE k=1 IF if_deleted = true")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_quoted_identifier_literally_containing_if_prefix(self):
+        # A quoted identifier can contain arbitrary text, including a
+        # leading "IF "; it is not a real LWT clause.
+        s = SimpleStatement('UPDATE ks.t SET "IF status" = 1 WHERE k=1')
+        self.assertIs(s.is_lwt(), False)
+
+    # --- Comments: must not hide a real clause or fabricate one ---
+
+    def test_leading_line_comment_before_real_lwt(self):
+        s = SimpleStatement(
+            "-- trace comment\nINSERT INTO ks.t (a) VALUES (1) IF NOT EXISTS")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_leading_slash_comment_before_real_lwt(self):
+        s = SimpleStatement(
+            "// trace comment\nINSERT INTO ks.t (a) VALUES (1) IF NOT EXISTS")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_leading_block_comment_before_real_lwt(self):
+        s = SimpleStatement(
+            "/* trace comment */ INSERT INTO ks.t (a) VALUES (1) IF NOT EXISTS")
+        self.assertIs(s.is_lwt(), True)
+
+    def test_trailing_comment_mentioning_if_not_exists_is_not_lwt(self):
+        s = SimpleStatement("INSERT INTO ks.t (a) VALUES (1) -- IF NOT EXISTS")
+        self.assertIs(s.is_lwt(), False)
+
+    def test_inline_block_comment_mentioning_if_exists_is_not_lwt(self):
+        s = SimpleStatement(
+            "INSERT INTO ks.t (a) /* IF NOT EXISTS, check later */ VALUES (1)")
+        self.assertIs(s.is_lwt(), False)


### PR DESCRIPTION
## Summary

`SimpleStatement.is_lwt()` always returns `False` (inherited from `Statement` base class, line 348). This means **all LWT-aware optimizations are silently disabled** for:

1. **Raw CQL users**: `session.execute(SimpleStatement("INSERT ... IF NOT EXISTS"))` — LWT routing and retry policies never activate
2. **All cqlengine queries**: cqlengine wraps every query in `SimpleStatement` at `connection.py:347-349`, losing any LWT information

This is particularly impactful because:
- PR #782 (Paxos leader routing) only activates when `query.is_lwt()` returns `True`
- PR #783 (LWT retry policy) relies on `WriteType.CAS` from the server, but the routing optimization from #782 is lost
- Any `SimpleStatement` user gets no LWT-specific behavior at all

## Fix

Added regex-based LWT detection to `SimpleStatement.is_lwt()` that matches CQL patterns:

| Pattern | Example |
|---------|---------|
| `IF NOT EXISTS` | `INSERT INTO t (a) VALUES (1) IF NOT EXISTS` |
| `IF EXISTS` | `UPDATE t SET a=1 WHERE k=1 IF EXISTS` |
| `IF <column>` | `UPDATE t SET a=1 WHERE k=1 IF a = 2` |

The regex is case-insensitive and handles multiline queries, extra whitespace, and tabs. The result is cached after the first call to avoid repeated regex matching.

This is a **best-effort heuristic** — `PreparedStatement` continues to use the authoritative `is_lwt` flag from the server. DDL statements like `CREATE TABLE IF NOT EXISTS` are **not** a false positive here: `is_lwt()` first checks that the statement's leading keyword is a DML verb (`_LWT_DML_VERBS = {INSERT, UPDATE, DELETE, BEGIN}`) before ever looking for an `IF [NOT] EXISTS`/`IF <condition>` clause, so DDL's `IF [NOT] EXISTS` is excluded up front and `is_lwt()` correctly returns `False` for DDL.

## Changes

- `cassandra/query.py`: Added `_LWT_PATTERN` regex and `SimpleStatement.is_lwt()` override
- `tests/unit/test_query.py`: Added `SimpleStatementIsLwtTest` class with 20 tests; updated existing `BatchStatement` test to use the new detection instead of a workaround subclass

## Tests

20 new tests covering:
- INSERT/UPDATE/DELETE IF [NOT] EXISTS (various cases)
- Conditional updates/deletes (IF col = val, IF col != val, IF col > val)
- Multiple conditions (IF a = 1 AND b = 2)
- Case insensitivity (lowercase, mixed case)
- Non-LWT queries (SELECT, INSERT/UPDATE/DELETE without IF)
- DDL with IF NOT EXISTS (correctly excluded via `_LWT_DML_VERBS`, not a false positive)
- Result caching
- Multiline queries, extra whitespace, tab separation

All 26 tests in `tests/unit/test_query.py` pass. All 82 tests in `tests/unit/test_policies.py` pass.

## Related

- Enables PR #782 (Paxos leader routing) for SimpleStatement and cqlengine users
- Enables PR #783 (LWT retry policy) routing benefits for SimpleStatement users
