### PR TITLE
(improvement) Skip tuple(partial(...)) construction for empty callbacks/errbacks (190ns saving per call - 63%)

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5431,16 +5431,21 @@ class ResponseFuture(object):
             # -- prevents case where _final_result is set, then a callback is
             # added and executed on the spot, then executed again as a
             # registered callback
-            to_call = tuple(
-                partial(fn, response, *args, **kwargs)
-                for (fn, args, kwargs) in self._callbacks
-            )
+            callbacks = self._callbacks
+            if callbacks:
+                to_call = tuple(
+                    partial(fn, response, *args, **kwargs)
+                    for (fn, args, kwargs) in callbacks
+                )
+            else:
+                to_call = None
 
         self._event.set()
 
         # apply each callback
-        for callback_partial in to_call:
-            callback_partial()
+        if to_call:
+            for callback_partial in to_call:
+                callback_partial()
 
     def _set_final_exception(self, response):
         self._cancel_timer()
@@ -5453,15 +5458,20 @@ class ResponseFuture(object):
             # prevents case where _final_exception is set, then an errback is
             # added and executed on the spot, then executed again as a
             # registered errback
-            to_call = tuple(
-                partial(fn, response, *args, **kwargs)
-                for (fn, args, kwargs) in self._errbacks
-            )
+            errbacks = self._errbacks
+            if errbacks:
+                to_call = tuple(
+                    partial(fn, response, *args, **kwargs)
+                    for (fn, args, kwargs) in errbacks
+                )
+            else:
+                to_call = None
         self._event.set()
 
         # apply each callback
-        for callback_partial in to_call:
-            callback_partial()
+        if to_call:
+            for callback_partial in to_call:
+                callback_partial()
 
     def _handle_retry_decision(self, retry_decision, response, host):
 

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5471,16 +5471,21 @@ class ResponseFuture(object):
             # -- prevents case where _final_result is set, then a callback is
             # added and executed on the spot, then executed again as a
             # registered callback
-            to_call = tuple(
-                partial(fn, response, *args, **kwargs)
-                for (fn, args, kwargs) in self._callbacks
-            )
+            callbacks = self._callbacks
+            if callbacks:
+                to_call = tuple(
+                    partial(fn, response, *args, **kwargs)
+                    for (fn, args, kwargs) in callbacks
+                )
+            else:
+                to_call = None
 
         self._event.set()
 
         # apply each callback
-        for callback_partial in to_call:
-            callback_partial()
+        if to_call:
+            for callback_partial in to_call:
+                callback_partial()
 
     def _set_final_exception(self, response):
         self._cancel_timer()
@@ -5493,15 +5498,20 @@ class ResponseFuture(object):
             # prevents case where _final_exception is set, then an errback is
             # added and executed on the spot, then executed again as a
             # registered errback
-            to_call = tuple(
-                partial(fn, response, *args, **kwargs)
-                for (fn, args, kwargs) in self._errbacks
-            )
+            errbacks = self._errbacks
+            if errbacks:
+                to_call = tuple(
+                    partial(fn, response, *args, **kwargs)
+                    for (fn, args, kwargs) in errbacks
+                )
+            else:
+                to_call = None
         self._event.set()
 
         # apply each callback
-        for callback_partial in to_call:
-            callback_partial()
+        if to_call:
+            for callback_partial in to_call:
+                callback_partial()
 
     def _handle_retry_decision(self, retry_decision, response, host):
 


### PR DESCRIPTION
## Summary

In `_set_final_result` and `_set_final_exception`, skip building the `tuple(partial(fn, ...))` when the callbacks/errbacks list is empty. Most queries use the synchronous `result()` path and never register callbacks or errbacks.

## Motivation

Every query completion (`_set_final_result` / `_set_final_exception`) previously constructed a `tuple(partial(fn, response, *args, **kwargs) for ...)` from the callbacks/errbacks list, even when that list is empty. This creates an empty generator and an empty tuple on every query. The synchronous `result()` API (the overwhelmingly common usage pattern) never registers callbacks, so this work is wasted.

## Benchmark (CPython 3.14, per-call)

| Callback state | Original | Optimized | Savings per call |
|---|---|---|---|
| Empty (synchronous `result()`) | 304ns | 114ns | **190ns (63%)** |
| 1 callback (async path) | 562ns | 560ns | **2ns** (no regression) |

The synchronous `result()` API is the common path — this saves 190ns per query completion.

## Changes

- `cassandra/cluster.py`:
  - `_set_final_result`: Check `if callbacks:` before building `to_call`; set `to_call = None` otherwise
  - `_set_final_exception`: Same pattern for errbacks
  - Guard the application loop with `if to_call:` check

## Testing

Unit tests pass (58/58 in test_response_future.py and test_cluster.py). The lock semantics are preserved — the check and tuple construction still happen inside `_callback_lock`.