### PR TITLE
feat: NumPy-accelerated vector serialization in VectorType (huge improvements in some use cases 60us -> 0.6us)

### DIFF
--- a/benchmarks/bench_vector_numpy_serialize.py
+++ b/benchmarks/bench_vector_numpy_serialize.py
@@ -1,0 +1,257 @@
+# Copyright 2025 ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Benchmark: VectorType serialization – list vs NumPy ndarray vs bulk.
+
+Compares three approaches for serializing float vectors into the CQL
+binary protocol wire format:
+
+  1. list path      – original element-by-element serialize (struct.pack per element)
+  2. numpy path     – single ndarray passed to serialize(), uses tobytes()
+  3. bulk path      – serialize_numpy_bulk() on a 2-D array (one byte-swap for
+                      the entire batch, then bytes slicing)
+
+Each scenario is tested at realistic vector dimensions (128, 768, 1536) and
+batch sizes (1, 100, 10_000 rows).
+
+Usage:
+  python benchmarks/bench_vector_numpy_serialize.py
+"""
+
+import os
+import sys
+import time
+import timeit
+
+# Ensure the repo root is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+
+from cassandra.cqltypes import parse_casstype_args
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DIMENSIONS = [128, 768, 1536]
+BATCH_SIZES = [1, 100, 10_000]
+REPEATS = 3
+# Number of iterations is scaled per scenario to keep total time reasonable
+MIN_ITERS = 5
+TARGET_TIME_S = 0.2  # aim for ~0.2s per measurement
+
+
+def auto_iters(fn, target_s=TARGET_TIME_S, min_iters=MIN_ITERS):
+    """Estimate a good iteration count for the given function."""
+    # Warm up
+    fn()
+    # Time a single call
+    t0 = time.perf_counter()
+    fn()
+    t1 = time.perf_counter()
+    elapsed = t1 - t0
+    if elapsed <= 0:
+        return 100_000
+    n = max(min_iters, int(target_s / elapsed))
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Benchmark functions
+# ---------------------------------------------------------------------------
+
+
+def bench_list_serialize(ctype, vectors_list, protocol_version=4):
+    """Serialize each row as a Python list (original path)."""
+    for row in vectors_list:
+        ctype.serialize(row, protocol_version)
+
+
+def bench_numpy_serialize(ctype, vectors_np_rows, protocol_version=4):
+    """Serialize each row as an individual 1-D ndarray (numpy fast path)."""
+    for row in vectors_np_rows:
+        ctype.serialize(row, protocol_version)
+
+
+def bench_bulk_serialize(ctype, vectors_2d, protocol_version=4):
+    """Serialize all rows at once with serialize_numpy_bulk()."""
+    ctype.serialize_numpy_bulk(vectors_2d)
+
+
+def bench_bytes_passthrough(ctype, pre_serialized, protocol_version=4):
+    """Simulate bind() calling serialize() on pre-serialized bytes."""
+    for row_bytes in pre_serialized:
+        ctype.serialize(row_bytes, protocol_version)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    print(f"Python:     {sys.version.split()[0]}")
+    print(f"NumPy:      {np.__version__}")
+    print(f"Repeats:    {REPEATS} (best of)")
+    print()
+
+    for dim in DIMENSIONS:
+        ctype_str = (
+            f"org.apache.cassandra.db.marshal.VectorType("
+            f"org.apache.cassandra.db.marshal.FloatType, {dim})"
+        )
+        ctype = parse_casstype_args(ctype_str)
+
+        print(f"{'=' * 72}")
+        print(f"  Vector dimension: {dim}  (float32, {dim * 4} bytes/vector)")
+        print(f"{'=' * 72}")
+        print()
+
+        for batch_size in BATCH_SIZES:
+            # Prepare data
+            vectors_2d = np.random.rand(batch_size, dim).astype(np.float32)
+            vectors_list = [vectors_2d[i].tolist() for i in range(batch_size)]
+            vectors_np_rows = [vectors_2d[i] for i in range(batch_size)]
+
+            print(f"  --- batch_size = {batch_size:,} ---")
+            print(
+                f"    {'method':30s}  {'iters':>8s}  {'ns/call':>12s}  {'total_ms':>10s}  {'us/row':>10s}  {'vs list':>8s}"
+            )
+            print(
+                f"    {'------':30s}  {'-----':>8s}  {'-------':>12s}  {'--------':>10s}  {'------':>10s}  {'-------':>8s}"
+            )
+
+            results = {}
+
+            # 1. List path
+            def run_list():
+                bench_list_serialize(ctype, vectors_list)
+
+            n_iters = auto_iters(run_list)
+            t = timeit.repeat(
+                run_list, number=n_iters, repeat=REPEATS, timer=time.perf_counter
+            )
+            best_s = min(t) / n_iters
+            us_per_row = best_s / batch_size * 1e6
+            total_ms = best_s * 1e3
+            ns_per_call = best_s * 1e9
+            results["list"] = us_per_row
+            print(
+                f"    {'list (element-by-element)':30s}  {n_iters:8d}  {ns_per_call:12.1f}  {total_ms:10.3f}  {us_per_row:10.3f}  {'1.00x':>8s}"
+            )
+
+            # 2. NumPy per-row path
+            def run_numpy():
+                bench_numpy_serialize(ctype, vectors_np_rows)
+
+            n_iters = auto_iters(run_numpy)
+            t = timeit.repeat(
+                run_numpy, number=n_iters, repeat=REPEATS, timer=time.perf_counter
+            )
+            best_s = min(t) / n_iters
+            us_per_row = best_s / batch_size * 1e6
+            total_ms = best_s * 1e3
+            ns_per_call = best_s * 1e9
+            speedup = results["list"] / us_per_row if us_per_row > 0 else float("inf")
+            results["numpy"] = us_per_row
+            print(
+                f"    {'numpy (per-row ndarray)':30s}  {n_iters:8d}  {ns_per_call:12.1f}  {total_ms:10.3f}  {us_per_row:10.3f}  {speedup:7.2f}x"
+            )
+
+            # 3. Bulk path
+            def run_bulk():
+                bench_bulk_serialize(ctype, vectors_2d)
+
+            n_iters = auto_iters(run_bulk)
+            t = timeit.repeat(
+                run_bulk, number=n_iters, repeat=REPEATS, timer=time.perf_counter
+            )
+            best_s = min(t) / n_iters
+            us_per_row = best_s / batch_size * 1e6
+            total_ms = best_s * 1e3
+            ns_per_call = best_s * 1e9
+            speedup = results["list"] / us_per_row if us_per_row > 0 else float("inf")
+            results["bulk"] = us_per_row
+            print(
+                f"    {'bulk (serialize_numpy_bulk)':30s}  {n_iters:8d}  {ns_per_call:12.1f}  {total_ms:10.3f}  {us_per_row:10.3f}  {speedup:7.2f}x"
+            )
+
+            # 4. Bytes passthrough (simulates bind() on pre-serialized bulk output)
+            pre_serialized = ctype.serialize_numpy_bulk(vectors_2d)
+
+            def run_passthrough():
+                bench_bytes_passthrough(ctype, pre_serialized)
+
+            n_iters = auto_iters(run_passthrough)
+            t = timeit.repeat(
+                run_passthrough, number=n_iters, repeat=REPEATS, timer=time.perf_counter
+            )
+            best_s = min(t) / n_iters
+            us_per_row = best_s / batch_size * 1e6
+            total_ms = best_s * 1e3
+            ns_per_call = best_s * 1e9
+            speedup = results["list"] / us_per_row if us_per_row > 0 else float("inf")
+            print(
+                f"    {'bytes passthrough (bind)':30s}  {n_iters:8d}  {ns_per_call:12.1f}  {total_ms:10.3f}  {us_per_row:10.3f}  {speedup:7.2f}x"
+            )
+
+            # 5. Bulk + passthrough combined (realistic end-to-end)
+            def run_bulk_e2e():
+                serialized = ctype.serialize_numpy_bulk(vectors_2d)
+                for row_bytes in serialized:
+                    ctype.serialize(row_bytes, 4)
+
+            n_iters = auto_iters(run_bulk_e2e)
+            t = timeit.repeat(
+                run_bulk_e2e, number=n_iters, repeat=REPEATS, timer=time.perf_counter
+            )
+            best_s = min(t) / n_iters
+            us_per_row = best_s / batch_size * 1e6
+            total_ms = best_s * 1e3
+            ns_per_call = best_s * 1e9
+            speedup = results["list"] / us_per_row if us_per_row > 0 else float("inf")
+            print(
+                f"    {'bulk+passthrough (end-to-end)':30s}  {n_iters:8d}  {ns_per_call:12.1f}  {total_ms:10.3f}  {us_per_row:10.3f}  {speedup:7.2f}x"
+            )
+
+            print()
+
+    # --- Correctness verification ---
+    print("Correctness verification:")
+    for dim in DIMENSIONS:
+        ctype_str = (
+            f"org.apache.cassandra.db.marshal.VectorType("
+            f"org.apache.cassandra.db.marshal.FloatType, {dim})"
+        )
+        ctype = parse_casstype_args(ctype_str)
+        vectors = np.random.rand(10, dim).astype(np.float32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        for i in range(10):
+            list_result = ctype.serialize(vectors[i].tolist(), 4)
+            numpy_result = ctype.serialize(vectors[i], 4)
+            assert bulk[i] == list_result == numpy_result, (
+                f"Mismatch at dim={dim}, row={i}"
+            )
+            # Bytes passthrough
+            assert ctype.serialize(bulk[i], 4) == bulk[i]
+        print(f"  dim={dim}: OK (list == numpy == bulk == passthrough)")
+
+    print()
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_vector_numpy_serialize.py
+++ b/benchmarks/bench_vector_numpy_serialize.py
@@ -1,0 +1,260 @@
+# Copyright 2025 ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Benchmark: VectorType serialization - list vs NumPy ndarray vs bulk.
+
+Compares five approaches for serializing float vectors into the CQL
+binary protocol wire format:
+
+  1. list path       - original element-by-element serialize (struct.pack per element)
+  2. numpy path      - single ndarray passed to serialize(), uses tobytes()
+  3. bulk path       - serialize_numpy_bulk() on a 2-D array (one byte-swap for
+                       the entire batch, then one tobytes() copy per row)
+  4. bytes path      - passthrough: serialize() on pre-serialized bytes (zero conversion)
+  5. bulk+bytes path - serialize_numpy_bulk() followed by the bytes passthrough,
+                       the realistic bulk-insert flow
+
+Each scenario is tested at realistic vector dimensions (128, 768, 1536) and
+batch sizes (1, 100, 10_000 rows).
+
+Usage:
+  python benchmarks/bench_vector_numpy_serialize.py
+"""
+
+import os
+import sys
+import time
+import timeit
+
+# Ensure the repo root is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+
+from cassandra.cqltypes import parse_casstype_args
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DIMENSIONS = [128, 768, 1536]
+BATCH_SIZES = [1, 100, 10_000]
+REPEATS = 3
+# Number of iterations is scaled per scenario to keep total time reasonable
+MIN_ITERS = 5
+TARGET_TIME_S = 0.2  # aim for ~0.2s per measurement
+
+
+def auto_iters(fn, target_s=TARGET_TIME_S, min_iters=MIN_ITERS):
+    """Estimate a good iteration count for the given function."""
+    # Warm up
+    fn()
+    # Time a single call
+    t0 = time.perf_counter()
+    fn()
+    t1 = time.perf_counter()
+    elapsed = t1 - t0
+    if elapsed <= 0:
+        return 100_000
+    n = max(min_iters, int(target_s / elapsed))
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Benchmark functions
+# ---------------------------------------------------------------------------
+
+
+def bench_list_serialize(ctype, vectors_list, protocol_version=4):
+    """Serialize each row as a Python list (original path)."""
+    for row in vectors_list:
+        ctype.serialize(row, protocol_version)
+
+
+def bench_numpy_serialize(ctype, vectors_np_rows, protocol_version=4):
+    """Serialize each row as an individual 1-D ndarray (numpy fast path)."""
+    for row in vectors_np_rows:
+        ctype.serialize(row, protocol_version)
+
+
+def bench_bulk_serialize(ctype, vectors_2d, protocol_version=4):
+    """Serialize all rows at once with serialize_numpy_bulk()."""
+    ctype.serialize_numpy_bulk(vectors_2d)
+
+
+def bench_bytes_passthrough(ctype, pre_serialized, protocol_version=4):
+    """Simulate bind() calling serialize() on pre-serialized bytes."""
+    for row_bytes in pre_serialized:
+        ctype.serialize(row_bytes, protocol_version)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    print(f"Python:     {sys.version.split()[0]}")
+    print(f"NumPy:      {np.__version__}")
+    print(f"Repeats:    {REPEATS} (best of)")
+    print()
+
+    for dim in DIMENSIONS:
+        ctype_str = (
+            f"org.apache.cassandra.db.marshal.VectorType("
+            f"org.apache.cassandra.db.marshal.FloatType, {dim})"
+        )
+        ctype = parse_casstype_args(ctype_str)
+
+        print(f"{'=' * 72}")
+        print(f"  Vector dimension: {dim}  (float32, {dim * 4} bytes/vector)")
+        print(f"{'=' * 72}")
+        print()
+
+        for batch_size in BATCH_SIZES:
+            # Prepare data
+            vectors_2d = np.random.rand(batch_size, dim).astype(np.float32)
+            vectors_list = [vectors_2d[i].tolist() for i in range(batch_size)]
+            vectors_np_rows = [vectors_2d[i] for i in range(batch_size)]
+
+            print(f"  --- batch_size = {batch_size:,} ---")
+            print(
+                f"    {'method':30s}  {'iters':>8s}  {'ns/call':>12s}  {'total_ms':>10s}  {'us/row':>10s}  {'vs list':>8s}"
+            )
+            print(
+                f"    {'------':30s}  {'-----':>8s}  {'-------':>12s}  {'--------':>10s}  {'------':>10s}  {'-------':>8s}"
+            )
+
+            results = {}
+
+            # 1. List path
+            def run_list(ctype=ctype, vectors_list=vectors_list):
+                bench_list_serialize(ctype, vectors_list)
+
+            n_iters = auto_iters(run_list)
+            t = timeit.repeat(
+                run_list, number=n_iters, repeat=REPEATS, timer=time.perf_counter
+            )
+            best_s = min(t) / n_iters
+            us_per_row = best_s / batch_size * 1e6
+            total_ms = best_s * 1e3
+            ns_per_call = best_s * 1e9
+            results["list"] = us_per_row
+            print(
+                f"    {'list (element-by-element)':30s}  {n_iters:8d}  {ns_per_call:12.1f}  {total_ms:10.3f}  {us_per_row:10.3f}  {'1.00x':>8s}"
+            )
+
+            # 2. NumPy per-row path
+            def run_numpy(ctype=ctype, vectors_np_rows=vectors_np_rows):
+                bench_numpy_serialize(ctype, vectors_np_rows)
+
+            n_iters = auto_iters(run_numpy)
+            t = timeit.repeat(
+                run_numpy, number=n_iters, repeat=REPEATS, timer=time.perf_counter
+            )
+            best_s = min(t) / n_iters
+            us_per_row = best_s / batch_size * 1e6
+            total_ms = best_s * 1e3
+            ns_per_call = best_s * 1e9
+            speedup = results["list"] / us_per_row if us_per_row > 0 else float("inf")
+            results["numpy"] = us_per_row
+            print(
+                f"    {'numpy (per-row ndarray)':30s}  {n_iters:8d}  {ns_per_call:12.1f}  {total_ms:10.3f}  {us_per_row:10.3f}  {speedup:7.2f}x"
+            )
+
+            # 3. Bulk path
+            def run_bulk(ctype=ctype, vectors_2d=vectors_2d):
+                bench_bulk_serialize(ctype, vectors_2d)
+
+            n_iters = auto_iters(run_bulk)
+            t = timeit.repeat(
+                run_bulk, number=n_iters, repeat=REPEATS, timer=time.perf_counter
+            )
+            best_s = min(t) / n_iters
+            us_per_row = best_s / batch_size * 1e6
+            total_ms = best_s * 1e3
+            ns_per_call = best_s * 1e9
+            speedup = results["list"] / us_per_row if us_per_row > 0 else float("inf")
+            results["bulk"] = us_per_row
+            print(
+                f"    {'bulk (serialize_numpy_bulk)':30s}  {n_iters:8d}  {ns_per_call:12.1f}  {total_ms:10.3f}  {us_per_row:10.3f}  {speedup:7.2f}x"
+            )
+
+            # 4. Bytes passthrough (simulates bind() on pre-serialized bulk output)
+            pre_serialized = ctype.serialize_numpy_bulk(vectors_2d)
+
+            def run_passthrough(ctype=ctype, pre_serialized=pre_serialized):
+                bench_bytes_passthrough(ctype, pre_serialized)
+
+            n_iters = auto_iters(run_passthrough)
+            t = timeit.repeat(
+                run_passthrough, number=n_iters, repeat=REPEATS, timer=time.perf_counter
+            )
+            best_s = min(t) / n_iters
+            us_per_row = best_s / batch_size * 1e6
+            total_ms = best_s * 1e3
+            ns_per_call = best_s * 1e9
+            speedup = results["list"] / us_per_row if us_per_row > 0 else float("inf")
+            print(
+                f"    {'bytes passthrough (bind)':30s}  {n_iters:8d}  {ns_per_call:12.1f}  {total_ms:10.3f}  {us_per_row:10.3f}  {speedup:7.2f}x"
+            )
+
+            # 5. Bulk + passthrough combined (realistic end-to-end)
+            def run_bulk_e2e(ctype=ctype, vectors_2d=vectors_2d):
+                serialized = ctype.serialize_numpy_bulk(vectors_2d)
+                for row_bytes in serialized:
+                    ctype.serialize(row_bytes, 4)
+
+            n_iters = auto_iters(run_bulk_e2e)
+            t = timeit.repeat(
+                run_bulk_e2e, number=n_iters, repeat=REPEATS, timer=time.perf_counter
+            )
+            best_s = min(t) / n_iters
+            us_per_row = best_s / batch_size * 1e6
+            total_ms = best_s * 1e3
+            ns_per_call = best_s * 1e9
+            speedup = results["list"] / us_per_row if us_per_row > 0 else float("inf")
+            print(
+                f"    {'bulk+passthrough (end-to-end)':30s}  {n_iters:8d}  {ns_per_call:12.1f}  {total_ms:10.3f}  {us_per_row:10.3f}  {speedup:7.2f}x"
+            )
+
+            print()
+
+    # --- Correctness verification ---
+    print("Correctness verification:")
+    for dim in DIMENSIONS:
+        ctype_str = (
+            f"org.apache.cassandra.db.marshal.VectorType("
+            f"org.apache.cassandra.db.marshal.FloatType, {dim})"
+        )
+        ctype = parse_casstype_args(ctype_str)
+        vectors = np.random.rand(10, dim).astype(np.float32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        for i in range(10):
+            list_result = ctype.serialize(vectors[i].tolist(), 4)
+            numpy_result = ctype.serialize(vectors[i], 4)
+            assert bulk[i] == list_result == numpy_result, (
+                f"Mismatch at dim={dim}, row={i}"
+            )
+            # Bytes passthrough
+            assert ctype.serialize(bulk[i], 4) == bulk[i]
+        print(f"  dim={dim}: OK (list == numpy == bulk == passthrough)")
+
+    print()
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -54,6 +54,12 @@ from cassandra import util
 _little_endian_flag = 1  # we always serialize LE
 import ipaddress
 
+
+try:
+    import numpy as _np
+    _HAVE_NUMPY = True
+except ImportError:
+    _HAVE_NUMPY = False
 apache_cassandra_type_prefix = 'org.apache.cassandra.db.marshal.'
 
 cassandra_empty_type = 'org.apache.cassandra.db.marshal.EmptyType'
@@ -1428,10 +1434,25 @@ class DateRangeType(CassandraType):
 
         return buf.getvalue()
 
+# Used by VectorType to enable fast serialization from NumPy arrays.
+# Only types with a fixed serial_size() are included, because the vector
+# wire format for variable-size subtypes uses uvint length prefixes per
+# element, which cannot be produced by raw numpy tobytes().
+_NUMPY_DTYPE_MAP = {}
+if _HAVE_NUMPY:
+    _NUMPY_DTYPE_MAP = {
+        'float': _np.dtype('>f4'),   # FloatType  - 4-byte big-endian float
+        'double': _np.dtype('>f8'),  # DoubleType - 8-byte big-endian double
+        'int': _np.dtype('>i4'),     # Int32Type  - 4-byte big-endian int32
+        'bigint': _np.dtype('>i8'),  # LongType   - 8-byte big-endian int64
+    }
+
+
 class VectorType(_CassandraType):
     typename = 'org.apache.cassandra.db.marshal.VectorType'
     vector_size = 0
     subtype = None
+    _numpy_dtype = None
 
     @classmethod
     def serial_size(cls):
@@ -1443,7 +1464,12 @@ class VectorType(_CassandraType):
         assert len(params) == 2
         subtype = lookup_casstype(params[0])
         vsize = params[1]
-        return type('%s(%s)' % (cls.cass_parameterized_type_with([]), vsize), (cls,), {'vector_size': vsize, 'subtype': subtype})
+        # Determine the NumPy dtype for fast serialization (only for
+        # fixed-size subtypes whose typename appears in _NUMPY_DTYPE_MAP).
+        np_dtype = None
+        if _HAVE_NUMPY and subtype.serial_size() is not None:
+            np_dtype = _NUMPY_DTYPE_MAP.get(subtype.typename)
+        return type('%s(%s)' % (cls.cass_parameterized_type_with([]), vsize), (cls,), {'vector_size': vsize, 'subtype': subtype, '_numpy_dtype': np_dtype})
 
     @classmethod
     def deserialize(cls, byts, protocol_version):
@@ -1476,6 +1502,36 @@ class VectorType(_CassandraType):
 
     @classmethod
     def serialize(cls, v, protocol_version):
+        # ---- bytes / bytearray passthrough ----
+        # If the caller already holds a correctly-sized blob (e.g. from
+        # serialize_numpy_bulk), skip all conversion work.
+        # Only enabled for subtypes with a known NumPy dtype (float, double,
+        # int32, bigint) - variable-size subtypes fall through to the
+        # element-by-element path.
+        if cls._numpy_dtype is not None and isinstance(v, (bytes, bytearray)):
+            expected = cls.serial_size()
+            if len(v) == expected:
+                return v if isinstance(v, bytes) else bytes(v)
+            raise ValueError(
+                'Pre-serialized bytes have wrong length %d (expected %d for vector<%s, %d>)'
+                % (len(v), expected, cls.subtype.typename, cls.vector_size))
+
+        # ---- NumPy ndarray fast path ----
+        if cls._numpy_dtype is not None and _HAVE_NUMPY and isinstance(v, _np.ndarray):
+            if v.shape != (cls.vector_size,):
+                raise ValueError(
+                    'Expected ndarray of shape ({0},) for vector of type {1}, got shape {2}'.format(
+                        cls.vector_size, cls.subtype.typename, v.shape))
+            if v.dtype != cls._numpy_dtype and not _np.can_cast(v.dtype, cls._numpy_dtype, casting='safe'):
+                raise TypeError(
+                    'Unsafe dtype conversion from %s to %s for vector<%s, %d>: '
+                    'values may overflow or lose precision. '
+                    'Cast explicitly with arr.astype(%r) if this is intentional.'
+                    % (v.dtype, cls._numpy_dtype, cls.subtype.typename, cls.vector_size, cls._numpy_dtype))
+            arr = _np.asarray(v, dtype=cls._numpy_dtype)
+            return arr.tobytes()
+
+        # ---- Original element-by-element path ----
         v_length = len(v)
         if cls.vector_size != v_length:
             raise ValueError(
@@ -1490,6 +1546,67 @@ class VectorType(_CassandraType):
                 buf.write(uvint_pack(len(item_bytes)))
             buf.write(item_bytes)
         return buf.getvalue()
+
+    @classmethod
+    def serialize_numpy_bulk(cls, vectors):
+        """Serialize a batch of vectors from a 2-D NumPy array.
+
+        Parameters
+        ----------
+        vectors : numpy.ndarray
+            A 2-D array of shape ``(N, cls.vector_size)`` whose values are
+            compatible with the CQL vector subtype.
+
+        Returns
+        -------
+        list[bytes]
+            One ``bytes`` object per row, ready to be bound to a CQL
+            ``vector<...>`` column.
+
+        Raises
+        ------
+        TypeError
+            If NumPy is not available or ``cls._numpy_dtype`` is ``None``
+            (subtype not supported for the fast path).
+        ValueError
+            If the second dimension of *vectors* does not match
+            ``cls.vector_size``.
+
+        Notes
+        -----
+        The entire array is byte-swapped to big-endian once, then each row
+        is sliced out of the raw buffer with zero per-element overhead.
+        The returned ``bytes`` objects are accepted directly by
+        ``VectorType.serialize()`` (bytes passthrough) so they flow through
+        ``BoundStatement.bind()`` without further conversion.
+        """
+        if not _HAVE_NUMPY:
+            raise TypeError('serialize_numpy_bulk() requires NumPy to be installed')
+        if cls._numpy_dtype is None:
+            raise TypeError(
+                'serialize_numpy_bulk() requires a subtype with a known '
+                'NumPy dtype; %s is not supported' % cls.subtype.typename)
+        if not isinstance(vectors, _np.ndarray):
+            raise ValueError(
+                'Expected a 2-D NumPy array, got %s' % type(vectors).__name__)
+        if vectors.ndim != 2:
+            raise ValueError(
+                'Expected a 2-D NumPy array, got %d-D array with shape %s'
+                % (vectors.ndim, vectors.shape))
+        if vectors.shape[1] != cls.vector_size:
+            raise ValueError(
+                'Expected array with %d columns, got shape %s'
+                % (cls.vector_size, vectors.shape))
+        if vectors.dtype != cls._numpy_dtype and not _np.can_cast(vectors.dtype, cls._numpy_dtype, casting='safe'):
+            raise TypeError(
+                'Unsafe dtype conversion from %s to %s for vector<%s, %d>: '
+                'values may overflow or lose precision. '
+                'Cast explicitly with arr.astype(%r) if this is intentional.'
+                % (vectors.dtype, cls._numpy_dtype, cls.subtype.typename, cls.vector_size, cls._numpy_dtype))
+        arr = _np.asarray(vectors, dtype=cls._numpy_dtype)
+        row_bytes = cls._numpy_dtype.itemsize * cls.vector_size
+        raw = arr.tobytes()
+        return [raw[i * row_bytes:(i + 1) * row_bytes] for i in range(arr.shape[0])]
 
     @classmethod
     def cql_parameterized_type(cls):

--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -53,6 +53,12 @@ from cassandra import util
 _little_endian_flag = 1  # we always serialize LE
 import ipaddress
 
+
+try:
+    import numpy as _np
+    _HAVE_NUMPY = True
+except ImportError:
+    _HAVE_NUMPY = False
 apache_cassandra_type_prefix = 'org.apache.cassandra.db.marshal.'
 
 cassandra_empty_type = 'org.apache.cassandra.db.marshal.EmptyType'
@@ -1427,10 +1433,25 @@ class DateRangeType(CassandraType):
 
         return buf.getvalue()
 
+# Used by VectorType to enable fast serialization from NumPy arrays.
+# Only types with a fixed serial_size() are included, because the vector
+# wire format for variable-size subtypes uses uvint length prefixes per
+# element, which cannot be produced by raw numpy tobytes().
+_NUMPY_DTYPE_MAP = {}
+if _HAVE_NUMPY:
+    _NUMPY_DTYPE_MAP = {
+        'float': _np.dtype('>f4'),   # FloatType  - 4-byte big-endian float
+        'double': _np.dtype('>f8'),  # DoubleType - 8-byte big-endian double
+        'int': _np.dtype('>i4'),     # Int32Type  - 4-byte big-endian int32
+        'bigint': _np.dtype('>i8'),  # LongType   - 8-byte big-endian int64
+    }
+
+
 class VectorType(_CassandraType):
     typename = 'org.apache.cassandra.db.marshal.VectorType'
     vector_size = 0
     subtype = None
+    _numpy_dtype = None
 
     @classmethod
     def serial_size(cls):
@@ -1442,7 +1463,12 @@ class VectorType(_CassandraType):
         assert len(params) == 2
         subtype = lookup_casstype(params[0])
         vsize = params[1]
-        return type('%s(%s)' % (cls.cass_parameterized_type_with([]), vsize), (cls,), {'vector_size': vsize, 'subtype': subtype})
+        # Determine the NumPy dtype for fast serialization (only for
+        # fixed-size subtypes whose typename appears in _NUMPY_DTYPE_MAP).
+        np_dtype = None
+        if _HAVE_NUMPY and subtype.serial_size() is not None:
+            np_dtype = _NUMPY_DTYPE_MAP.get(subtype.typename)
+        return type('%s(%s)' % (cls.cass_parameterized_type_with([]), vsize), (cls,), {'vector_size': vsize, 'subtype': subtype, '_numpy_dtype': np_dtype})
 
     @classmethod
     def deserialize(cls, byts, protocol_version):
@@ -1475,6 +1501,51 @@ class VectorType(_CassandraType):
 
     @classmethod
     def serialize(cls, v, protocol_version):
+        # ---- bytes / bytearray passthrough ----
+        # If the caller already holds a correctly-sized blob (e.g. from
+        # serialize_numpy_bulk), skip all conversion work.
+        # Enabled for any subtype with a fixed wire-format size (mirrors the
+        # fixed-vs-variable-width check `deserialize()` above already uses
+        # via `cls.subtype.serial_size()`), independent of whether NumPy is
+        # installed - `cls.serial_size()` is `None` only for variable-size
+        # subtypes, which correctly fall through to the element-by-element
+        # path below since there is no single expected length to validate
+        # against. Gating this on `cls._numpy_dtype` instead would be wrong:
+        # that attribute is only populated when NumPy is available, so on a
+        # NumPy-less install correctly pre-serialized bytes would otherwise
+        # miss this fast path and fall into the element-by-element path,
+        # raising a misleading "vector length" error instead of just
+        # passing through.
+        expected = cls.serial_size()
+        if expected is not None and isinstance(v, (bytes, bytearray)):
+            if len(v) == expected:
+                return v if isinstance(v, bytes) else bytes(v)
+            raise ValueError(
+                'Pre-serialized bytes have wrong length %d (expected %d for vector<%s, %d>)'
+                % (len(v), expected, cls.subtype.typename, cls.vector_size))
+
+        # Variable-size subtypes have no fixed serialized length to
+        # validate, so raw bytes cannot be a correctly pre-serialized
+        # blob; reject them rather than treating each byte as an element.
+        if expected is None and isinstance(v, (bytes, bytearray)):
+            raise TypeError(
+                'Pre-serialized bytes are not supported for vector<%s, %d> '
+                '(subtype %s has no fixed serialized length)'
+                % (cls.subtype.typename, cls.vector_size, cls.subtype.typename))
+
+        # ---- NumPy ndarray fast path ----
+        if cls._numpy_dtype is not None and _HAVE_NUMPY and isinstance(v, _np.ndarray):
+            if v.shape != (cls.vector_size,):
+                raise ValueError(
+                    'Expected ndarray of shape ({0},) for vector of type {1}, got shape {2}'.format(
+                        cls.vector_size, cls.subtype.typename, v.shape))
+            if v.dtype == cls._numpy_dtype or _np.can_cast(v.dtype, cls._numpy_dtype, casting='safe'):
+                arr = _np.asarray(v, dtype=cls._numpy_dtype)
+                return arr.tobytes()
+            # Unsafe or object dtype: fall through to the element-by-element
+            # path below rather than converting with potential precision loss.
+
+        # ---- Original element-by-element path ----
         v_length = len(v)
         if cls.vector_size != v_length:
             raise ValueError(
@@ -1489,6 +1560,81 @@ class VectorType(_CassandraType):
                 buf.write(uvint_pack(len(item_bytes)))
             buf.write(item_bytes)
         return buf.getvalue()
+
+    @classmethod
+    def serialize_numpy_bulk(cls, vectors):
+        """Serialize a batch of vectors from a 2-D NumPy array.
+
+        Parameters
+        ----------
+        vectors : numpy.ndarray
+            A 2-D array of shape ``(N, cls.vector_size)`` whose values are
+            compatible with the CQL vector subtype.
+
+        Returns
+        -------
+        list[bytes]
+            One ``bytes`` object per row, ready to be bound to a CQL
+            ``vector<...>`` column.
+
+        Raises
+        ------
+        TypeError
+            If NumPy is not available, if ``cls._numpy_dtype`` is ``None``
+            (subtype not supported for the fast path), if *vectors* is not
+            a ``numpy.ndarray``, or if its dtype cannot be safely converted
+            to ``cls._numpy_dtype``.
+        ValueError
+            If *vectors* is not 2-dimensional, or if its second dimension
+            does not match ``cls.vector_size``.
+
+        Notes
+        -----
+        The array is byte-swapped to big-endian (if needed) and made
+        C-contiguous once, then each row is copied directly out of that
+        shared buffer one at a time. This avoids materializing the whole
+        batch as one large intermediate ``bytes`` object in addition to the
+        per-row ``bytes`` objects in the returned list, which would roughly
+        double peak memory for large batches. The returned ``bytes``
+        objects are accepted directly by ``VectorType.serialize()`` (bytes
+        passthrough) so they flow through ``BoundStatement.bind()`` without
+        further conversion.
+        """
+        if not _HAVE_NUMPY:
+            raise TypeError('serialize_numpy_bulk() requires NumPy to be installed')
+        if cls._numpy_dtype is None:
+            raise TypeError(
+                'serialize_numpy_bulk() requires a subtype with a known '
+                'NumPy dtype; %s is not supported' % cls.subtype.typename)
+        if not isinstance(vectors, _np.ndarray):
+            raise TypeError(
+                'Expected a 2-D NumPy array, got %s' % type(vectors).__name__)
+        if vectors.ndim != 2:
+            raise ValueError(
+                'Expected a 2-D NumPy array, got %d-D array with shape %s'
+                % (vectors.ndim, vectors.shape))
+        if vectors.shape[1] != cls.vector_size:
+            raise ValueError(
+                'Expected array with %d columns, got shape %s'
+                % (cls.vector_size, vectors.shape))
+        if vectors.dtype != cls._numpy_dtype and not _np.can_cast(vectors.dtype, cls._numpy_dtype, casting='safe'):
+            raise TypeError(
+                'Unsafe dtype conversion from %s to %s for vector<%s, %d>: '
+                'values may overflow or lose precision. '
+                'Cast explicitly with arr.astype(%r) if this is intentional.'
+                % (vectors.dtype, cls._numpy_dtype, cls.subtype.typename, cls.vector_size, cls._numpy_dtype))
+        arr = _np.asarray(vectors, dtype=cls._numpy_dtype)
+        # Ensure a C-contiguous buffer so each row occupies a single
+        # contiguous span of memory. This is a no-op (no copy) if `arr` is
+        # already C-contiguous; otherwise (e.g. Fortran-ordered input) it
+        # performs one copy here rather than an implicit one being hidden
+        # inside a subsequent whole-array `tobytes()` call.
+        arr = _np.ascontiguousarray(arr)
+        # Copy each row directly out of the shared buffer one at a time
+        # instead of first materializing the entire batch as one large
+        # `bytes` object and then slicing per-row copies out of it - see
+        # the Notes section above.
+        return [row.tobytes() for row in arr]
 
     @classmethod
     def cql_parameterized_type(cls):

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -43,3 +43,53 @@ objects should all be created after forking the process, not before.
 
 For further discussion and simple examples using the driver with ``multiprocessing``,
 see `this blog post <http://www.datastax.com/dev/blog/datastax-python-driver-multiprocessing-example-for-improved-bulk-data-throughput>`_.
+
+NumPy-accelerated Vector Serialization
+--------------------------------------
+When inserting high-dimensional vectors (e.g. ML embeddings), the default
+element-by-element serialization in
+:class:`~cassandra.cqltypes.VectorType` can become a bottleneck.  If
+`NumPy <https://numpy.org>`_ is installed, the driver provides three
+progressively faster paths:
+
+**Single-row ndarray fast path** – pass a 1-D ``numpy.ndarray`` directly
+as the bound value for a ``vector<float, N>`` column.  The driver
+byte-swaps the array to big-endian in a single C-level operation and
+calls ``tobytes()``, replacing *N* individual ``struct.pack`` calls::
+
+    import numpy as np
+    embedding = np.array([0.1, 0.2, ..., 0.768], dtype=np.float32)
+    session.execute(insert_stmt, [key, embedding])
+
+**Bulk serialization** – for batch inserts, convert an entire 2-D array
+(one row per vector) into a list of ``bytes`` objects with a single
+byte-swap::
+
+    from cassandra.cqltypes import VectorType
+
+    # Build the parameterized type (usually done once)
+    ctype = VectorType.apply_parameters(
+        [lookup_casstype('org.apache.cassandra.db.marshal.FloatType'), 768],
+        names=None,
+    )
+
+    vectors_2d = np.array(all_embeddings, dtype=np.float32)   # (N, 768)
+    blobs = ctype.serialize_numpy_bulk(vectors_2d)             # list[bytes]
+
+    for key, blob in zip(keys, blobs):
+        session.execute(insert_stmt, [key, blob])
+
+Each ``bytes`` object in the returned list is accepted directly by the
+driver's bytes-passthrough path, so ``BoundStatement.bind()`` performs no
+further conversion.
+
+**Supported subtypes** – the fast paths are available for ``float``
+(``>f4``), ``double`` (``>f8``), ``int`` (``>i4``), and ``bigint``
+(``>i8``).  Variable-length subtypes (``smallint``, ``tinyint``, text
+types, etc.) fall back to the original element-by-element serialization
+automatically.
+
+**Benchmarks** – on 768-dimension ``float32`` vectors (100-row batches),
+the bulk path is ~146× faster than the baseline, and the bytes
+passthrough path is ~298× faster.  See
+``benchmarks/bench_vector_numpy_serialize.py`` for reproducible numbers.

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -43,3 +43,62 @@ objects should all be created after forking the process, not before.
 
 For further discussion and simple examples using the driver with ``multiprocessing``,
 see `this blog post <http://www.datastax.com/dev/blog/datastax-python-driver-multiprocessing-example-for-improved-bulk-data-throughput>`_.
+
+NumPy-accelerated Vector Serialization
+--------------------------------------
+When inserting high-dimensional vectors (e.g. ML embeddings), the default
+element-by-element serialization in
+:class:`~cassandra.cqltypes.VectorType` can become a bottleneck.  If
+`NumPy <https://numpy.org>`_ is installed, the driver provides three
+progressively faster paths:
+
+**Single-row ndarray fast path** – pass a 1-D ``numpy.ndarray`` directly
+as the bound value for a ``vector<float, N>`` column.  The driver
+byte-swaps the array to big-endian in a single C-level operation and
+calls ``tobytes()``, replacing *N* individual ``struct.pack`` calls::
+
+    import numpy as np
+    embedding = np.random.rand(768).astype(np.float32)  # a 768-dim embedding
+    session.execute(insert_stmt, [key, embedding])
+
+**Bulk serialization** – for batch inserts, convert an entire 2-D array
+(one row per vector) into a list of ``bytes`` objects with a single
+byte-swap::
+
+    from cassandra.cqltypes import VectorType, lookup_casstype
+
+    # Build the parameterized type (usually done once)
+    ctype = VectorType.apply_parameters(
+        [lookup_casstype('org.apache.cassandra.db.marshal.FloatType'), 768],
+        names=None,
+    )
+
+    vectors_2d = np.array(all_embeddings, dtype=np.float32)   # (N, 768)
+    blobs = ctype.serialize_numpy_bulk(vectors_2d)             # list[bytes]
+
+    for key, blob in zip(keys, blobs):
+        session.execute(insert_stmt, [key, blob])
+
+Each ``bytes`` object in the returned list is accepted directly by the
+driver's bytes-passthrough path, so ``BoundStatement.bind()`` performs no
+further conversion.
+
+**Supported subtypes** – the fast paths are available for ``float``
+(``>f4``), ``double`` (``>f8``), ``int`` (``>i4``), and ``bigint``
+(``>i8``).  All other subtypes (including the fixed-width CQL types
+``smallint`` and ``tinyint``) lack the fast path because their
+``serial_size()`` returns ``None`` in this driver, so the vector wire
+format uses per-element length prefixes and they fall back to the
+original element-by-element serialization automatically.
+
+For the fast path the ndarray dtype must be safely castable to the
+subtype's wire dtype - e.g. ``np.random.rand`` returns ``float64``, so
+cast to ``float32`` for a ``vector<float, N>`` column as shown above.
+If the dtype is not safely castable, ``serialize()`` falls back to
+element-by-element serialization and ``serialize_numpy_bulk()`` raises
+``TypeError``.
+
+**Benchmarks** – on 768-dimension ``float32`` vectors (100-row batches),
+the bulk path is ~146× faster than the baseline, and the bytes
+passthrough path is ~298× faster.  See
+``benchmarks/bench_vector_numpy_serialize.py`` for reproducible numbers.

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1117,3 +1117,358 @@ class TestOrdering(unittest.TestCase):
         tokens_equal = [Token(1), Token(1)]
         check_sequence_consistency(tokens)
         check_sequence_consistency(tokens_equal, equal=True)
+
+
+
+try:
+    import numpy as np
+
+    _HAVE_NUMPY = True
+except ImportError:
+    _HAVE_NUMPY = False
+
+
+@unittest.skipUnless(_HAVE_NUMPY, "NumPy not installed")
+class VectorNumpySerializeTests(unittest.TestCase):
+    """Tests for NumPy fast path in VectorType.serialize()."""
+
+    FLOAT_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 4)"
+    DOUBLE_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.DoubleType, 4)"
+    INT32_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.Int32Type, 4)"
+    BIGINT_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.LongType, 4)"
+
+    def _get_ctype(self, ctype_str):
+        return parse_casstype_args(ctype_str)
+
+    # -- NumPy dtype is cached in the parameterized subclass --
+
+    def test_numpy_dtype_cached_for_float(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        self.assertEqual(ctype._numpy_dtype, np.dtype(">f4"))
+
+    def test_numpy_dtype_cached_for_double(self):
+        ctype = self._get_ctype(self.DOUBLE_CTYPE)
+        self.assertEqual(ctype._numpy_dtype, np.dtype(">f8"))
+
+    def test_numpy_dtype_cached_for_int32(self):
+        ctype = self._get_ctype(self.INT32_CTYPE)
+        self.assertEqual(ctype._numpy_dtype, np.dtype(">i4"))
+
+    def test_numpy_dtype_cached_for_bigint(self):
+        ctype = self._get_ctype(self.BIGINT_CTYPE)
+        self.assertEqual(ctype._numpy_dtype, np.dtype(">i8"))
+
+    def test_numpy_dtype_none_for_variable_size_numeric_subtype(self):
+        """ShortType/ByteType have no fixed serial_size(), so numpy fast path is disabled."""
+        for ctype_str in [
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.ShortType, 4)",
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.ByteType, 4)",
+        ]:
+            ctype = self._get_ctype(ctype_str)
+            self.assertIsNone(ctype._numpy_dtype)
+
+    def test_numpy_dtype_none_for_unsupported_subtype(self):
+        """Subtypes without a fixed-size wire format (e.g. AsciiType) should have _numpy_dtype = None."""
+        ctype = self._get_ctype(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.AsciiType, 4)"
+        )
+        self.assertIsNone(ctype._numpy_dtype)
+
+    # -- NumPy fast path: correctness (result matches list path) --
+
+    def test_numpy_float32_matches_list_serialize(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        data = [1.0, 2.0, 3.0, 4.0]
+        list_result = ctype.serialize(data, 4)
+        arr = np.array(data, dtype=np.float32)
+        numpy_result = ctype.serialize(arr, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    def test_numpy_float64_matches_list_serialize(self):
+        ctype = self._get_ctype(self.DOUBLE_CTYPE)
+        data = [1.5, 2.5, 3.5, 4.5]
+        list_result = ctype.serialize(data, 4)
+        arr = np.array(data, dtype=np.float64)
+        numpy_result = ctype.serialize(arr, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    def test_numpy_int32_matches_list_serialize(self):
+        ctype = self._get_ctype(self.INT32_CTYPE)
+        data = [10, 20, 30, 40]
+        list_result = ctype.serialize(data, 4)
+        arr = np.array(data, dtype=np.int32)
+        numpy_result = ctype.serialize(arr, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    def test_numpy_bigint_matches_list_serialize(self):
+        ctype = self._get_ctype(self.BIGINT_CTYPE)
+        data = [100, 200, 300, 400]
+        list_result = ctype.serialize(data, 4)
+        arr = np.array(data, dtype=np.int64)
+        numpy_result = ctype.serialize(arr, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    # -- NumPy fast path: safe dtype widening (no precision loss) --
+
+    def test_numpy_widens_float32_to_float64(self):
+        """float32 -> float64 is a safe widening conversion, should work."""
+        ctype = self._get_ctype(self.DOUBLE_CTYPE)
+        data = [1.0, 2.0, 3.0, 4.0]
+        list_result = ctype.serialize(data, 4)
+        arr_f32 = np.array(data, dtype=np.float32)
+        numpy_result = ctype.serialize(arr_f32, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    def test_numpy_widens_int32_to_int64(self):
+        """int32 -> int64 is a safe widening conversion, should work."""
+        ctype = self._get_ctype(self.BIGINT_CTYPE)
+        data = [10, 20, 30, 40]
+        list_result = ctype.serialize(data, 4)
+        arr_i32 = np.array(data, dtype=np.int32)
+        numpy_result = ctype.serialize(arr_i32, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    # -- NumPy fast path: unsafe dtype narrowing raises TypeError --
+
+    def test_numpy_rejects_float64_to_float32(self):
+        """float64 -> float32 is an unsafe narrowing, should raise TypeError."""
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr_f64 = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
+        with pytest.raises(TypeError, match="Unsafe dtype conversion"):
+            ctype.serialize(arr_f64, 4)
+
+    def test_numpy_rejects_int64_to_int32(self):
+        """int64 -> int32 is an unsafe narrowing, should raise TypeError."""
+        ctype = self._get_ctype(self.INT32_CTYPE)
+        arr_i64 = np.array([10, 20, 30, 40], dtype=np.int64)
+        with pytest.raises(TypeError, match="Unsafe dtype conversion"):
+            ctype.serialize(arr_i64, 4)
+
+    # -- NumPy fast path: round-trip (serialize -> deserialize) --
+
+    def test_numpy_round_trip_float(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        data = np.array([1.5, 2.5, 3.5, 4.5], dtype=np.float32)
+        serialized = ctype.serialize(data, 4)
+        deserialized = ctype.deserialize(serialized, 4)
+        np.testing.assert_allclose(deserialized, data, rtol=1e-5)
+
+    def test_numpy_round_trip_double(self):
+        ctype = self._get_ctype(self.DOUBLE_CTYPE)
+        data = np.array([1.5, 2.5, 3.5, 4.5], dtype=np.float64)
+        serialized = ctype.serialize(data, 4)
+        deserialized = ctype.deserialize(serialized, 4)
+        np.testing.assert_allclose(deserialized, data, rtol=1e-10)
+
+    # -- NumPy fast path: error cases --
+
+    def test_numpy_wrong_shape_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr = np.array([1.0, 2.0, 3.0], dtype=np.float32)  # 3 elements, expected 4
+        with pytest.raises(ValueError, match="Expected ndarray of shape"):
+            ctype.serialize(arr, 4)
+
+    def test_numpy_2d_array_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32)  # 2D
+        with pytest.raises(ValueError, match="Expected ndarray of shape"):
+            ctype.serialize(arr, 4)
+
+    def test_numpy_falls_back_to_list_for_unsupported_subtype(self):
+        """For subtypes without a NumPy dtype mapping, ndarray input should fall through to the list path."""
+        ctype = self._get_ctype(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.AsciiType, 3)"
+        )
+        arr = np.array(["abc", "def", "ghi"], dtype=object)
+        result = ctype.serialize(arr, 4)
+        list_result = ctype.serialize(["abc", "def", "ghi"], 4)
+        self.assertEqual(result, list_result)
+
+
+@unittest.skipUnless(_HAVE_NUMPY, "NumPy not installed")
+class VectorBytesPassthroughTests(unittest.TestCase):
+    """Tests for bytes/bytearray passthrough in VectorType.serialize()."""
+
+    FLOAT_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 4)"
+
+    def _get_ctype(self, ctype_str):
+        return parse_casstype_args(ctype_str)
+
+    def test_bytes_passthrough_exact_size(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        original = ctype.serialize([1.0, 2.0, 3.0, 4.0], 4)
+        passthrough = ctype.serialize(original, 4)
+        self.assertEqual(original, passthrough)
+
+    def test_bytearray_passthrough(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        original = ctype.serialize([1.0, 2.0, 3.0, 4.0], 4)
+        ba = bytearray(original)
+        passthrough = ctype.serialize(ba, 4)
+        self.assertEqual(original, passthrough)
+        self.assertIsInstance(passthrough, bytes)
+
+    def test_bytes_wrong_size_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        with pytest.raises(ValueError, match="Pre-serialized bytes"):
+            ctype.serialize(b"\x00" * 12, 4)  # 12 bytes, expected 16
+
+    def test_bytes_passthrough_round_trip(self):
+        """Bytes from serialize_numpy_bulk flow through BoundStatement.bind() without double-serialization."""
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32)
+        bulk = ctype.serialize_numpy_bulk(arr)
+        re_serialized = ctype.serialize(bulk[0], 4)
+        self.assertEqual(bulk[0], re_serialized)
+        deserialized = ctype.deserialize(re_serialized, 4)
+        np.testing.assert_allclose(deserialized, [1.0, 2.0, 3.0, 4.0], rtol=1e-5)
+
+    def test_bytes_not_intercepted_for_unsupported_subtype(self):
+        """Bytes passed to a variable-size vector should NOT be intercepted by the passthrough path."""
+        ctype = self._get_ctype(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.AsciiType, 3)"
+        )
+        with pytest.raises((ValueError, TypeError)):
+            ctype.serialize(b"\x00" * 10, 4)
+
+
+@unittest.skipUnless(_HAVE_NUMPY, "NumPy not installed")
+class VectorSerializeNumpyBulkTests(unittest.TestCase):
+    """Tests for VectorType.serialize_numpy_bulk()."""
+
+    FLOAT_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 4)"
+    DOUBLE_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.DoubleType, 3)"
+    INT32_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.Int32Type, 4)"
+
+    def _get_ctype(self, ctype_str):
+        return parse_casstype_args(ctype_str)
+
+    def test_bulk_float32_matches_individual(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.array(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
+            dtype=np.float32,
+        )
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 3)
+        for i in range(3):
+            individual = ctype.serialize(vectors[i], 4)
+            self.assertEqual(bulk[i], individual)
+
+    def test_bulk_float64_matches_individual(self):
+        ctype = self._get_ctype(self.DOUBLE_CTYPE)
+        vectors = np.array([[1.5, 2.5, 3.5], [4.5, 5.5, 6.5]], dtype=np.float64)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 2)
+        for i in range(2):
+            individual = ctype.serialize(vectors[i], 4)
+            self.assertEqual(bulk[i], individual)
+
+    def test_bulk_int32_matches_individual(self):
+        ctype = self._get_ctype(self.INT32_CTYPE)
+        vectors = np.array([[10, 20, 30, 40], [50, 60, 70, 80]], dtype=np.int32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 2)
+        for i in range(2):
+            individual = ctype.serialize(vectors[i], 4)
+            self.assertEqual(bulk[i], individual)
+
+    def test_bulk_widens_int32_to_int64(self):
+        """Widening int32 -> int64 should work in bulk path."""
+        ctype = self._get_ctype(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.LongType, 4)"
+        )
+        vectors = np.array([[10, 20, 30, 40]], dtype=np.int32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        individual = ctype.serialize(np.array([10, 20, 30, 40], dtype=np.int32), 4)
+        self.assertEqual(bulk[0], individual)
+
+    def test_bulk_rejects_float64_to_float32(self):
+        """float64 -> float32 is unsafe narrowing, should raise TypeError."""
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float64)
+        with pytest.raises(TypeError, match="Unsafe dtype conversion"):
+            ctype.serialize_numpy_bulk(vectors)
+
+    def test_bulk_rejects_int64_to_int32(self):
+        """int64 -> int32 is unsafe narrowing, should raise TypeError."""
+        ctype = self._get_ctype(self.INT32_CTYPE)
+        vectors = np.array([[10, 20, 30, 40]], dtype=np.int64)
+        with pytest.raises(TypeError, match="Unsafe dtype conversion"):
+            ctype.serialize_numpy_bulk(vectors)
+
+    def test_bulk_round_trip(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.random.rand(100, 4).astype(np.float32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        for i in range(100):
+            deserialized = ctype.deserialize(bulk[i], 4)
+            np.testing.assert_allclose(deserialized, vectors[i], rtol=1e-5)
+
+    def test_bulk_single_row(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 1)
+
+    def test_bulk_empty_array(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.empty((0, 4), dtype=np.float32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 0)
+
+    def test_bulk_fortran_order_array(self):
+        """Column-major (Fortran) arrays should be handled correctly."""
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors_c = np.array(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], dtype=np.float32, order="C"
+        )
+        vectors_f = np.asfortranarray(vectors_c)
+        self.assertFalse(vectors_f.flags["C_CONTIGUOUS"])
+        bulk_c = ctype.serialize_numpy_bulk(vectors_c)
+        bulk_f = ctype.serialize_numpy_bulk(vectors_f)
+        self.assertEqual(bulk_c, bulk_f)
+
+    def test_bulk_large_batch(self):
+        """Stress test with a realistic embedding size (768-dim, 10K rows)."""
+        ctype = parse_casstype_args(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 768)"
+        )
+        vectors = np.random.rand(10000, 768).astype(np.float32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 10000)
+        self.assertEqual(len(bulk[0]), 768 * 4)
+        np.testing.assert_allclose(ctype.deserialize(bulk[0], 4), vectors[0], rtol=1e-5)
+        np.testing.assert_allclose(
+            ctype.deserialize(bulk[-1], 4), vectors[-1], rtol=1e-5
+        )
+
+    def test_bulk_wrong_dimension_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+        with pytest.raises(ValueError, match="Expected array with 4 columns"):
+            ctype.serialize_numpy_bulk(vectors)
+
+    def test_bulk_1d_array_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+        with pytest.raises(ValueError, match="Expected a 2-D NumPy array"):
+            ctype.serialize_numpy_bulk(arr)
+
+    def test_bulk_3d_array_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr = np.ones((2, 4, 3), dtype=np.float32)
+        with pytest.raises(ValueError, match="Expected a 2-D NumPy array"):
+            ctype.serialize_numpy_bulk(arr)
+
+    def test_bulk_unsupported_subtype_raises(self):
+        ctype = self._get_ctype(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.AsciiType, 4)"
+        )
+        with pytest.raises(TypeError, match="serialize_numpy_bulk.*is not supported"):
+            ctype.serialize_numpy_bulk(np.array([["a", "b", "c", "d"]], dtype=object))
+
+    def test_bulk_non_array_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        with pytest.raises(ValueError, match="Expected a 2-D NumPy array"):
+            ctype.serialize_numpy_bulk([[1.0, 2.0, 3.0, 4.0]])

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1117,3 +1117,472 @@ class TestOrdering(unittest.TestCase):
         tokens_equal = [Token(1), Token(1)]
         check_sequence_consistency(tokens)
         check_sequence_consistency(tokens_equal, equal=True)
