### PR TITLE
code: add __slots__ to _Frame to eliminate per-instance __dict__ (small memory/time win)

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -485,6 +485,8 @@ class ClientRoutesEndPoint(EndPoint):
 
 
 class _Frame(object):
+    __slots__ = ('version', 'flags', 'stream', 'opcode', 'body_offset', 'end_pos')
+
     def __init__(self, version, flags, stream, opcode, body_offset, end_pos):
         self.version = version
         self.flags = flags


### PR DESCRIPTION
## Summary

Add `__slots__` to the `_Frame` class in `cassandra/connection.py`. Eliminates per-instance `__dict__` allocation.

## Motivation

`_Frame` is instantiated for every response frame received from the server. It has exactly 6 fixed attributes (`version`, `flags`, `stream`, `opcode`, `body_offset`, `end_pos`) and is never monkey-patched or dynamically extended. Adding `__slots__` removes the per-instance `__dict__`, reducing memory pressure on high-throughput workloads.

## Benchmark (updated — see note below)

Original PR description quoted a per-call benchmark (CPython 3.14) showing 264 bytes / 76.7% memory savings and 28ns / 19% construction-time savings. That figure assumed a non-key-shared `__dict__`; it did not hold up on re-measurement.

Modern CPython (3.3+) uses key-sharing dictionaries (PEP 412): since `_Frame` sets the same attributes in the same order every time, instances of the same class share one keys table, so the per-instance `__dict__` cost is already much smaller than a standalone dict in practice. Re-measured on CPython 3.14 (`tracemalloc`/`timeit`, 500k iterations):

| | Size |
|---|---|
| Original (obj + shared-key `__dict__`) | ~128 bytes |
| Optimized (`__slots__`) | ~88 bytes |
| **Savings per frame** | **~40 bytes** |

| Operation | Original | Optimized | Savings per call |
|---|---|---|---|
| Construction | ~92-98ns | ~78ns | **~15-20ns** |

The direction of the claim (less time, less memory) holds, and `__slots__` remains the correct choice for a fixed-attribute class instantiated on every response frame — but the actual per-frame saving is roughly an order of magnitude smaller than originally quoted, since the baseline `__dict__` cost was already reduced by key-sharing.

## Changes

- `cassandra/connection.py`: Add `__slots__ = ('version', 'flags', 'stream', 'opcode', 'body_offset', 'end_pos')` to `_Frame`

## Testing

Unit tests pass (`test_connection.py`, `test_protocol.py`). Verified that `_Frame` instances no longer have `__dict__`.