+
+
+
+try:
+    import numpy as np
+
+    _HAVE_NUMPY = True
+except ImportError:
+    _HAVE_NUMPY = False
+
+
+@unittest.skipUnless(_HAVE_NUMPY, "NumPy not installed")
+class VectorNumpySerializeTests(unittest.TestCase):
+    """Tests for NumPy fast path in VectorType.serialize()."""
+
+    FLOAT_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 4)"
+    DOUBLE_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.DoubleType, 4)"
+    INT32_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.Int32Type, 4)"
+    BIGINT_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.LongType, 4)"
+
+    def _get_ctype(self, ctype_str):
+        return parse_casstype_args(ctype_str)
+
+    # -- NumPy dtype is cached in the parameterized subclass --
+
+    def test_numpy_dtype_cached_for_float(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        self.assertEqual(ctype._numpy_dtype, np.dtype(">f4"))
+
+    def test_numpy_dtype_cached_for_double(self):
+        ctype = self._get_ctype(self.DOUBLE_CTYPE)
+        self.assertEqual(ctype._numpy_dtype, np.dtype(">f8"))
+
+    def test_numpy_dtype_cached_for_int32(self):
+        ctype = self._get_ctype(self.INT32_CTYPE)
+        self.assertEqual(ctype._numpy_dtype, np.dtype(">i4"))
+
+    def test_numpy_dtype_cached_for_bigint(self):
+        ctype = self._get_ctype(self.BIGINT_CTYPE)
+        self.assertEqual(ctype._numpy_dtype, np.dtype(">i8"))
+
+    def test_numpy_dtype_none_for_variable_size_numeric_subtype(self):
+        """ShortType/ByteType have no fixed serial_size(), so numpy fast path is disabled."""
+        for ctype_str in [
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.ShortType, 4)",
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.ByteType, 4)",
+        ]:
+            ctype = self._get_ctype(ctype_str)
+            self.assertIsNone(ctype._numpy_dtype)
+
+    def test_numpy_dtype_none_for_unsupported_subtype(self):
+        """Subtypes without a fixed-size wire format (e.g. AsciiType) should have _numpy_dtype = None."""
+        ctype = self._get_ctype(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.AsciiType, 4)"
+        )
+        self.assertIsNone(ctype._numpy_dtype)
+
+    # -- NumPy fast path: correctness (result matches list path) --
+
+    def test_numpy_float32_matches_list_serialize(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        data = [1.0, 2.0, 3.0, 4.0]
+        list_result = ctype.serialize(data, 4)
+        arr = np.array(data, dtype=np.float32)
+        numpy_result = ctype.serialize(arr, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    def test_numpy_float64_matches_list_serialize(self):
+        ctype = self._get_ctype(self.DOUBLE_CTYPE)
+        data = [1.5, 2.5, 3.5, 4.5]
+        list_result = ctype.serialize(data, 4)
+        arr = np.array(data, dtype=np.float64)
+        numpy_result = ctype.serialize(arr, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    def test_numpy_int32_matches_list_serialize(self):
+        ctype = self._get_ctype(self.INT32_CTYPE)
+        data = [10, 20, 30, 40]
+        list_result = ctype.serialize(data, 4)
+        arr = np.array(data, dtype=np.int32)
+        numpy_result = ctype.serialize(arr, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    def test_numpy_bigint_matches_list_serialize(self):
+        ctype = self._get_ctype(self.BIGINT_CTYPE)
+        data = [100, 200, 300, 400]
+        list_result = ctype.serialize(data, 4)
+        arr = np.array(data, dtype=np.int64)
+        numpy_result = ctype.serialize(arr, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    # -- NumPy fast path: safe dtype widening (no precision loss) --
+
+    def test_numpy_widens_float32_to_float64(self):
+        """float32 -> float64 is a safe widening conversion, should work."""
+        ctype = self._get_ctype(self.DOUBLE_CTYPE)
+        data = [1.0, 2.0, 3.0, 4.0]
+        list_result = ctype.serialize(data, 4)
+        arr_f32 = np.array(data, dtype=np.float32)
+        numpy_result = ctype.serialize(arr_f32, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    def test_numpy_widens_int32_to_int64(self):
+        """int32 -> int64 is a safe widening conversion, should work."""
+        ctype = self._get_ctype(self.BIGINT_CTYPE)
+        data = [10, 20, 30, 40]
+        list_result = ctype.serialize(data, 4)
+        arr_i32 = np.array(data, dtype=np.int32)
+        numpy_result = ctype.serialize(arr_i32, 4)
+        self.assertEqual(list_result, numpy_result)
+
+    # -- NumPy fast path: unsafe dtype falls back to element-by-element --
+
+    def test_numpy_falls_back_to_elementwise_for_float64(self):
+        """float64 -> float32 is unsafe, so serialize() falls back to the element-by-element path."""
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr_f64 = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
+        result = ctype.serialize(arr_f64, 4)
+        self.assertEqual(result, ctype.serialize([1.0, 2.0, 3.0, 4.0], 4))
+
+    def test_numpy_falls_back_to_elementwise_for_int64(self):
+        """int64 -> int32 is unsafe, so serialize() falls back to the element-by-element path."""
+        ctype = self._get_ctype(self.INT32_CTYPE)
+        arr_i64 = np.array([10, 20, 30, 40], dtype=np.int64)
+        result = ctype.serialize(arr_i64, 4)
+        self.assertEqual(result, ctype.serialize([10, 20, 30, 40], 4))
+
+    def test_numpy_falls_back_to_elementwise_for_object_dtype(self):
+        """Object-dtype arrays cannot be cast safely; fall back to the element-by-element path."""
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr_obj = np.array([1.0, 2.0, 3.0, 4.0], dtype=object)
+        result = ctype.serialize(arr_obj, 4)
+        self.assertEqual(result, ctype.serialize([1.0, 2.0, 3.0, 4.0], 4))
+
+    # -- NumPy fast path: round-trip (serialize -> deserialize) --
+
+    def test_numpy_round_trip_float(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        data = np.array([1.5, 2.5, 3.5, 4.5], dtype=np.float32)
+        serialized = ctype.serialize(data, 4)
+        deserialized = ctype.deserialize(serialized, 4)
+        np.testing.assert_allclose(deserialized, data, rtol=1e-5)
+
+    def test_numpy_round_trip_double(self):
+        ctype = self._get_ctype(self.DOUBLE_CTYPE)
+        data = np.array([1.5, 2.5, 3.5, 4.5], dtype=np.float64)
+        serialized = ctype.serialize(data, 4)
+        deserialized = ctype.deserialize(serialized, 4)
+        np.testing.assert_allclose(deserialized, data, rtol=1e-10)
+
+    # -- NumPy fast path: error cases --
+
+    def test_numpy_wrong_shape_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr = np.array([1.0, 2.0, 3.0], dtype=np.float32)  # 3 elements, expected 4
+        with pytest.raises(ValueError, match="Expected ndarray of shape"):
+            ctype.serialize(arr, 4)
+
+    def test_numpy_2d_array_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32)  # 2D
+        with pytest.raises(ValueError, match="Expected ndarray of shape"):
+            ctype.serialize(arr, 4)
+
+    def test_numpy_falls_back_to_list_for_unsupported_subtype(self):
+        """For subtypes without a NumPy dtype mapping, ndarray input should fall through to the list path."""
+        ctype = self._get_ctype(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.AsciiType, 3)"
+        )
+        arr = np.array(["abc", "def", "ghi"], dtype=object)
+        result = ctype.serialize(arr, 4)
+        list_result = ctype.serialize(["abc", "def", "ghi"], 4)
+        self.assertEqual(result, list_result)
+
+
+class VectorBytesPassthroughTests(unittest.TestCase):
+    """Tests for bytes/bytearray passthrough in VectorType.serialize()."""
+
+    FLOAT_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 4)"
+
+    def _get_ctype(self, ctype_str):
+        return parse_casstype_args(ctype_str)
+
+    def test_bytes_passthrough_exact_size(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        original = ctype.serialize([1.0, 2.0, 3.0, 4.0], 4)
+        passthrough = ctype.serialize(original, 4)
+        self.assertEqual(original, passthrough)
+
+    def test_bytearray_passthrough(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        original = ctype.serialize([1.0, 2.0, 3.0, 4.0], 4)
+        ba = bytearray(original)
+        passthrough = ctype.serialize(ba, 4)
+        self.assertEqual(original, passthrough)
+        self.assertIsInstance(passthrough, bytes)
+
+    def test_bytes_wrong_size_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        with pytest.raises(ValueError, match="Pre-serialized bytes"):
+            ctype.serialize(b"\x00" * 12, 4)  # 12 bytes, expected 16
+
+    @unittest.skipUnless(_HAVE_NUMPY, "NumPy not installed")
+    def test_bytes_passthrough_round_trip(self):
+        """Bytes from serialize_numpy_bulk flow through BoundStatement.bind() without double-serialization."""
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32)
+        bulk = ctype.serialize_numpy_bulk(arr)
+        re_serialized = ctype.serialize(bulk[0], 4)
+        self.assertEqual(bulk[0], re_serialized)
+        deserialized = ctype.deserialize(re_serialized, 4)
+        np.testing.assert_allclose(deserialized, [1.0, 2.0, 3.0, 4.0], rtol=1e-5)
+
+    def test_bytes_rejected_for_variable_size_subtype(self):
+        """Raw bytes for a variable-size subtype have no fixed length to validate; raise TypeError."""
+        ctype = self._get_ctype(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.AsciiType, 3)"
+        )
+        with pytest.raises(TypeError, match="Pre-serialized bytes"):
+            ctype.serialize(b"\x00" * 10, 4)
+
+
+class VectorBytesPassthroughWithoutNumpyTests(unittest.TestCase):
+    """Regression tests for bytes/bytearray passthrough in
+    ``VectorType.serialize()`` when NumPy is not available.
+
+    ``apply_parameters()`` only populates ``cls._numpy_dtype`` when
+    ``_HAVE_NUMPY`` is ``True`` (see cqltypes.py). Gating the
+    bytes/bytearray passthrough on ``cls._numpy_dtype`` therefore made it
+    silently unusable on installs without NumPy: correctly pre-serialized
+    bytes would fall into the element-by-element path and raise a
+    misleading "vector length" error instead of just passing through.
+
+    These tests run unconditionally - they do not require NumPy to be
+    installed - and simulate its absence by clearing the cached dtype on
+    the parameterized class after construction, i.e. exactly what
+    ``apply_parameters()`` would have produced had ``_HAVE_NUMPY`` been
+    ``False`` when the class was built.
+    """
+
+    FLOAT_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 4)"
+
+    def _get_ctype_without_numpy_dtype(self, ctype_str):
+        ctype = parse_casstype_args(ctype_str)
+        ctype._numpy_dtype = None
+        return ctype
+
+    def test_bytes_passthrough_without_numpy_dtype(self):
+        ctype = self._get_ctype_without_numpy_dtype(self.FLOAT_CTYPE)
+        self.assertIsNone(ctype._numpy_dtype)
+        original = ctype.serialize([1.0, 2.0, 3.0, 4.0], 4)  # element-by-element path
+        passthrough = ctype.serialize(original, 4)
+        self.assertEqual(original, passthrough)
+
+    def test_bytearray_passthrough_without_numpy_dtype(self):
+        ctype = self._get_ctype_without_numpy_dtype(self.FLOAT_CTYPE)
+        original = ctype.serialize([1.0, 2.0, 3.0, 4.0], 4)
+        ba_passthrough = ctype.serialize(bytearray(original), 4)
+        self.assertEqual(original, ba_passthrough)
+        self.assertIsInstance(ba_passthrough, bytes)
+
+    def test_bytes_wrong_size_raises_without_numpy_dtype(self):
+        """Even without a NumPy dtype, wrong-length bytes should still hit
+        the passthrough's own length check. The misleading pre-fix
+        behavior was to instead fall through to the element-by-element
+        path and raise a confusing "sequence length" error."""
+        ctype = self._get_ctype_without_numpy_dtype(self.FLOAT_CTYPE)
+        with pytest.raises(ValueError, match="Pre-serialized bytes"):
+            ctype.serialize(b"\x00" * 12, 4)  # 12 bytes, expected 16
+
+
+@unittest.skipUnless(_HAVE_NUMPY, "NumPy not installed")
+class VectorSerializeNumpyBulkTests(unittest.TestCase):
+    """Tests for VectorType.serialize_numpy_bulk()."""
+
+    FLOAT_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 4)"
+    DOUBLE_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.DoubleType, 3)"
+    INT32_CTYPE = "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.Int32Type, 4)"
+
+    def _get_ctype(self, ctype_str):
+        return parse_casstype_args(ctype_str)
+
+    def test_bulk_float32_matches_individual(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.array(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
+            dtype=np.float32,
+        )
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 3)
+        for i in range(3):
+            individual = ctype.serialize(vectors[i], 4)
+            self.assertEqual(bulk[i], individual)
+
+    def test_bulk_float64_matches_individual(self):
+        ctype = self._get_ctype(self.DOUBLE_CTYPE)
+        vectors = np.array([[1.5, 2.5, 3.5], [4.5, 5.5, 6.5]], dtype=np.float64)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 2)
+        for i in range(2):
+            individual = ctype.serialize(vectors[i], 4)
+            self.assertEqual(bulk[i], individual)
+
+    def test_bulk_int32_matches_individual(self):
+        ctype = self._get_ctype(self.INT32_CTYPE)
+        vectors = np.array([[10, 20, 30, 40], [50, 60, 70, 80]], dtype=np.int32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 2)
+        for i in range(2):
+            individual = ctype.serialize(vectors[i], 4)
+            self.assertEqual(bulk[i], individual)
+
+    def test_bulk_widens_int32_to_int64(self):
+        """Widening int32 -> int64 should work in bulk path."""
+        ctype = self._get_ctype(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.LongType, 4)"
+        )
+        vectors = np.array([[10, 20, 30, 40]], dtype=np.int32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        individual = ctype.serialize(np.array([10, 20, 30, 40], dtype=np.int32), 4)
+        self.assertEqual(bulk[0], individual)
+
+    def test_bulk_rejects_float64_to_float32(self):
+        """float64 -> float32 is unsafe narrowing, should raise TypeError."""
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float64)
+        with pytest.raises(TypeError, match="Unsafe dtype conversion"):
+            ctype.serialize_numpy_bulk(vectors)
+
+    def test_bulk_rejects_int64_to_int32(self):
+        """int64 -> int32 is unsafe narrowing, should raise TypeError."""
+        ctype = self._get_ctype(self.INT32_CTYPE)
+        vectors = np.array([[10, 20, 30, 40]], dtype=np.int64)
+        with pytest.raises(TypeError, match="Unsafe dtype conversion"):
+            ctype.serialize_numpy_bulk(vectors)
+
+    def test_bulk_round_trip(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.random.rand(100, 4).astype(np.float32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        for i in range(100):
+            deserialized = ctype.deserialize(bulk[i], 4)
+            np.testing.assert_allclose(deserialized, vectors[i], rtol=1e-5)
+
+    def test_bulk_single_row(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 1)
+
+    def test_bulk_empty_array(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.empty((0, 4), dtype=np.float32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 0)
+
+    def test_bulk_fortran_order_array(self):
+        """Column-major (Fortran) arrays should be handled correctly."""
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors_c = np.array(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], dtype=np.float32, order="C"
+        )
+        vectors_f = np.asfortranarray(vectors_c)
+        self.assertFalse(vectors_f.flags["C_CONTIGUOUS"])
+        bulk_c = ctype.serialize_numpy_bulk(vectors_c)
+        bulk_f = ctype.serialize_numpy_bulk(vectors_f)
+        self.assertEqual(bulk_c, bulk_f)
+
+    @staticmethod
+    def _old_serialize_numpy_bulk(ctype, vectors):
+        """Reference re-implementation of the pre-fix ``serialize_numpy_bulk()``
+        body: a single ``raw = arr.tobytes()`` allocation for the whole
+        batch, followed by per-row ``bytes`` slices cut out of it. Used only
+        to prove that the memory-optimized implementation in cqltypes.py
+        (which copies each row directly out of a C-contiguous array without
+        that intermediate ``raw`` buffer) is byte-for-byte equivalent."""
+        arr = np.asarray(vectors, dtype=ctype._numpy_dtype)
+        row_bytes = ctype._numpy_dtype.itemsize * ctype.vector_size
+        raw = arr.tobytes()
+        return [raw[i * row_bytes:(i + 1) * row_bytes] for i in range(arr.shape[0])]
+
+    def test_bulk_matches_old_full_buffer_implementation(self):
+        """serialize_numpy_bulk() was changed to avoid materializing one
+        large `raw = arr.tobytes()` buffer for the whole batch before
+        slicing per-row copies out of it, to reduce peak memory for large
+        batches. Confirm the new implementation still produces
+        byte-for-byte identical output to the original one, across dtypes,
+        batch sizes, and memory layouts (not just "doesn't crash")."""
+        rng = np.random.RandomState(42)
+        cases = [
+            (self.FLOAT_CTYPE, np.float32, (1, 4)),
+            (self.FLOAT_CTYPE, np.float32, (5, 4)),
+            (self.FLOAT_CTYPE, np.float32, (200, 4)),
+            (self.DOUBLE_CTYPE, np.float64, (7, 3)),
+            (self.INT32_CTYPE, np.int32, (11, 4)),
+        ]
+        for ctype_str, dtype, shape in cases:
+            ctype = self._get_ctype(ctype_str)
+            if np.issubdtype(dtype, np.integer):
+                vectors = rng.randint(-1000, 1000, size=shape).astype(dtype)
+            else:
+                vectors = rng.rand(*shape).astype(dtype)
+            expected = self._old_serialize_numpy_bulk(ctype, vectors)
+            actual = ctype.serialize_numpy_bulk(vectors)
+            self.assertEqual(
+                expected, actual,
+                "mismatch between old and new serialize_numpy_bulk() for "
+                "%s shape=%s" % (ctype_str, shape))
+
+        # Fortran-ordered (non-contiguous) input is the case most likely to
+        # reveal a divergence, since the fix explicitly forces C-contiguity
+        # before slicing rows out of the buffer.
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors_c = rng.rand(6, 4).astype(np.float32)
+        vectors_f = np.asfortranarray(vectors_c)
+        self.assertFalse(vectors_f.flags['C_CONTIGUOUS'])
+        expected = self._old_serialize_numpy_bulk(ctype, vectors_f)
+        actual = ctype.serialize_numpy_bulk(vectors_f)
+        self.assertEqual(expected, actual)
+
+    def test_bulk_large_batch(self):
+        """Sanity check with a realistic (if modestly sized) embedding batch:
+        128-dim rows, 256 rows. Kept deliberately small - this test only
+        needs to confirm correctness across many rows, not exercise
+        large-batch-specific behavior, so a smaller size avoids the extra
+        CI runtime/memory of a 10K x 768 array while still meaningfully
+        validating the round trip for the first and last rows of a
+        multi-row batch."""
+        ctype = parse_casstype_args(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType, 128)"
+        )
+        vectors = np.random.rand(256, 128).astype(np.float32)
+        bulk = ctype.serialize_numpy_bulk(vectors)
+        self.assertEqual(len(bulk), 256)
+        self.assertEqual(len(bulk[0]), 128 * 4)
+        np.testing.assert_allclose(ctype.deserialize(bulk[0], 4), vectors[0], rtol=1e-5)
+        np.testing.assert_allclose(
+            ctype.deserialize(bulk[-1], 4), vectors[-1], rtol=1e-5
+        )
+
+    def test_bulk_wrong_dimension_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        vectors = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+        with pytest.raises(ValueError, match="Expected array with 4 columns"):
+            ctype.serialize_numpy_bulk(vectors)
+
+    def test_bulk_1d_array_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+        with pytest.raises(ValueError, match="Expected a 2-D NumPy array"):
+            ctype.serialize_numpy_bulk(arr)
+
+    def test_bulk_3d_array_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        arr = np.ones((2, 4, 3), dtype=np.float32)
+        with pytest.raises(ValueError, match="Expected a 2-D NumPy array"):
+            ctype.serialize_numpy_bulk(arr)
+
+    def test_bulk_unsupported_subtype_raises(self):
+        ctype = self._get_ctype(
+            "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.AsciiType, 4)"
+        )
+        with pytest.raises(TypeError, match=r"serialize_numpy_bulk\(\).*is not supported"):
+            ctype.serialize_numpy_bulk(np.array([["a", "b", "c", "d"]], dtype=object))
+
+    def test_bulk_non_array_raises(self):
+        ctype = self._get_ctype(self.FLOAT_CTYPE)
+        with pytest.raises(TypeError, match="Expected a 2-D NumPy array"):
+            ctype.serialize_numpy_bulk([[1.0, 2.0, 3.0, 4.0]])


### PR DESCRIPTION
## Summary

- Add three fast serialization paths to `VectorType` for fixed-size numeric subtypes (`float`, `double`, `int`, `bigint`), delivering **70–300× speedups** for high-dimensional vector inserts
- Add `serialize_numpy_bulk()` classmethod for batch workloads (e.g. loading embeddings from Parquet files in VectorDBBench)
- NumPy remains optional; all new code is guarded by `try/except ImportError`

## Motivation

The VectorDBBench use case (https://github.com/scylladb/VectorDBBench) pipelines data as `Parquet → PyArrow/NumPy → wire`. The existing `VectorType.serialize()` performed 768+ individual `struct.pack('>f', val)` + `BytesIO.write()` calls per vector, making serialization the bottleneck for bulk inserts.

## What's new

### Three fast paths in `VectorType.serialize()`:

1. **bytes/bytearray passthrough** – if the caller already holds a correctly-sized blob (e.g. from `serialize_numpy_bulk()`), return it directly with zero conversion
2. **NumPy ndarray fast path** – for a 1-D ndarray, byte-swap to big-endian via `np.asarray(v, dtype='>f4').tobytes()` instead of per-element struct.pack
3. **`serialize_numpy_bulk()` classmethod** – byte-swap an entire 2-D array `(N_rows × dim)` once and slice the raw buffer into a `list[bytes]`

### Benchmark results

768-dim float32, 100-row batches (Python 3.14, NumPy 2.3, best of 3):

| Method | ns/call | µs/row | Speedup |
|--------|---------|--------|---------|
| list (baseline) | 6,196,012 | 61.96 | 1× |
| numpy (per-row) | 85,245 | 0.85 | 73× |
| bulk (serialize_numpy_bulk) | 41,239 | 0.41 | 150× |
| bytes passthrough | 17,980 | 0.18 | 345× |
| bulk+passthrough (end-to-end) | 60,216 | 0.60 | 103× |

**In absolute terms:** serializing 100 × 768-dim float32 vectors drops from **~6.2 ms** (baseline) to **~60 µs** (bulk+passthrough end-to-end) — a **103× improvement**. The bottleneck was 76,800 individual `struct.pack('>f', val)` + `BytesIO.write()` calls (768 elements × 100 rows); NumPy replaces all of that with a single array byte-swap + buffer slice.

768-dim float32, single vector (latency per call):

| Method | ns/call | Speedup |
|--------|---------|---------|
| list (baseline) | 65,181 | 1× |
| numpy (per-row) | 963 | 68× |
| bytes passthrough | 237 | 275× |

**Per-vector latency:** a single 768-dim vector goes from **~65 µs** to under **1 µs** via the NumPy path, or **237 ns** if pre-serialized bytes are reused.

### Safety

- Variable-size subtypes (`smallint`, `tinyint`, text) are **excluded** from the fast path and continue to use the original element-by-element serialization
- Passing raw `bytes` for a variable-size subtype now raises `TypeError` explicitly (rather than silently falling through)
- `_numpy_dtype` is only set when `subtype.serial_size() is not None` and the typename is in the 4-entry `_NUMPY_DTYPE_MAP`
- Comprehensive unit tests (97 pass) cover correctness, round-trip fidelity, error handling, and fallback behavior

## Commits

1. **feat: NumPy-accelerated vector serialization** – all code + 97 unit tests
2. **bench: add vector NumPy serialization benchmark** – standalone benchmark script with ns/call column
3. **docs: document NumPy-accelerated vector serialization** – usage examples in `docs/performance.rst`