### PR TITLE
perf: result path memory allocation optimizations (mostly memory savings, 10's of ns improvements)

### DIFF
--- a/benchmarks/micro/bench_col_names_cache.py
+++ b/benchmarks/micro/bench_col_names_cache.py
@@ -1,0 +1,66 @@
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Micro-benchmark: column_names / column_types extraction from metadata.
+
+Measures the cost of building [c[2] for c in metadata] and [c[3] for c in metadata]
+vs using pre-cached lists (as done for prepared statements with result_metadata).
+
+Run:
+    python benchmarks/bench_col_names_cache.py
+"""
+
+import sys
+import timeit
+
+
+def make_column_metadata(ncols):
+    """Create fake column_metadata tuples like recv_results_metadata produces."""
+    class FakeType:
+        pass
+    return [(f"ks_{i}", f"tbl_{i}", f"col_{i}", FakeType) for i in range(ncols)]
+
+
+def bench():
+    for ncols in (5, 10, 20, 50):
+        metadata = make_column_metadata(ncols)
+
+        # Pre-cached (done once at prepare time)
+        cached_names = [c[2] for c in metadata]
+        cached_types = [c[3] for c in metadata]
+
+        def extract_uncached():
+            names = [c[2] for c in metadata]
+            types = [c[3] for c in metadata]
+            return names, types
+
+        def extract_cached():
+            return cached_names, cached_types
+
+        n = 500_000
+        t_uncached = timeit.timeit(extract_uncached, number=n)
+        t_cached = timeit.timeit(extract_cached, number=n)
+
+        saving_ns = (t_uncached - t_cached) / n * 1e9
+        speedup = t_uncached / t_cached if t_cached > 0 else float('inf')
+        print(f"  {ncols} cols: uncached={t_uncached / n * 1e9:.1f} ns, "
+              f"cached={t_cached / n * 1e9:.1f} ns, "
+              f"saving={saving_ns:.1f} ns ({speedup:.1f}x)")
+
+
+if __name__ == "__main__":
+    print(f"Python {sys.version}")
+    print("\n=== column_names / column_types extraction ===")
+    bench()

--- a/benchmarks/micro/bench_col_names_cache.py
+++ b/benchmarks/micro/bench_col_names_cache.py
@@ -1,0 +1,66 @@
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Micro-benchmark: column_names / column_types extraction from metadata.
+
+Measures the cost of building [c[2] for c in metadata] and [c[3] for c in metadata]
+vs using pre-cached lists (as done for prepared statements with result_metadata).
+
+Run:
+    python benchmarks/micro/bench_col_names_cache.py
+"""
+
+import sys
+import timeit
+
+
+def make_column_metadata(ncols):
+    """Create fake column_metadata tuples like recv_results_metadata produces."""
+    class FakeType:
+        pass
+    return [(f"ks_{i}", f"tbl_{i}", f"col_{i}", FakeType) for i in range(ncols)]
+
+
+def bench():
+    for ncols in (5, 10, 20, 50):
+        metadata = make_column_metadata(ncols)
+
+        # Pre-cached (done once at prepare time)
+        cached_names = [c[2] for c in metadata]
+        cached_types = [c[3] for c in metadata]
+
+        def extract_uncached():
+            names = [c[2] for c in metadata]
+            types = [c[3] for c in metadata]
+            return names, types
+
+        def extract_cached():
+            return cached_names, cached_types
+
+        n = 500_000
+        t_uncached = timeit.timeit(extract_uncached, number=n)
+        t_cached = timeit.timeit(extract_cached, number=n)
+
+        saving_ns = (t_uncached - t_cached) / n * 1e9
+        speedup = t_uncached / t_cached if t_cached > 0 else float('inf')
+        print(f"  {ncols} cols: uncached={t_uncached / n * 1e9:.1f} ns, "
+              f"cached={t_cached / n * 1e9:.1f} ns, "
+              f"saving={saving_ns:.1f} ns ({speedup:.1f}x)")
+
+
+if __name__ == "__main__":
+    print(f"Python {sys.version}")
+    print("\n=== column_names / column_types extraction ===")
+    bench()

--- a/benchmarks/micro/bench_result_kind_dispatch.py
+++ b/benchmarks/micro/bench_result_kind_dispatch.py
@@ -1,0 +1,115 @@
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Micro-benchmark: RESULT_KIND dispatch ordering and getattr vs direct access.
+
+Measures the cost difference between:
+1. Checking RESULT_KIND_ROWS first vs third in the if/elif chain
+2. getattr(msg, 'continuous_paging_options', None) vs msg.continuous_paging_options
+
+Run:
+    python benchmarks/bench_result_kind_dispatch.py
+"""
+
+import sys
+import timeit
+
+
+def bench():
+    n = 2_000_000
+
+    # Simulate the result kind values
+    RESULT_KIND_SET_KEYSPACE = 0x0003
+    RESULT_KIND_SCHEMA_CHANGE = 0x0005
+    RESULT_KIND_ROWS = 0x0002
+    RESULT_KIND_VOID = 0x0001
+
+    kind = RESULT_KIND_ROWS  # the common case
+
+    # Old order: SET_KEYSPACE, SCHEMA_CHANGE, ROWS, VOID
+    def old_dispatch():
+        if kind == RESULT_KIND_SET_KEYSPACE:
+            return 'set_keyspace'
+        elif kind == RESULT_KIND_SCHEMA_CHANGE:
+            return 'schema_change'
+        elif kind == RESULT_KIND_ROWS:
+            return 'rows'
+        elif kind == RESULT_KIND_VOID:
+            return 'void'
+
+    # New order: ROWS, VOID, SET_KEYSPACE, SCHEMA_CHANGE
+    def new_dispatch():
+        if kind == RESULT_KIND_ROWS:
+            return 'rows'
+        elif kind == RESULT_KIND_VOID:
+            return 'void'
+        elif kind == RESULT_KIND_SET_KEYSPACE:
+            return 'set_keyspace'
+        elif kind == RESULT_KIND_SCHEMA_CHANGE:
+            return 'schema_change'
+
+    print(f"=== RESULT_KIND dispatch order ({n:,} iters) ===\n")
+
+    # Warmup
+    for _ in range(10000):
+        old_dispatch()
+        new_dispatch()
+
+    t_old = timeit.timeit(old_dispatch, number=n)
+    t_new = timeit.timeit(new_dispatch, number=n)
+    ns_old = t_old / n * 1e9
+    ns_new = t_new / n * 1e9
+    saving = ns_old - ns_new
+    speedup = ns_old / ns_new if ns_new > 0 else float('inf')
+    print(f"  Old (ROWS=3rd):  {ns_old:.1f} ns")
+    print(f"  New (ROWS=1st):  {ns_new:.1f} ns")
+    print(f"  Saving: {saving:.1f} ns ({speedup:.2f}x)")
+
+    # getattr vs direct attribute access
+    print(f"\n=== getattr vs direct attribute access ({n:,} iters) ===\n")
+
+    class OldMsg:
+        pass
+
+    class NewMsg:
+        continuous_paging_options = None
+
+    old_msg = OldMsg()
+    new_msg = NewMsg()
+
+    def old_getattr():
+        return getattr(old_msg, 'continuous_paging_options', None)
+
+    def new_direct():
+        return new_msg.continuous_paging_options
+
+    for _ in range(10000):
+        old_getattr()
+        new_direct()
+
+    t_old = timeit.timeit(old_getattr, number=n)
+    t_new = timeit.timeit(new_direct, number=n)
+    ns_old = t_old / n * 1e9
+    ns_new = t_new / n * 1e9
+    saving = ns_old - ns_new
+    speedup = ns_old / ns_new if ns_new > 0 else float('inf')
+    print(f"  getattr(msg, 'continuous_paging_options', None): {ns_old:.1f} ns")
+    print(f"  msg.continuous_paging_options:                    {ns_new:.1f} ns")
+    print(f"  Saving: {saving:.1f} ns ({speedup:.2f}x)")
+
+
+if __name__ == "__main__":
+    print(f"Python {sys.version}\n")
+    bench()

--- a/benchmarks/micro/bench_result_kind_dispatch.py
+++ b/benchmarks/micro/bench_result_kind_dispatch.py
@@ -1,0 +1,115 @@
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Micro-benchmark: RESULT_KIND dispatch ordering and getattr vs direct access.
+
+Measures the cost difference between:
+1. Checking RESULT_KIND_ROWS first vs third in the if/elif chain
+2. getattr(msg, 'continuous_paging_options', None) vs msg.continuous_paging_options
+
+Run:
+    python benchmarks/micro/bench_result_kind_dispatch.py
+"""
+
+import sys
+import timeit
+
+
+def bench():
+    n = 2_000_000
+
+    # Simulate the result kind values
+    RESULT_KIND_SET_KEYSPACE = 0x0003
+    RESULT_KIND_SCHEMA_CHANGE = 0x0005
+    RESULT_KIND_ROWS = 0x0002
+    RESULT_KIND_VOID = 0x0001
+
+    kind = RESULT_KIND_ROWS  # the common case
+
+    # Old order: SET_KEYSPACE, SCHEMA_CHANGE, ROWS, VOID
+    def old_dispatch():
+        if kind == RESULT_KIND_SET_KEYSPACE:
+            return 'set_keyspace'
+        elif kind == RESULT_KIND_SCHEMA_CHANGE:
+            return 'schema_change'
+        elif kind == RESULT_KIND_ROWS:
+            return 'rows'
+        elif kind == RESULT_KIND_VOID:
+            return 'void'
+
+    # New order: ROWS, VOID, SET_KEYSPACE, SCHEMA_CHANGE
+    def new_dispatch():
+        if kind == RESULT_KIND_ROWS:
+            return 'rows'
+        elif kind == RESULT_KIND_VOID:
+            return 'void'
+        elif kind == RESULT_KIND_SET_KEYSPACE:
+            return 'set_keyspace'
+        elif kind == RESULT_KIND_SCHEMA_CHANGE:
+            return 'schema_change'
+
+    print(f"=== RESULT_KIND dispatch order ({n:,} iters) ===\n")
+
+    # Warmup
+    for _ in range(10000):
+        old_dispatch()
+        new_dispatch()
+
+    t_old = timeit.timeit(old_dispatch, number=n)
+    t_new = timeit.timeit(new_dispatch, number=n)
+    ns_old = t_old / n * 1e9
+    ns_new = t_new / n * 1e9
+    saving = ns_old - ns_new
+    speedup = ns_old / ns_new if ns_new > 0 else float('inf')
+    print(f"  Old (ROWS=3rd):  {ns_old:.1f} ns")
+    print(f"  New (ROWS=1st):  {ns_new:.1f} ns")
+    print(f"  Saving: {saving:.1f} ns ({speedup:.2f}x)")
+
+    # getattr vs direct attribute access
+    print(f"\n=== getattr vs direct attribute access ({n:,} iters) ===\n")
+
+    class OldMsg:
+        pass
+
+    class NewMsg:
+        continuous_paging_options = None
+
+    old_msg = OldMsg()
+    new_msg = NewMsg()
+
+    def old_getattr():
+        return getattr(old_msg, 'continuous_paging_options', None)
+
+    def new_direct():
+        return new_msg.continuous_paging_options
+
+    for _ in range(10000):
+        old_getattr()
+        new_direct()
+
+    t_old = timeit.timeit(old_getattr, number=n)
+    t_new = timeit.timeit(new_direct, number=n)
+    ns_old = t_old / n * 1e9
+    ns_new = t_new / n * 1e9
+    saving = ns_old - ns_new
+    speedup = ns_old / ns_new if ns_new > 0 else float('inf')
+    print(f"  getattr(msg, 'continuous_paging_options', None): {ns_old:.1f} ns")
+    print(f"  msg.continuous_paging_options:                    {ns_new:.1f} ns")
+    print(f"  Saving: {saving:.1f} ns ({speedup:.2f}x)")
+
+
+if __name__ == "__main__":
+    print(f"Python {sys.version}\n")
+    bench()

--- a/benchmarks/micro/bench_session_cluster_cache.py
+++ b/benchmarks/micro/bench_session_cluster_cache.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""
+Benchmark: caching self.session.cluster as a local variable.
+
+Measures the cost of repeated self.session.cluster double-lookups
+vs. a single local assignment.
+"""
+
+import sys
+import time
+
+ITERS = 5_000_000
+
+
+class FakeCluster:
+    class control_connection:
+        _tablets_routing_v1 = True
+    protocol_version = 5
+    class metadata:
+        class _tablets:
+            @staticmethod
+            def add_tablet(ks, tbl, tablet):
+                pass
+
+
+class FakeSession:
+    cluster = FakeCluster()
+
+
+class FakeResponseFuture:
+    def __init__(self):
+        self.session = FakeSession()
+
+
+def bench_double_lookup(rf, n):
+    """Simulates 3 accesses to self.session.cluster (tablet routing block)."""
+    t0 = time.perf_counter_ns()
+    for _ in range(n):
+        _ = rf.session.cluster.control_connection
+        _ = rf.session.cluster.protocol_version
+        _ = rf.session.cluster.metadata
+    return (time.perf_counter_ns() - t0) / n
+
+
+def bench_cached_local(rf, n):
+    """Simulates caching session.cluster in a local."""
+    t0 = time.perf_counter_ns()
+    for _ in range(n):
+        cluster = rf.session.cluster
+        _ = cluster.control_connection
+        _ = cluster.protocol_version
+        _ = cluster.metadata
+    return (time.perf_counter_ns() - t0) / n
+
+
+def main():
+    print(f"Python {sys.version}\n")
+    rf = FakeResponseFuture()
+
+    ns_old = bench_double_lookup(rf, ITERS)
+    ns_new = bench_cached_local(rf, ITERS)
+    saving = ns_old - ns_new
+    speedup = ns_old / ns_new if ns_new else float('inf')
+
+    print(f"=== self.session.cluster caching ({ITERS:,} iters) ===\n")
+    print(f"  3x self.session.cluster (old): {ns_old:.1f} ns")
+    print(f"  1x local + 3x local (new):     {ns_new:.1f} ns")
+    print(f"  Saving: {saving:.1f} ns ({speedup:.2f}x)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/micro/bench_session_cluster_cache.py
+++ b/benchmarks/micro/bench_session_cluster_cache.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# Copyright ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Benchmark: caching self.session.cluster as a local variable.
+
+Measures the cost of repeated self.session.cluster double-lookups
+vs. a single local assignment.
+"""
+
+import sys
+import time
+
+ITERS = 5_000_000
+
+
+class FakeCluster:
+    class control_connection:
+        _tablets_routing_v1 = True
+    protocol_version = 5
+    class metadata:
+        class _tablets:
+            @staticmethod
+            def add_tablet(ks, tbl, tablet):
+                pass
+
+
+class FakeSession:
+    cluster = FakeCluster()
+
+
+class FakeResponseFuture:
+    def __init__(self):
+        self.session = FakeSession()
+
+
+def bench_double_lookup(rf, n):
+    """Simulates 3 accesses to self.session.cluster (tablet routing block)."""
+    t0 = time.perf_counter_ns()
+    for _ in range(n):
+        _ = rf.session.cluster.control_connection
+        _ = rf.session.cluster.protocol_version
+        _ = rf.session.cluster.metadata
+    return (time.perf_counter_ns() - t0) / n
+
+
+def bench_cached_local(rf, n):
+    """Simulates caching session.cluster in a local."""
+    t0 = time.perf_counter_ns()
+    for _ in range(n):
+        cluster = rf.session.cluster
+        _ = cluster.control_connection
+        _ = cluster.protocol_version
+        _ = cluster.metadata
+    return (time.perf_counter_ns() - t0) / n
+
+
+def main():
+    print(f"Python {sys.version}\n")
+    rf = FakeResponseFuture()
+
+    ns_old = bench_double_lookup(rf, ITERS)
+    ns_new = bench_cached_local(rf, ITERS)
+    saving = ns_old - ns_new
+    speedup = ns_old / ns_new if ns_new else float('inf')
+
+    print(f"=== self.session.cluster caching ({ITERS:,} iters) ===\n")
+    print(f"  3x self.session.cluster (old): {ns_old:.1f} ns")
+    print(f"  1x local + 3x local (new):     {ns_new:.1f} ns")
+    print(f"  Saving: {saving:.1f} ns ({speedup:.2f}x)")
+
+
+if __name__ == "__main__":
+    main()

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -4773,12 +4773,21 @@ class ResponseFuture(object):
                         self, connection, **response.schema_change_event)
                 elif response.kind == RESULT_KIND_ROWS:
                     self._paging_state = response.paging_state
-                    self._col_names = response.column_names
-                    self._col_types = response.column_types
+                    # Use pre-cached column names/types from PreparedStatement
+                    # when available to avoid rebuilding lists from metadata.
+                    ps = self.prepared_statement
+                    if ps is not None and ps._result_col_names is not None:
+                        col_names = ps._result_col_names
+                        col_types = ps._result_col_types
+                    else:
+                        col_names = response.column_names
+                        col_types = response.column_types
+                    self._col_names = col_names
+                    self._col_types = col_types
                     if getattr(self.message, 'continuous_paging_options', None):
                         self._handle_continuous_paging_first_response(connection, response)
                     else:
-                        self._set_final_result(self.row_factory(response.column_names, response.parsed_rows))
+                        self._set_final_result(self.row_factory(col_names, response.parsed_rows))
                 elif response.kind == RESULT_KIND_VOID:
                     self._set_final_result(None)
                 else:
@@ -4944,6 +4953,7 @@ class ResponseFuture(object):
                             )
                         ))
                     self.prepared_statement.result_metadata = response.column_metadata
+                    self.prepared_statement._cache_result_metadata_columns(response.column_metadata)
                     new_metadata_id = response.result_metadata_id
                     if new_metadata_id is not None:
                         self.prepared_statement.result_metadata_id = new_metadata_id

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -4734,21 +4734,17 @@ class ResponseFuture(object):
             self._warnings = getattr(response, 'warnings', None)
             self._custom_payload = getattr(response, 'custom_payload', None)
 
-            if self._custom_payload and self.session.cluster.control_connection._tablets_routing_v1 and 'tablets-routing-v1' in self._custom_payload:
-                protocol = self.session.cluster.protocol_version
+            if self._custom_payload and self.session.cluster.control_connection._tablets_routing_v1:
                 info = self._custom_payload.get('tablets-routing-v1')
-                ctype = ResponseFuture._TABLET_ROUTING_CTYPE
-                if ctype is None:
-                    ctype = types.lookup_casstype('TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)))')
-                    ResponseFuture._TABLET_ROUTING_CTYPE = ctype
-                tablet_routing_info = ctype.from_binary(info, protocol)
-                first_token = tablet_routing_info[0]
-                last_token = tablet_routing_info[1]
-                tablet_replicas = tablet_routing_info[2]
-                tablet = Tablet.from_row(first_token, last_token, tablet_replicas)
-                keyspace = self.query.keyspace
-                table = self.query.table
-                self.session.cluster.metadata._tablets.add_tablet(keyspace, table, tablet)
+                if info is not None:
+                    ctype = ResponseFuture._TABLET_ROUTING_CTYPE
+                    if ctype is None:
+                        ctype = types.lookup_casstype('TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)))')
+                        ResponseFuture._TABLET_ROUTING_CTYPE = ctype
+                    first_token, last_token, tablet_replicas = ctype.from_binary(info, self.session.cluster.protocol_version)
+                    tablet = Tablet.from_row(first_token, last_token, tablet_replicas)
+                    if tablet is not None:
+                        self.session.cluster.metadata._tablets.add_tablet(self.query.keyspace, self.query.table, tablet)
 
             if isinstance(response, ResultMessage):
                 if response.kind == RESULT_KIND_SET_KEYSPACE:

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5264,6 +5264,9 @@ class ResultSet(object):
     like you might see on a normal call to ``session.execute()``.
     """
 
+    __slots__ = ('response_future', 'column_names', 'column_types',
+                 '_current_rows', '_page_iter', '_list_mode')
+
     def __init__(self, response_future, initial_response):
         self.response_future = response_future
         self.column_names = response_future._col_names

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -4730,26 +4730,30 @@ class ResponseFuture(object):
                 # custom_payload in __slots__, always initialised in __init__,
                 # so direct attribute access is safe and faster than getattr().
                 trace_id = response.trace_id
+                session = self.session
                 if trace_id:
                     if not self._query_traces:
                         self._query_traces = []
-                    self._query_traces.append(QueryTrace(trace_id, self.session))
+                    self._query_traces.append(QueryTrace(trace_id, session))
 
                 self._warnings = response.warnings
                 custom_payload = response.custom_payload
                 self._custom_payload = custom_payload
 
-                if custom_payload and self.session.cluster.control_connection._tablets_routing_v1:
+                # Cache session.cluster to avoid repeated double-lookup in the
+                # tablet routing block (3 accesses) and schema-change path.
+                cluster = session.cluster
+                if custom_payload and cluster.control_connection._tablets_routing_v1:
                     info = custom_payload.get('tablets-routing-v1')
                     if info is not None:
                         ctype = ResponseFuture._TABLET_ROUTING_CTYPE
                         if ctype is None:
                             ctype = types.lookup_casstype('TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)))')
                             ResponseFuture._TABLET_ROUTING_CTYPE = ctype
-                        first_token, last_token, tablet_replicas = ctype.from_binary(info, self.session.cluster.protocol_version)
+                        first_token, last_token, tablet_replicas = ctype.from_binary(info, cluster.protocol_version)
                         tablet = Tablet.from_row(first_token, last_token, tablet_replicas)
                         if tablet is not None:
-                            self.session.cluster.metadata._tablets.add_tablet(self.query.keyspace, self.query.table, tablet)
+                            cluster.metadata._tablets.add_tablet(self.query.keyspace, self.query.table, tablet)
 
                 if response.kind == RESULT_KIND_ROWS:
                     self._paging_state = response.paging_state
@@ -4771,7 +4775,6 @@ class ResponseFuture(object):
                 elif response.kind == RESULT_KIND_VOID:
                     self._set_final_result(None)
                 elif response.kind == RESULT_KIND_SET_KEYSPACE:
-                    session = getattr(self, 'session', None)
                     # since we're running on the event loop thread, we need to
                     # use a non-blocking method for setting the keyspace on
                     # all connections in this session, otherwise the event
@@ -4786,9 +4789,9 @@ class ResponseFuture(object):
                     # refresh the schema before responding, but do it in another
                     # thread instead of the event loop thread
                     self.is_schema_agreed = False
-                    self.session.submit(
+                    session.submit(
                         refresh_schema_and_set_result,
-                        self.session.cluster.control_connection,
+                        cluster.control_connection,
                         self, connection, **response.schema_change_event)
                 else:
                     self._set_final_result(response)

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -4725,28 +4725,32 @@ class ResponseFuture(object):
             if pool and not pool.is_shutdown:
                 pool.return_connection(connection)
 
-            trace_id = getattr(response, 'trace_id', None)
-            if trace_id:
-                if not self._query_traces:
-                    self._query_traces = []
-                self._query_traces.append(QueryTrace(trace_id, self.session))
-
-            self._warnings = getattr(response, 'warnings', None)
-            self._custom_payload = getattr(response, 'custom_payload', None)
-
-            if self._custom_payload and self.session.cluster.control_connection._tablets_routing_v1:
-                info = self._custom_payload.get('tablets-routing-v1')
-                if info is not None:
-                    ctype = ResponseFuture._TABLET_ROUTING_CTYPE
-                    if ctype is None:
-                        ctype = types.lookup_casstype('TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)))')
-                        ResponseFuture._TABLET_ROUTING_CTYPE = ctype
-                    first_token, last_token, tablet_replicas = ctype.from_binary(info, self.session.cluster.protocol_version)
-                    tablet = Tablet.from_row(first_token, last_token, tablet_replicas)
-                    if tablet is not None:
-                        self.session.cluster.metadata._tablets.add_tablet(self.query.keyspace, self.query.table, tablet)
-
             if isinstance(response, ResultMessage):
+                # Hot path: ResultMessage has trace_id, warnings, and
+                # custom_payload in __slots__, always initialised in __init__,
+                # so direct attribute access is safe and faster than getattr().
+                trace_id = response.trace_id
+                if trace_id:
+                    if not self._query_traces:
+                        self._query_traces = []
+                    self._query_traces.append(QueryTrace(trace_id, self.session))
+
+                self._warnings = response.warnings
+                custom_payload = response.custom_payload
+                self._custom_payload = custom_payload
+
+                if custom_payload and self.session.cluster.control_connection._tablets_routing_v1:
+                    info = custom_payload.get('tablets-routing-v1')
+                    if info is not None:
+                        ctype = ResponseFuture._TABLET_ROUTING_CTYPE
+                        if ctype is None:
+                            ctype = types.lookup_casstype('TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)))')
+                            ResponseFuture._TABLET_ROUTING_CTYPE = ctype
+                        first_token, last_token, tablet_replicas = ctype.from_binary(info, self.session.cluster.protocol_version)
+                        tablet = Tablet.from_row(first_token, last_token, tablet_replicas)
+                        if tablet is not None:
+                            self.session.cluster.metadata._tablets.add_tablet(self.query.keyspace, self.query.table, tablet)
+
                 if response.kind == RESULT_KIND_SET_KEYSPACE:
                     session = getattr(self, 'session', None)
                     # since we're running on the event loop thread, we need to
@@ -4780,6 +4784,18 @@ class ResponseFuture(object):
                 else:
                     self._set_final_result(response)
             elif isinstance(response, ErrorMessage):
+                # Cold path: ErrorMessage inherits from _MessageType which
+                # defines warnings/custom_payload as class-level defaults but
+                # does NOT have trace_id -- getattr is required here.
+                trace_id = getattr(response, 'trace_id', None)
+                if trace_id:
+                    if not self._query_traces:
+                        self._query_traces = []
+                    self._query_traces.append(QueryTrace(trace_id, self.session))
+
+                self._warnings = getattr(response, 'warnings', None)
+                self._custom_payload = getattr(response, 'custom_payload', None)
+
                 retry_policy = self._retry_policy
 
                 if isinstance(response, ReadTimeoutErrorMessage):
@@ -4858,6 +4874,10 @@ class ResponseFuture(object):
 
                 self._handle_retry_decision(retry, response, host)
             elif isinstance(response, ConnectionException):
+                # ConnectionException has no trace_id/warnings/custom_payload;
+                # clear any stale values from a previous retry attempt.
+                self._warnings = None
+                self._custom_payload = None
                 if self._metrics is not None:
                     self._metrics.on_connection_error()
                 if not isinstance(response, ConnectionShutdown):
@@ -4867,6 +4887,8 @@ class ResponseFuture(object):
                     self.query, cl, error=response, retry_num=self._query_retries)
                 self._handle_retry_decision(retry, response, host)
             elif isinstance(response, Exception):
+                self._warnings = None
+                self._custom_payload = None
                 if hasattr(response, 'to_exception'):
                     self._set_final_exception(response.to_exception())
                 else:

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5076,9 +5076,12 @@ class ResponseFuture(object):
             ...     log.exception("Operation failed:")
 
         """
+        return ResultSet(self, self._wait_for_result())
+
+    def _wait_for_result(self):
         self._event.wait()
         if self._final_result is not _NOT_SET:
-            return ResultSet(self, self._final_result)
+            return self._final_result
         else:
             raise self._final_exception
 
@@ -5352,8 +5355,7 @@ class ResultSet(object):
         """
         if self.response_future.has_more_pages:
             self.response_future.start_fetching_next_page()
-            result = self.response_future.result()
-            self._current_rows = result._current_rows  # ResultSet has already _set_current_rows to the appropriate form
+            self._set_current_rows(self.response_future._wait_for_result())
         else:
             self._current_rows = []
 

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -4751,7 +4751,26 @@ class ResponseFuture(object):
                         if tablet is not None:
                             self.session.cluster.metadata._tablets.add_tablet(self.query.keyspace, self.query.table, tablet)
 
-                if response.kind == RESULT_KIND_SET_KEYSPACE:
+                if response.kind == RESULT_KIND_ROWS:
+                    self._paging_state = response.paging_state
+                    # Use pre-cached column names/types from PreparedStatement
+                    # when available to avoid rebuilding lists from metadata.
+                    ps = self.prepared_statement
+                    if ps is not None and ps._result_col_names is not None:
+                        col_names = ps._result_col_names
+                        col_types = ps._result_col_types
+                    else:
+                        col_names = response.column_names
+                        col_types = response.column_types
+                    self._col_names = col_names
+                    self._col_types = col_types
+                    if self.message.continuous_paging_options:
+                        self._handle_continuous_paging_first_response(connection, response)
+                    else:
+                        self._set_final_result(self.row_factory(col_names, response.parsed_rows))
+                elif response.kind == RESULT_KIND_VOID:
+                    self._set_final_result(None)
+                elif response.kind == RESULT_KIND_SET_KEYSPACE:
                     session = getattr(self, 'session', None)
                     # since we're running on the event loop thread, we need to
                     # use a non-blocking method for setting the keyspace on
@@ -4771,25 +4790,6 @@ class ResponseFuture(object):
                         refresh_schema_and_set_result,
                         self.session.cluster.control_connection,
                         self, connection, **response.schema_change_event)
-                elif response.kind == RESULT_KIND_ROWS:
-                    self._paging_state = response.paging_state
-                    # Use pre-cached column names/types from PreparedStatement
-                    # when available to avoid rebuilding lists from metadata.
-                    ps = self.prepared_statement
-                    if ps is not None and ps._result_col_names is not None:
-                        col_names = ps._result_col_names
-                        col_types = ps._result_col_types
-                    else:
-                        col_names = response.column_names
-                        col_types = response.column_types
-                    self._col_names = col_names
-                    self._col_types = col_types
-                    if getattr(self.message, 'continuous_paging_options', None):
-                        self._handle_continuous_paging_first_response(connection, response)
-                    else:
-                        self._set_final_result(self.row_factory(col_names, response.parsed_rows))
-                elif response.kind == RESULT_KIND_VOID:
-                    self._set_final_result(None)
                 else:
                     self._set_final_result(response)
             elif isinstance(response, ErrorMessage):

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5279,15 +5279,19 @@ class ResponseFuture(object):
                 # custom_payload in __slots__, always initialised in __init__,
                 # so direct attribute access is safe and faster than getattr().
                 trace_id = response.trace_id
+                session = self.session
                 if trace_id:
                     if not self._query_traces:
                         self._query_traces = []
-                    self._query_traces.append(QueryTrace(trace_id, self.session))
+                    self._query_traces.append(QueryTrace(trace_id, session))
 
                 self._warnings = response.warnings
                 custom_payload = response.custom_payload
                 self._custom_payload = custom_payload
 
+# Cache session.cluster to avoid repeated double-lookup in the
+                # tablet routing block (3 accesses) and schema-change path.
+                cluster = session.cluster
                 if custom_payload and connection is not None:
                     # Parse the routing payload according to what the connection that
                     # *served this request* negotiated, not the control connection:
@@ -5378,7 +5382,13 @@ class ResponseFuture(object):
                 elif response.kind == RESULT_KIND_VOID:
                     self._set_final_result(None)
                 elif response.kind == RESULT_KIND_SET_KEYSPACE:
-                    session = getattr(self, 'session', None)
+                    # Update this response's own connection directly and
+                    # immediately. This matters most when pool is None (the
+                    # control-connection fallback case): _set_keyspace_for_all_pools
+                    # below only updates session.keyspace and pooled connections, so
+                    # without this the control connection's fallback connection would
+                    # keep its old keyspace and subsequent fallback queries would run
+                    # against the wrong keyspace.
                     if connection is not None:
                         connection.keyspace = response.new_keyspace
                     # since we're running on the event loop thread, we need to
@@ -5395,9 +5405,9 @@ class ResponseFuture(object):
                     # refresh the schema before responding, but do it in another
                     # thread instead of the event loop thread
                     self.is_schema_agreed = False
-                    self.session.submit(
+                    session.submit(
                         refresh_schema_and_set_result,
-                        self.session.cluster.control_connection,
+                        cluster.control_connection,
                         self, connection, **response.schema_change_event)
                 else:
                     self._set_final_result(response)

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3046,9 +3046,13 @@ class Session(object):
         else:
             timestamp = None
 
-        # Snapshot passed to the ResponseFuture for decoding skip_meta responses; only
-        # bound statements carry cached result metadata (set in the BoundStatement branch).
+        # Snapshot passed to the ResponseFuture for decoding skip_meta responses, and
+        # the column names/types derived from that same metadata (see
+        # PreparedStatement.result_metadata_snapshot); only bound statements carry
+        # cached result metadata (set in the BoundStatement branch).
         bound_result_metadata = _NOT_SET
+        bound_col_names = None
+        bound_col_types = None
 
         # Compute the ring token once, here on the request path, and pass it
         # explicitly to the two consumers that run while sending: the
@@ -3082,11 +3086,13 @@ class Session(object):
                 continuous_paging_options, statement_keyspace)
         elif isinstance(query, BoundStatement):
             prepared_statement = query.prepared_statement
-            # Snapshot metadata and its id as one atomic pair so the message never
-            # carries the id of one schema version alongside a skip_meta decision
-            # made for another. skip_meta is requested only when there is both an
-            # id to validate it with and cached metadata to decode against: while
-            # a statement has no cached metadata there is nothing to decode a
+            # Snapshot metadata, its id, and the column names/types derived from
+            # that metadata all together in one atomic read (result_metadata_snapshot)
+            # so the message never carries the id of one schema version alongside a
+            # skip_meta decision, or a later column-name/type lookup, made for
+            # another. skip_meta is requested only when there is both an id to
+            # validate it with and cached metadata to decode against: while a
+            # statement has no cached metadata there is nothing to decode a
             # metadata-less response with, so the server must send it.
             # Whether skip_meta and the id actually reach the wire is decided per
             # connection at serialization time (see ExecuteMessage.send_body).
@@ -3094,7 +3100,8 @@ class Session(object):
             # result_metadata=None for every page after the first (it isn't threaded
             # through the paging session), so a skip_meta response has nothing to
             # decode page 2+ against.
-            result_metadata, result_metadata_id = prepared_statement.result_metadata_and_id
+            result_metadata, result_metadata_id, bound_col_names, bound_col_types = \
+                prepared_statement.result_metadata_snapshot
             bound_result_metadata = result_metadata
 
             # The tablet_version_block value is connection-independent, so compute
@@ -3136,7 +3143,7 @@ class Session(object):
             prepared_statement=prepared_statement, retry_policy=retry_policy, row_factory=row_factory,
             load_balancer=load_balancing_policy, start_time=start_time, speculative_execution_plan=spec_exec_plan,
             continuous_paging_state=None, host=host, bound_result_metadata=bound_result_metadata,
-            routing_token=routing_token)
+            routing_token=routing_token, bound_col_names=bound_col_names, bound_col_types=bound_col_types)
 
     def _compute_tablet_version_block(self, query, routing_key: Optional[bytes],
                                       routing_token: Optional[Token]) -> int:
@@ -4816,13 +4823,15 @@ class ResponseFuture(object):
     _TABLET_ROUTING_CTYPE = None
     _TABLET_ROUTING_V2_CTYPE = None
     _bound_result_metadata = None
+    _bound_col_names = None
+    _bound_col_types = None
 
     _warned_timeout = False
 
     def __init__(self, session, message, query, timeout, metrics=None, prepared_statement=None,
                  retry_policy=RetryPolicy(), row_factory=None, load_balancer=None, start_time=None,
                  speculative_execution_plan=None, continuous_paging_state=None, host=None,
-                 bound_result_metadata=_NOT_SET, routing_token=None):
+                 bound_result_metadata=_NOT_SET, routing_token=None, bound_col_names=None, bound_col_types=None):
         self.session = session
         # TODO: normalize handling of retry policy and row factory
         self.row_factory = row_factory or session.row_factory
@@ -4839,6 +4848,15 @@ class ResponseFuture(object):
         # even if a concurrent METADATA_CHANGED replaces the prepared statement's cache in
         # between. Defaults to [] for unprepared statements (no cached metadata).
         self._bound_result_metadata = [] if bound_result_metadata is _NOT_SET else bound_result_metadata
+        # Column names/types derived from that same result_metadata snapshot (see
+        # PreparedStatement.result_metadata_snapshot), captured together with it in
+        # one atomic read. _set_result() uses these -- rather than a fresh read of
+        # prepared_statement's live cache -- so a response decoded against this
+        # snapshot can never be paired with column names/types cached for a
+        # different schema version by a concurrent in-flight response for the same
+        # prepared statement.
+        self._bound_col_names = bound_col_names
+        self._bound_col_types = bound_col_types
         self._callback_lock = Lock()
         self._start_time = start_time or time.time()
         self._host = host
@@ -5312,8 +5330,6 @@ class ResponseFuture(object):
                         self, connection, **response.schema_change_event)
                 elif response.kind == RESULT_KIND_ROWS:
                     self._paging_state = response.paging_state
-                    self._col_names = response.column_names
-                    self._col_types = response.column_types
                     new_result_metadata_id = getattr(response, 'result_metadata_id', None)
                     if self.prepared_statement and new_result_metadata_id is not None:
                         if response.column_metadata:
@@ -5322,7 +5338,9 @@ class ResponseFuture(object):
                             # new id with the old metadata (the server would then
                             # skip sending metadata and rows would be decoded
                             # against stale columns, with no recovery).
-                            # (this also re-arms the anomaly warning below)
+                            # (this also re-arms the anomaly warning below, and
+                            # refreshes the cached column names/types together
+                            # with the metadata they were derived from)
                             self.prepared_statement.update_result_metadata(
                                 response.column_metadata, new_result_metadata_id)
                         elif not self.prepared_statement._warned_missing_column_metadata:
@@ -5341,10 +5359,44 @@ class ResponseFuture(object):
                                 "and id are left unchanged.",
                                 getattr(self.prepared_statement, 'query_id', None)
                             )
+                    # A response that carries its own column_metadata (set only
+                    # when the server actually sent metadata on the wire -- see
+                    # ResultMessage.recv_results_metadata's _NO_METADATA_FLAG
+                    # check) was decoded against THAT metadata, not against
+                    # whatever this ResponseFuture had bound at construction
+                    # time: this is either the METADATA_CHANGED case (the
+                    # schema changed since the statement was prepared, and the
+                    # response's rows may have a different column count/types
+                    # than the old snapshot) or the very first response for a
+                    # statement with no cached metadata yet. response.column_names/
+                    # column_types are derived from that same response metadata
+                    # (see recv_results_rows), so they always match
+                    # response.parsed_rows and must be preferred here.
+                    #
+                    # Only when the response is metadata-less (the common,
+                    # schema-unchanged skip_meta case) do we use the column
+                    # names/types snapshotted on this ResponseFuture at
+                    # construction time (see Session._create_response_future),
+                    # to avoid rebuilding lists from metadata. Those come from
+                    # the same atomic read as _bound_result_metadata, which is
+                    # what a metadata-less response was actually decoded
+                    # against; a fresh read of prepared_statement's live cache
+                    # here could instead observe a different schema version if
+                    # a concurrent in-flight response for the same prepared
+                    # statement updated it (via update_result_metadata) between
+                    # decode and this callback.
+                    if not response.column_metadata and self._bound_col_names is not None:
+                        col_names = self._bound_col_names
+                        col_types = self._bound_col_types
+                    else:
+                        col_names = response.column_names
+                        col_types = response.column_types
+                    self._col_names = col_names
+                    self._col_types = col_types
                     if getattr(self.message, 'continuous_paging_options', None):
                         self._handle_continuous_paging_first_response(connection, response)
                     else:
-                        self._set_final_result(self.row_factory(response.column_names, response.parsed_rows))
+                        self._set_final_result(self.row_factory(col_names, response.parsed_rows))
                 elif response.kind == RESULT_KIND_VOID:
                     self._set_final_result(None)
                 else:
@@ -5517,7 +5569,9 @@ class ResponseFuture(object):
                     # between the two PREPAREs) - a stale-but-plausible id a later
                     # id-aware execute could send without the server detecting the
                     # mismatch. Dropping it instead triggers the same self-healing
-                    # b'' sentinel path a never-prepared id would.
+                    # b'' sentinel path a never-prepared id would. This also
+                    # refreshes the cached column names/types together with the
+                    # metadata they were derived from.
                     self.prepared_statement.update_result_metadata(
                         response.column_metadata, response.result_metadata_id)
                 

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5306,29 +5306,7 @@ class ResponseFuture(object):
                             ResponseFuture._TABLET_ROUTING_CTYPE = ctype
                         self._cache_tablet_from_payload('tablets-routing-v1', ctype)
 
-                if response.kind == RESULT_KIND_SET_KEYSPACE:
-                    session = getattr(self, 'session', None)
-                    if connection is not None:
-                        connection.keyspace = response.new_keyspace
-                    # since we're running on the event loop thread, we need to
-                    # use a non-blocking method for setting the keyspace on
-                    # all connections in this session, otherwise the event
-                    # loop thread will deadlock waiting for keyspaces to be
-                    # set.  This uses a callback chain which ends with
-                    # self._set_keyspace_completed() being called in the
-                    # event loop thread.
-                    if session:
-                        session._set_keyspace_for_all_pools(
-                            response.new_keyspace, self._set_keyspace_completed)
-                elif response.kind == RESULT_KIND_SCHEMA_CHANGE:
-                    # refresh the schema before responding, but do it in another
-                    # thread instead of the event loop thread
-                    self.is_schema_agreed = False
-                    self.session.submit(
-                        refresh_schema_and_set_result,
-                        self.session.cluster.control_connection,
-                        self, connection, **response.schema_change_event)
-                elif response.kind == RESULT_KIND_ROWS:
+                if response.kind == RESULT_KIND_ROWS:
                     self._paging_state = response.paging_state
                     new_result_metadata_id = getattr(response, 'result_metadata_id', None)
                     if self.prepared_statement and new_result_metadata_id is not None:
@@ -5393,12 +5371,34 @@ class ResponseFuture(object):
                         col_types = response.column_types
                     self._col_names = col_names
                     self._col_types = col_types
-                    if getattr(self.message, 'continuous_paging_options', None):
+                    if self.message.continuous_paging_options:
                         self._handle_continuous_paging_first_response(connection, response)
                     else:
                         self._set_final_result(self.row_factory(col_names, response.parsed_rows))
                 elif response.kind == RESULT_KIND_VOID:
                     self._set_final_result(None)
+                elif response.kind == RESULT_KIND_SET_KEYSPACE:
+                    session = getattr(self, 'session', None)
+                    if connection is not None:
+                        connection.keyspace = response.new_keyspace
+                    # since we're running on the event loop thread, we need to
+                    # use a non-blocking method for setting the keyspace on
+                    # all connections in this session, otherwise the event
+                    # loop thread will deadlock waiting for keyspaces to be
+                    # set.  This uses a callback chain which ends with
+                    # self._set_keyspace_completed() being called in the
+                    # event loop thread.
+                    if session:
+                        session._set_keyspace_for_all_pools(
+                            response.new_keyspace, self._set_keyspace_completed)
+                elif response.kind == RESULT_KIND_SCHEMA_CHANGE:
+                    # refresh the schema before responding, but do it in another
+                    # thread instead of the event loop thread
+                    self.is_schema_agreed = False
+                    self.session.submit(
+                        refresh_schema_and_set_result,
+                        self.session.cluster.control_connection,
+                        self, connection, **response.schema_change_event)
                 else:
                     self._set_final_result(response)
             elif isinstance(response, ErrorMessage):

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5663,9 +5663,12 @@ class ResponseFuture(object):
             ...     log.exception("Operation failed:")
 
         """
+        return ResultSet(self, self._wait_for_result())
+
+    def _wait_for_result(self):
         self._event.wait()
         if self._final_result is not _NOT_SET:
-            return ResultSet(self, self._final_result)
+            return self._final_result
         else:
             raise self._final_exception
 
@@ -5936,8 +5939,7 @@ class ResultSet(object):
         """
         if self.response_future.has_more_pages:
             self.response_future.start_fetching_next_page()
-            result = self.response_future.result()
-            self._current_rows = result._current_rows  # ResultSet has already _set_current_rows to the appropriate form
+            self._set_current_rows(self.response_future._wait_for_result())
         else:
             self._current_rows = []
 

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5256,34 +5256,38 @@ class ResponseFuture(object):
             if pool and not pool.is_shutdown:
                 pool.return_connection(connection)
 
-            trace_id = getattr(response, 'trace_id', None)
-            if trace_id:
-                if not self._query_traces:
-                    self._query_traces = []
-                self._query_traces.append(QueryTrace(trace_id, self.session))
-
-            self._warnings = getattr(response, 'warnings', None)
-            self._custom_payload = getattr(response, 'custom_payload', None)
-
-            if self._custom_payload and connection is not None:
-                # Parse the routing payload according to what the connection that
-                # *served this request* negotiated, not the control connection:
-                # different nodes may negotiate different extensions, and each
-                # payload key matches the extension its own connection negotiated.
-                if connection.features.tablets_routing_v2 and 'tablets-routing-v2' in self._custom_payload:
-                    ctype = ResponseFuture._TABLET_ROUTING_V2_CTYPE
-                    if ctype is None:
-                        ctype = types.lookup_casstype('TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)), LongType)')
-                        ResponseFuture._TABLET_ROUTING_V2_CTYPE = ctype
-                    self._cache_tablet_from_payload('tablets-routing-v2', ctype)
-                elif connection.features.tablets_routing_v1 and 'tablets-routing-v1' in self._custom_payload:
-                    ctype = ResponseFuture._TABLET_ROUTING_CTYPE
-                    if ctype is None:
-                        ctype = types.lookup_casstype('TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)))')
-                        ResponseFuture._TABLET_ROUTING_CTYPE = ctype
-                    self._cache_tablet_from_payload('tablets-routing-v1', ctype)
-
             if isinstance(response, ResultMessage):
+                # Hot path: ResultMessage has trace_id, warnings, and
+                # custom_payload in __slots__, always initialised in __init__,
+                # so direct attribute access is safe and faster than getattr().
+                trace_id = response.trace_id
+                if trace_id:
+                    if not self._query_traces:
+                        self._query_traces = []
+                    self._query_traces.append(QueryTrace(trace_id, self.session))
+
+                self._warnings = response.warnings
+                custom_payload = response.custom_payload
+                self._custom_payload = custom_payload
+
+                if custom_payload and connection is not None:
+                    # Parse the routing payload according to what the connection that
+                    # *served this request* negotiated, not the control connection:
+                    # different nodes may negotiate different extensions, and each
+                    # payload key matches the extension its own connection negotiated.
+                    if connection.features.tablets_routing_v2 and 'tablets-routing-v2' in custom_payload:
+                        ctype = ResponseFuture._TABLET_ROUTING_V2_CTYPE
+                        if ctype is None:
+                            ctype = types.lookup_casstype('TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)), LongType)')
+                            ResponseFuture._TABLET_ROUTING_V2_CTYPE = ctype
+                        self._cache_tablet_from_payload('tablets-routing-v2', ctype)
+                    elif connection.features.tablets_routing_v1 and 'tablets-routing-v1' in custom_payload:
+                        ctype = ResponseFuture._TABLET_ROUTING_CTYPE
+                        if ctype is None:
+                            ctype = types.lookup_casstype('TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)))')
+                            ResponseFuture._TABLET_ROUTING_CTYPE = ctype
+                        self._cache_tablet_from_payload('tablets-routing-v1', ctype)
+
                 if response.kind == RESULT_KIND_SET_KEYSPACE:
                     session = getattr(self, 'session', None)
                     if connection is not None:
@@ -5346,6 +5350,18 @@ class ResponseFuture(object):
                 else:
                     self._set_final_result(response)
             elif isinstance(response, ErrorMessage):
+                # Cold path: ErrorMessage inherits from _MessageType which
+                # defines warnings/custom_payload as class-level defaults but
+                # does NOT have trace_id -- getattr is required here.
+                trace_id = getattr(response, 'trace_id', None)
+                if trace_id:
+                    if not self._query_traces:
+                        self._query_traces = []
+                    self._query_traces.append(QueryTrace(trace_id, self.session))
+
+                self._warnings = getattr(response, 'warnings', None)
+                self._custom_payload = getattr(response, 'custom_payload', None)
+
                 retry_policy = self._retry_policy
 
                 if isinstance(response, ReadTimeoutErrorMessage):
@@ -5424,6 +5440,10 @@ class ResponseFuture(object):
 
                 self._handle_retry_decision(retry, response, host)
             elif isinstance(response, ConnectionException):
+                # ConnectionException has no trace_id/warnings/custom_payload;
+                # clear any stale values from a previous retry attempt.
+                self._warnings = None
+                self._custom_payload = None
                 if self._metrics is not None:
                     self._metrics.on_connection_error()
                 if not isinstance(response, ConnectionShutdown):
@@ -5433,6 +5453,8 @@ class ResponseFuture(object):
                     self.query, cl, error=response, retry_num=self._query_retries)
                 self._handle_retry_decision(retry, response, host)
             elif isinstance(response, Exception):
+                self._warnings = None
+                self._custom_payload = None
                 if hasattr(response, 'to_exception'):
                     self._set_final_exception(response.to_exception())
                 else:

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -86,6 +86,8 @@ class _RegisterMessageType(type):
 
 class _MessageType(object, metaclass=_RegisterMessageType):
 
+    __slots__ = ()
+
     tracing = False
     custom_payload = None
     warnings = None
@@ -105,7 +107,7 @@ class _MessageType(object, metaclass=_RegisterMessageType):
 def _get_params(message_obj):
     base_attrs = dir(_MessageType)
     return (
-        (n, a) for n, a in message_obj.__dict__.items()
+        (n, a) for n, a in getattr(message_obj, '__dict__', {}).items()
         if n not in base_attrs and not n.startswith('_') and not callable(a)
     )
 
@@ -658,6 +660,13 @@ class ResultMessage(_MessageType):
     opcode = 0x08
     name = 'RESULT'
 
+    __slots__ = ('kind', 'column_names', 'column_types', 'parsed_rows',
+                 'paging_state', 'continuous_paging_seq', 'continuous_paging_last',
+                 'new_keyspace', 'column_metadata', 'query_id', 'bind_metadata',
+                 'pk_indexes', 'schema_change_event', 'is_lwt',
+                 'result_metadata_id', 'stream_id', 'trace_id',
+                 'custom_payload', 'warnings')
+
     # Names match type name in module scope. Most are imported from cassandra.cqltypes (except CUSTOM_TYPE)
     type_codes = _cqltypes_by_code = dict((v, globals()[k]) for k, v in type_codes.__dict__.items() if not k.startswith('_'))
 
@@ -668,24 +677,26 @@ class ResultMessage(_MessageType):
     _CONTINUOUS_PAGING_LAST_FLAG = 0x80000000
     _METADATA_ID_FLAG = 0x0008
 
-    # These are all the things a result message might contain. They are populated according to 'kind'
-    kind = None
-    column_names = None
-    column_types = None
-    parsed_rows = None
-    paging_state = None
-    continuous_paging_seq = None
-    continuous_paging_last = None
-    new_keyspace = None
-    column_metadata = None
-    query_id = None
-    bind_metadata = None
-    pk_indexes = None
-    schema_change_event = None
-    is_lwt = False
-
     def __init__(self, kind):
         self.kind = kind
+        self.column_names = None
+        self.column_types = None
+        self.parsed_rows = None
+        self.paging_state = None
+        self.continuous_paging_seq = None
+        self.continuous_paging_last = None
+        self.new_keyspace = None
+        self.column_metadata = None
+        self.query_id = None
+        self.bind_metadata = None
+        self.pk_indexes = None
+        self.schema_change_event = None
+        self.is_lwt = False
+        self.result_metadata_id = None
+        self.stream_id = None
+        self.trace_id = None
+        self.custom_payload = None
+        self.warnings = None
 
     def recv(self, f, protocol_version, protocol_features, user_type_map, result_metadata, column_encryption_policy):
         if self.kind == RESULT_KIND_VOID:
@@ -1216,6 +1227,7 @@ def cython_protocol_handler(colparser):
         Cython version of Result Message that has a faster implementation of
         recv_results_row.
         """
+        __slots__ = ()
         # type_codes = ResultMessage.type_codes.copy()
         code_to_type = dict((v, k) for k, v in ResultMessage.type_codes.items())
         recv_results_rows = make_recv_results_rows(colparser)

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -658,10 +658,6 @@ class ResultMessage(_MessageType):
     opcode = 0x08
     name = 'RESULT'
 
-    kind = None
-    results = None
-    paging_state = None
-
     # Names match type name in module scope. Most are imported from cassandra.cqltypes (except CUSTOM_TYPE)
     type_codes = _cqltypes_by_code = dict((v, globals()[k]) for k, v in type_codes.__dict__.items() if not k.startswith('_'))
 
@@ -672,9 +668,8 @@ class ResultMessage(_MessageType):
     _CONTINUOUS_PAGING_LAST_FLAG = 0x80000000
     _METADATA_ID_FLAG = 0x0008
 
-    kind = None
-
     # These are all the things a result message might contain. They are populated according to 'kind'
+    kind = None
     column_names = None
     column_types = None
     parsed_rows = None

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -1177,11 +1177,14 @@ class _ProtocolHandler(object):
         msg_class = cls.message_types_by_opcode[opcode]
         msg = msg_class.recv_body(body, protocol_version, protocol_features, user_type_map, result_metadata, cls.column_encryption_policy)
         msg.stream_id = stream_id
-        msg.trace_id = trace_id
-        msg.custom_payload = custom_payload
-        msg.warnings = warnings
+        if trace_id is not None:
+            msg.trace_id = trace_id
+        if custom_payload is not None:
+            msg.custom_payload = custom_payload
+        if warnings is not None:
+            msg.warnings = warnings
 
-        if msg.warnings:
+        if warnings:
             for w in msg.warnings:
                 log.warning("Server warning: %s", w)
 

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -544,6 +544,11 @@ _PAGING_OPTIONS_FLAG = 0x80000000
 
 class _QueryMessage(_MessageType):
 
+    # DSE continuous paging: stored when the feature is active, otherwise None.
+    # Declared as a class attribute so that callers can use direct attribute
+    # access instead of getattr(msg, 'continuous_paging_options', None).
+    continuous_paging_options = None
+
     def __init__(self, query_params, consistency_level,
                  serial_consistency_level=None, fetch_size=None,
                  paging_state=None, timestamp=None, skip_meta=False,
@@ -906,6 +911,11 @@ class PrepareMessage(_MessageType):
 class BatchMessage(_MessageType):
     opcode = 0x0D
     name = 'BATCH'
+
+    # Batch messages never use continuous paging, but callers access this
+    # attribute directly (instead of getattr) for speed.  Declare it here so
+    # that BatchMessage matches the same interface as _QueryMessage.
+    continuous_paging_options = None
 
     def __init__(self, batch_type, queries, consistency_level,
                  serial_consistency_level=None, timestamp=None,

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -710,10 +710,6 @@ class ResultMessage(_MessageType):
     opcode = 0x08
     name = 'RESULT'
 
-    kind = None
-    results = None
-    paging_state = None
-
     # Names match type name in module scope. Most are imported from cassandra.cqltypes (except CUSTOM_TYPE)
     type_codes = _cqltypes_by_code = dict((v, globals()[k]) for k, v in type_codes.__dict__.items() if not k.startswith('_'))
 
@@ -724,9 +720,8 @@ class ResultMessage(_MessageType):
     _CONTINUOUS_PAGING_LAST_FLAG = 0x80000000
     _METADATA_ID_FLAG = 0x0008
 
-    kind = None
-
     # These are all the things a result message might contain. They are populated according to 'kind'
+    kind = None
     column_names = None
     column_types = None
     parsed_rows = None

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -546,6 +546,11 @@ _PAGING_OPTIONS_FLAG = 0x80000000
 
 class _QueryMessage(_MessageType):
 
+    # DSE continuous paging: stored when the feature is active, otherwise None.
+    # Declared as a class attribute so that callers can use direct attribute
+    # access instead of getattr(msg, 'continuous_paging_options', None).
+    continuous_paging_options = None
+
     def __init__(self, query_params, consistency_level,
                  serial_consistency_level=None, fetch_size=None,
                  paging_state=None, timestamp=None, skip_meta=False,
@@ -963,6 +968,11 @@ class PrepareMessage(_MessageType):
 class BatchMessage(_MessageType):
     opcode = 0x0D
     name = 'BATCH'
+
+    # Batch messages never use continuous paging, but callers access this
+    # attribute directly (instead of getattr) for speed.  Declare it here so
+    # that BatchMessage matches the same interface as _QueryMessage.
+    continuous_paging_options = None
 
     def __init__(self, batch_type, queries, consistency_level,
                  serial_consistency_level=None, timestamp=None,

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -760,6 +760,19 @@ class ResultMessage(_MessageType):
         self.custom_payload = None
         self.warnings = None
 
+    def __repr__(self):
+        slots = set()
+        for cls in type(self).__mro__:
+            slots.update(getattr(cls, '__slots__', ()))
+        params = ', '.join(
+            '%s=%r' % (s, getattr(self, s, None))
+            for s in slots
+            if not s.startswith('_')
+            and getattr(self, s, None) is not None
+            and getattr(self, s, None) is not False
+        )
+        return '<%s(%s)>' % (self.__class__.__name__, params)
+
     def recv(self, f, protocol_version, protocol_features, user_type_map, result_metadata, column_encryption_policy):
         if self.kind == RESULT_KIND_VOID:
             return

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -1235,11 +1235,14 @@ class _ProtocolHandler(object):
         msg_class = cls.message_types_by_opcode[opcode]
         msg = msg_class.recv_body(body, protocol_version, protocol_features, user_type_map, result_metadata, cls.column_encryption_policy)
         msg.stream_id = stream_id
-        msg.trace_id = trace_id
-        msg.custom_payload = custom_payload
-        msg.warnings = warnings
+        if trace_id is not None:
+            msg.trace_id = trace_id
+        if custom_payload is not None:
+            msg.custom_payload = custom_payload
+        if warnings is not None:
+            msg.warnings = warnings
 
-        if msg.warnings:
+        if warnings:
             for w in msg.warnings:
                 log.warning("Server warning: %s", w)
 

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -88,6 +88,8 @@ class _RegisterMessageType(type):
 
 class _MessageType(object, metaclass=_RegisterMessageType):
 
+    __slots__ = ()
+
     tracing = False
     custom_payload = None
     warnings = None
@@ -107,7 +109,7 @@ class _MessageType(object, metaclass=_RegisterMessageType):
 def _get_params(message_obj):
     base_attrs = dir(_MessageType)
     return (
-        (n, a) for n, a in message_obj.__dict__.items()
+        (n, a) for n, a in getattr(message_obj, '__dict__', {}).items()
         if n not in base_attrs and not n.startswith('_') and not callable(a)
     )
 
@@ -710,6 +712,13 @@ class ResultMessage(_MessageType):
     opcode = 0x08
     name = 'RESULT'
 
+    __slots__ = ('kind', 'column_names', 'column_types', 'parsed_rows',
+                 'paging_state', 'continuous_paging_seq', 'continuous_paging_last',
+                 'new_keyspace', 'column_metadata', 'query_id', 'bind_metadata',
+                 'pk_indexes', 'schema_change_event', 'is_lwt',
+                 'result_metadata_id', 'stream_id', 'trace_id',
+                 'custom_payload', 'warnings')
+
     # Names match type name in module scope. Most are imported from cassandra.cqltypes (except CUSTOM_TYPE)
     type_codes = _cqltypes_by_code = dict((v, globals()[k]) for k, v in type_codes.__dict__.items() if not k.startswith('_'))
 
@@ -720,24 +729,31 @@ class ResultMessage(_MessageType):
     _CONTINUOUS_PAGING_LAST_FLAG = 0x80000000
     _METADATA_ID_FLAG = 0x0008
 
-    # These are all the things a result message might contain. They are populated according to 'kind'
-    kind = None
-    column_names = None
-    column_types = None
-    parsed_rows = None
-    paging_state = None
-    continuous_paging_seq = None
-    continuous_paging_last = None
-    new_keyspace = None
-    column_metadata = None
-    query_id = None
-    bind_metadata = None
-    pk_indexes = None
-    schema_change_event = None
-    is_lwt = False
-
     def __init__(self, kind):
         self.kind = kind
+        self.column_names = None
+        self.column_types = None
+        self.parsed_rows = None
+        self.paging_state = None
+        self.continuous_paging_seq = None
+        self.continuous_paging_last = None
+        self.new_keyspace = None
+        self.column_metadata = None
+        self.query_id = None
+        self.bind_metadata = None
+        self.pk_indexes = None
+        self.schema_change_event = None
+        self.is_lwt = False
+        # result_metadata_id is intentionally NOT initialized here: it is only
+        # ever meaningful when the server actually sent one (PREPARED
+        # responses always set it explicitly; ROWS responses only set it when
+        # _METADATA_ID_FLAG is present). Leaving it unset lets callers detect
+        # "the server didn't send an id" via getattr(..., None)/hasattr rather
+        # than confusing that with an id that happens to be None.
+        self.stream_id = None
+        self.trace_id = None
+        self.custom_payload = None
+        self.warnings = None
 
     def recv(self, f, protocol_version, protocol_features, user_type_map, result_metadata, column_encryption_policy):
         if self.kind == RESULT_KIND_VOID:
@@ -1274,6 +1290,7 @@ def cython_protocol_handler(colparser):
         Cython version of Result Message that has a faster implementation of
         recv_results_row.
         """
+        __slots__ = ()
         # type_codes = ResultMessage.type_codes.copy()
         code_to_type = dict((v, k) for k, v in ResultMessage.type_codes.items())
         recv_results_rows = make_recv_results_rows(colparser)

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -459,6 +459,11 @@ class PreparedStatement(object):
     serial_consistency_level = None  # TODO never used?
     _is_lwt = False
 
+    # Cached column names/types derived from result_metadata, to avoid
+    # rebuilding [c[2] for c in result_metadata] on every result set.
+    _result_col_names = None
+    _result_col_types = None
+
     def __init__(self, column_metadata, query_id, routing_key_indexes, query,
                  keyspace, protocol_version, result_metadata, result_metadata_id,
                  is_lwt=False, column_encryption_policy=None):
@@ -469,10 +474,20 @@ class PreparedStatement(object):
         self.keyspace = keyspace
         self.protocol_version = protocol_version
         self.result_metadata = result_metadata
+        self._cache_result_metadata_columns(result_metadata)
         self.result_metadata_id = result_metadata_id
         self.column_encryption_policy = column_encryption_policy
         self.is_idempotent = False
         self._is_lwt = is_lwt
+
+    def _cache_result_metadata_columns(self, result_metadata):
+        """Pre-compute column names and types from result_metadata."""
+        if result_metadata:
+            self._result_col_names = [c[2] for c in result_metadata]
+            self._result_col_types = [c[3] for c in result_metadata]
+        else:
+            self._result_col_names = None
+            self._result_col_types = None
 
     @classmethod
     def from_message(cls, query_id, column_metadata, pk_indexes, cluster_metadata,

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -451,7 +451,19 @@ class PreparedStatement(object):
     protocol_version = None
     query_id = None
     query_string = None
-    _result_metadata_and_id = (None, None)
+    # Cached (result_metadata, result_metadata_id, result_col_names, result_col_types)
+    # stored as ONE tuple, replaced atomically (single attribute assignment) by
+    # update_result_metadata(). Response callbacks may update a statement while
+    # request threads read it; keeping all four values together means a single
+    # attribute read always observes a self-consistent snapshot: result_col_names
+    # and result_col_types can never be a torn pair (one from an old assignment,
+    # one from a newer one), and neither can ever be paired with a
+    # result_metadata/result_metadata_id from a different schema version.
+    # Callers that need that full guarantee (e.g. a ResponseFuture snapshotting
+    # state for one specific in-flight response, in cassandra.cluster) should
+    # read result_metadata_snapshot in one shot rather than combining
+    # result_metadata_and_id with a separate column names/types read.
+    _result_metadata_and_id = (None, None, None, None)
     column_encryption_policy = None
     routing_key_indexes = None
     _routing_key_index_set = None
@@ -471,7 +483,7 @@ class PreparedStatement(object):
         self.query_string = query
         self.keyspace = keyspace
         self.protocol_version = protocol_version
-        self._result_metadata_and_id = (result_metadata, result_metadata_id)
+        self._set_result_metadata(result_metadata, result_metadata_id)
         self.column_encryption_policy = column_encryption_policy
         self.is_idempotent = False
         self._is_lwt = is_lwt
@@ -482,12 +494,13 @@ class PreparedStatement(object):
         The cached result metadata and its metadata id as one immutable
         ``(result_metadata, result_metadata_id)`` pair.
 
-        Read this property when both values are needed together: the tuple is
-        replaced atomically by :meth:`update_result_metadata`, so a single read
-        can never observe the metadata of one schema version paired with the
-        metadata id of another.
+        Read this property when both values are needed together: the
+        underlying tuple is replaced atomically by
+        :meth:`update_result_metadata`, so a single read can never observe
+        the metadata of one schema version paired with the metadata id of
+        another.
         """
-        return self._result_metadata_and_id
+        return self._result_metadata_and_id[:2]
 
     @property
     def result_metadata(self):
@@ -507,20 +520,54 @@ class PreparedStatement(object):
         """
         return self._result_metadata_and_id[1]
 
+    @property
+    def result_metadata_snapshot(self):
+        """
+        Full atomic snapshot: ``(result_metadata, result_metadata_id,
+        result_col_names, result_col_types)``, with all four values replaced
+        together in a single attribute assignment by
+        :meth:`update_result_metadata`.
+
+        Unlike reading :attr:`result_metadata_and_id` and the column
+        names/types as two separate reads, a single read of this property is
+        guaranteed self-consistent even if another thread's
+        :meth:`update_result_metadata` call (e.g. from a concurrent
+        in-flight response's callback) races with it: there is no window in
+        which the two reads could observe different schema versions.
+        """
+        return self._result_metadata_and_id
+
     def update_result_metadata(self, result_metadata, result_metadata_id):
         """
-        Replace the cached result metadata and metadata id together, in a single
-        atomic attribute store. Response callbacks may update a statement while
-        request threads read it; updating the pair in one step (rather than the
-        two fields separately) prevents a reader from pairing a fresh metadata id
-        with stale metadata — a state in which the server would skip sending
-        metadata and rows would be decoded against the wrong columns.
+        Replace the cached result metadata, metadata id, and the column
+        names/types derived from that metadata, together in a single atomic
+        attribute store. Response callbacks may update a statement while
+        request threads read it; updating everything in one step (rather
+        than as separate fields) prevents a reader from pairing a fresh
+        metadata id with stale metadata, or column names/types cached for
+        one schema version with a metadata/id pair from another — a state in
+        which the server would skip sending metadata and rows would be
+        decoded against the wrong (or wrongly-named/typed) columns.
 
         Also re-arms :attr:`_warned_missing_column_metadata`, so an anomaly that
         recurs after the metadata was recovered is logged again.
         """
-        self._result_metadata_and_id = (result_metadata, result_metadata_id)
+        self._set_result_metadata(result_metadata, result_metadata_id)
         self._warned_missing_column_metadata = False
+
+    def _set_result_metadata(self, result_metadata, result_metadata_id):
+        """
+        Store result_metadata/result_metadata_id together with the column
+        names/types derived from that exact metadata, as one atomic tuple
+        (see :attr:`_result_metadata_and_id`).
+        """
+        if result_metadata:
+            col_names = [c[2] for c in result_metadata]
+            col_types = [c[3] for c in result_metadata]
+        else:
+            col_names = None
+            col_types = None
+        self._result_metadata_and_id = (result_metadata, result_metadata_id, col_names, col_types)
 
     @classmethod
     def from_message(cls, query_id, column_metadata, pk_indexes, cluster_metadata,

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -61,7 +61,8 @@ class ResponseFutureTests(unittest.TestCase):
         return ResponseFuture(session, message, query, 1)
 
     def make_mock_response(self, col_names, rows):
-        return Mock(spec=ResultMessage, kind=RESULT_KIND_ROWS, column_names=col_names, parsed_rows=rows, paging_state=None, col_types=None)
+        return Mock(spec=ResultMessage, kind=RESULT_KIND_ROWS, column_names=col_names, parsed_rows=rows,
+                    paging_state=None, col_types=None, trace_id=None, warnings=None, custom_payload=None)
 
     def test_result_message(self):
         session = self.make_basic_session()
@@ -104,7 +105,8 @@ class ResponseFutureTests(unittest.TestCase):
 
         result = Mock(spec=ResultMessage,
                       kind=RESULT_KIND_SET_KEYSPACE,
-                      results="keyspace1")
+                      results="keyspace1",
+                      trace_id=None, warnings=None, custom_payload=None)
         rf._set_result(None, None, None, result)
         rf._set_keyspace_completed({})
         assert not rf.result()
@@ -118,7 +120,8 @@ class ResponseFutureTests(unittest.TestCase):
                        'keyspace': "keyspace1", "table": "table1"}
         result = Mock(spec=ResultMessage,
                       kind=RESULT_KIND_SCHEMA_CHANGE,
-                      schema_change_event=event_results)
+                      schema_change_event=event_results,
+                      trace_id=None, warnings=None, custom_payload=None)
         connection = Mock()
         rf._set_result(None, connection, None, result)
         session.submit.assert_called_once_with(ANY, ANY, rf, connection, **event_results)
@@ -127,7 +130,8 @@ class ResponseFutureTests(unittest.TestCase):
         session = self.make_session()
         rf = self.make_response_future(session)
         rf.send_request()
-        result = Mock(spec=ResultMessage, kind=999, results=[1, 2, 3])
+        result = Mock(spec=ResultMessage, kind=999, results=[1, 2, 3],
+                      trace_id=None, warnings=None, custom_payload=None)
         rf._set_result(None, None, None, result)
         assert rf.result()[0] == result
 

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -629,7 +629,6 @@ class ResponseFutureTests(unittest.TestCase):
         response = Mock(spec=ResultMessage,
                         kind=RESULT_KIND_PREPARED,
                         result_metadata_id='foo')
-        response.results = (None, None, None, None, None)
         response.query_id = query_id
 
         rf._query = Mock(return_value=True)

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -440,6 +440,13 @@ class ResponseFutureTests(unittest.TestCase):
         session.cluster._default_load_balancing_policy.make_query_plan.return_value = ['ip1']
         session._pools = {}
 
+        # Faithful to the real Session._set_keyspace_for_all_pools: it only
+        # updates session.keyspace and pooled connections (none here, since
+        # _pools is empty) -- it has no way to reach an out-of-pool
+        # connection such as the control connection's fallback connection.
+        # If this mock updated `connection` itself, it would mask a
+        # regression where _set_result stops updating a fallback control
+        # connection's keyspace directly.
         def set_keyspace_for_all_pools(keyspace, callback):
             session.keyspace = keyspace
             callback({})

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -923,7 +923,8 @@ class ResponseFutureTests(unittest.TestCase):
 
         response = Mock(spec=ResultMessage,
                         kind=RESULT_KIND_PREPARED,
-                        result_metadata_id=b'foo')
+                        result_metadata_id=b'foo',
+                        column_metadata=[('ks', 'tb', 'col', Mock())])
         response.query_id = query_id
 
         rf._query = Mock(return_value=True)
@@ -1516,3 +1517,94 @@ class ResponseFutureTests(unittest.TestCase):
         connection.send_msg.assert_called_once()
         # _query decodes with the construction snapshot, not the mutated cache
         assert connection.send_msg.call_args.kwargs['result_metadata'] is meta_v1
+
+    def test_set_result_uses_construction_snapshot_for_columns_not_live_cache(self):
+        """
+        The column names/types used to build the result set must come from the
+        snapshot taken when this ResponseFuture's message was constructed --
+        the same snapshot the response was decoded against (see
+        test_query_decodes_with_construction_snapshot_not_live_cache) -- not
+        from a fresh read of the prepared statement's live cache.
+
+        Simulates two in-flight responses sharing one prepared statement: this
+        future's message is built while the statement still has old_meta
+        cached, then another in-flight response's METADATA_CHANGED replaces
+        the statement's cache with new_meta *before* this future's own
+        response callback runs. Without a per-future snapshot, the rows
+        (decoded against old_meta, per the previous test) would be paired
+        with column names/types derived from new_meta instead.
+        """
+        old_meta = [('ks', 'tb', 'old_col', Mock())]
+        new_meta = [('ks', 'tb', 'new_col', Mock())]
+        ps = self._make_prepared_statement(old_meta, b'id1')
+
+        # Message built (and metadata + column names/types snapshotted
+        # together, atomically) while ps still has old_meta cached.
+        rf = self._create_execute_future(ps)
+        assert rf._bound_result_metadata is old_meta
+        assert rf._bound_col_names == ['old_col']
+        assert rf._bound_col_types == [old_meta[0][3]]
+
+        # Another in-flight response for the same prepared statement completes
+        # a METADATA_CHANGED update before this future's callback runs.
+        ps.update_result_metadata(new_meta, b'id2')
+        assert ps.result_metadata is new_meta
+
+        # This response was decoded against old_meta (the skip_meta path: no
+        # column_metadata and no new result_metadata_id on the response
+        # itself -- the server didn't resend metadata).
+        response = self._make_rows_response(result_metadata_id=None, column_metadata=None)
+        response.column_names = ['SHOULD_NOT_BE_USED']
+        response.column_types = ['SHOULD_NOT_BE_USED']
+        rf._set_result(None, None, None, response)
+
+        # Must reflect old_meta -- what the rows were actually decoded
+        # against -- never new_meta, the prepared statement's current,
+        # since-mutated cache.
+        assert rf._col_names == ['old_col']
+        assert rf._col_types == [old_meta[0][3]]
+
+    def test_set_result_uses_response_metadata_when_metadata_changed(self):
+        """
+        The inverse of test_set_result_uses_construction_snapshot_for_columns_not_live_cache:
+        when THIS response is itself the METADATA_CHANGED response -- it carries
+        fresh column_metadata -- its rows were decoded (by
+        ResultMessage.recv_results_rows) against that fresh metadata, not
+        against the bound snapshot taken when this ResponseFuture's message was
+        constructed. response.column_names/column_types are derived from that
+        same fresh column_metadata, so _set_result must prefer them over the
+        now-stale bound snapshot.
+
+        Regression test: previously _set_result preferred the bound snapshot
+        whenever one existed, regardless of whether the response carried its
+        own metadata. After a schema change that altered the column count,
+        this paired a changed row shape with the old column-name list, which
+        made the row factory raise TypeError (wrong number of positional
+        arguments).
+        """
+        old_meta = [('ks', 'tb', 'old_col', Mock())]
+        new_meta = [('ks', 'tb', 'a', Mock()), ('ks', 'tb', 'b', Mock())]
+        ps = self._make_prepared_statement(old_meta, b'id1')
+
+        # Message built (and metadata + column names/types snapshotted
+        # together, atomically) while ps still has old_meta cached -- one
+        # column.
+        rf = self._create_execute_future(ps)
+        assert rf._bound_col_names == ['old_col']
+
+        # This response IS the METADATA_CHANGED response: the schema changed
+        # server-side since prepare, so it carries fresh column_metadata (two
+        # columns) and a new result_metadata_id, and its rows were decoded
+        # against that fresh metadata -- not the one-column bound snapshot.
+        response = self._make_rows_response(result_metadata_id=b'id2', column_metadata=new_meta)
+        response.column_names = ['a', 'b']
+        response.column_types = [new_meta[0][3], new_meta[1][3]]
+        response.parsed_rows = [(1, 2)]
+
+        rf._set_result(None, None, None, response)
+
+        # Must reflect the response's own fresh metadata -- what its rows were
+        # actually decoded against -- never the stale one-column bound
+        # snapshot, which would mismatch the two-value rows.
+        assert rf._col_names == ['a', 'b']
+        assert rf._col_types == [new_meta[0][3], new_meta[1][3]]

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -920,7 +920,6 @@ class ResponseFutureTests(unittest.TestCase):
         response = Mock(spec=ResultMessage,
                         kind=RESULT_KIND_PREPARED,
                         result_metadata_id=b'foo')
-        response.results = (None, None, None, None, None)
         response.query_id = query_id
 
         rf._query = Mock(return_value=True)

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -83,7 +83,8 @@ class ResponseFutureTests(unittest.TestCase):
         return ResponseFuture(session, message, query, 1)
 
     def make_mock_response(self, col_names, rows):
-        return Mock(spec=ResultMessage, kind=RESULT_KIND_ROWS, column_names=col_names, parsed_rows=rows, paging_state=None, col_types=None)
+        return Mock(spec=ResultMessage, kind=RESULT_KIND_ROWS, column_names=col_names, parsed_rows=rows,
+                    paging_state=None, col_types=None, trace_id=None, warnings=None, custom_payload=None)
 
     def test_result_message(self):
         session = self.make_basic_session()
@@ -126,7 +127,8 @@ class ResponseFutureTests(unittest.TestCase):
 
         result = Mock(spec=ResultMessage,
                       kind=RESULT_KIND_SET_KEYSPACE,
-                      results="keyspace1")
+                      results="keyspace1",
+                      trace_id=None, warnings=None, custom_payload=None)
         rf._set_result(None, None, None, result)
         rf._set_keyspace_completed({})
         assert not rf.result()
@@ -140,7 +142,8 @@ class ResponseFutureTests(unittest.TestCase):
                        'keyspace': "keyspace1", "table": "table1"}
         result = Mock(spec=ResultMessage,
                       kind=RESULT_KIND_SCHEMA_CHANGE,
-                      schema_change_event=event_results)
+                      schema_change_event=event_results,
+                      trace_id=None, warnings=None, custom_payload=None)
         connection = Mock()
         # Skip tablet-payload parsing for this mocked response/connection pair.
         connection.features.tablets_routing_v2 = False
@@ -152,7 +155,8 @@ class ResponseFutureTests(unittest.TestCase):
         session = self.make_session()
         rf = self.make_response_future(session)
         rf.send_request()
-        result = Mock(spec=ResultMessage, kind=999, results=[1, 2, 3])
+        result = Mock(spec=ResultMessage, kind=999, results=[1, 2, 3],
+                      trace_id=None, warnings=None, custom_payload=None)
         rf._set_result(None, None, None, result)
         assert rf.result()[0] == result
 

--- a/tests/unit/test_resultset.py
+++ b/tests/unit/test_resultset.py
@@ -33,7 +33,7 @@ class ResultSetTests(unittest.TestCase):
     def test_iter_paged(self):
         expected = list(range(10))
         response_future = Mock(has_more_pages=True, _continuous_paging_session=None)
-        response_future.result.side_effect = (ResultSet(Mock(), expected[-5:]), )  # ResultSet is iterable, so it must be protected in order to be returned whole by the Mock
+        response_future._wait_for_result.side_effect = (expected[-5:], )
         rs = ResultSet(response_future, expected[:5])
         itr = iter(rs)
         # this is brittle, depends on internal impl details. Would like to find a better way
@@ -43,11 +43,11 @@ class ResultSetTests(unittest.TestCase):
     def test_iter_paged_with_empty_pages(self):
         expected = list(range(10))
         response_future = Mock(has_more_pages=True, _continuous_paging_session=None)
-        response_future.result.side_effect = [
-            ResultSet(Mock(), []),
-            ResultSet(Mock(), [0, 1, 2, 3, 4]),
-            ResultSet(Mock(), []),
-            ResultSet(Mock(), [5, 6, 7, 8, 9]),
+        response_future._wait_for_result.side_effect = [
+            [],
+            [0, 1, 2, 3, 4],
+            [],
+            [5, 6, 7, 8, 9],
         ]
         rs = ResultSet(response_future, [])
         itr = iter(rs)
@@ -65,7 +65,7 @@ class ResultSetTests(unittest.TestCase):
         # list access on RS for backwards-compatibility
         expected = list(range(10))
         response_future = Mock(has_more_pages=True, _continuous_paging_session=None)
-        response_future.result.side_effect = (ResultSet(Mock(), expected[-5:]), )  # ResultSet is iterable, so it must be protected in order to be returned whole by the Mock
+        response_future._wait_for_result.side_effect = (expected[-5:], )
         rs = ResultSet(response_future, expected[:5])
         # this is brittle, depends on internal impl details. Would like to find a better way
         type(response_future).has_more_pages = PropertyMock(side_effect=(True, True, True, False))  # First two True are consumed on check entering list mode
@@ -98,7 +98,7 @@ class ResultSetTests(unittest.TestCase):
 
         # RuntimeError if indexing during or after pages
         response_future = Mock(has_more_pages=True, _continuous_paging_session=None)
-        response_future.result.side_effect = (ResultSet(Mock(), expected[-5:]), )  # ResultSet is iterable, so it must be protected in order to be returned whole by the Mock
+        response_future._wait_for_result.side_effect = (expected[-5:], )
         rs = ResultSet(response_future, expected[:5])
         type(response_future).has_more_pages = PropertyMock(side_effect=(True, False))
         itr = iter(rs)
@@ -131,7 +131,7 @@ class ResultSetTests(unittest.TestCase):
 
         # pages
         response_future = Mock(has_more_pages=True, _continuous_paging_session=None)
-        response_future.result.side_effect = (ResultSet(Mock(), expected[-5:]), )  # ResultSet is iterable, so it must be protected in order to be returned whole by the Mock
+        response_future._wait_for_result.side_effect = (expected[-5:], )
         rs = ResultSet(response_future, expected[:5])
         # this is brittle, depends on internal impl details. Would like to find a better way
         type(response_future).has_more_pages = PropertyMock(side_effect=(True, True, True, False))  # First two True are consumed on check entering list mode
@@ -159,7 +159,7 @@ class ResultSetTests(unittest.TestCase):
 
         # pages
         response_future = Mock(has_more_pages=True, _continuous_paging_session=None)
-        response_future.result.side_effect = (ResultSet(Mock(), expected[-5:]), )  # ResultSet is iterable, so it must be protected in order to be returned whole by the Mock
+        response_future._wait_for_result.side_effect = (expected[-5:], )
         rs = ResultSet(response_future, expected[:5])
         type(response_future).has_more_pages = PropertyMock(side_effect=(True, True, True, False))
         # eq before iteration causes list to be materialized


### PR DESCRIPTION
## Summary

Optimize the result message processing hot path (`_set_result`, `ResultMessage`) for memory and speed. Each commit is an independent, focused optimization.

## Commits

| # | Commit | Description |
|---|--------|-------------|
| 1 | `7df233481` | Remove dead and duplicate class attributes in `ResultMessage` |
| 2 | `3185a0bdd` | Skip redundant `None` attribute assignments in `decode_message` |
| 3 | `7b0191c09` | Avoid throwaway `ResultSet` creation in `fetch_next_page` |
| 4 | `3256340b9` | Add `__slots__` to `_MessageType`, `ResultMessage`, and `FastResultMessage` |
| 5 | `cacc76328` | Streamline tablet payload parsing in `_set_result` |
| 6 | `4f7c4103b` | Check `isinstance(ResultMessage)` first for direct attribute access |
| 7 | `bd4cb8f16` | Cache `column_names`/`column_types` on `PreparedStatement` |
| 8 | `4104aa6a1` | Reorder `RESULT_KIND` dispatch and replace `getattr` with direct access |
| 9 | `e76de060a` | Cache `session.cluster` as local in `_set_result` |
| 10 | `6106d61` | Add `__repr__` to `ResultMessage` for slotted attribute display |
| 11 | `9aa01fc` | Fix pre-existing bugs: `_set_keyspace_for_all_pools` errors dict, `wait_for_schema_agreement` scope validation |

## Details

### Commits 1-9 (original PR)

See individual commit messages for details.

### Commit 10: `__repr__` for `ResultMessage`

`ResultMessage.__slots__` eliminates `__dict__`, which broke the inherited `_MessageType.__repr__` (it only iterates `__dict__`). Added a `__repr__` override that walks `type(self).__mro__` to collect all `__slots__` from the full class hierarchy (handles `FastResultMessage` which has `__slots__ = ()`). Only displays non-None, non-False attributes for clean debug output.

### Commit 11: Pre-existing bug fixes

Two bugs found on `origin/master`:
- `_set_keyspace_for_all_pools`: `callback(host_errors)` passed only the last pool's errors instead of the accumulated `errors` dict
- `wait_for_schema_agreement`: Missing `scope` validation despite the docstring promising `ValueError`

## Benchmarks

All benchmarks: Python 3.14, pure-Python `.py` (not Cython `.so`).

### column_names / column_types extraction

| Columns | Uncached | Cached (PreparedStatement) | Saving |
|---------|----------|---------------------------|--------|
| 5 | 223 ns | 31 ns | **7.1x** |
| 10 | 341 ns | 32 ns | **10.6x** |
| 20 | 567 ns | 32 ns | **18.0x** |
| 50 | 1281 ns | 31 ns | **41.5x** |

### _set_result dispatch (2M iters)

| Optimization | Before | After | Saving |
|-------------|--------|-------|--------|
| RESULT_KIND reorder (ROWS=1st) | 39.8 ns | 27.8 ns | **−11.9 ns (1.43x)** |
| getattr → direct attribute | 38.6 ns | 20.3 ns | **−18.3 ns (1.90x)** |

### session.cluster caching (5M iters)

| Access pattern | Time | Saving |
|---------------|------|--------|
| 3× self.session.cluster | 62.3 ns | — |
| 1× local + 3× local | 37.5 ns | **−24.8 ns (1.66x)** |

### Net impact per query

- **decode_message** (commit 2): ~15 ns saved (skip 3 redundant None assignments)
- **_set_result dispatch** (commits 5-6): ~49 ns saved (streamlined tablet parsing + isinstance-first)
- **ResultSet allocation** (commit 3): ~300 ns saved per page fetch (avoids throwaway ResultSet)
- **Memory** (commit 4): ~120–200 bytes/ResultMessage saved (per-instance `__dict__` eliminated)

Total per-query savings on the hot path: **~65 ns latency + ~200 bytes memory**.

## Test results

- **671 unit tests pass, 8 skipped** — all green
- `ResultSet.__slots__` removed from the PR to avoid API breakage for users who subclass (no memory regression vs `origin/master` — `__slots__` wasn't on `origin/master` either)
- All benchmarks verified against claimed numbers
- 2 pre-existing `origin/master` bugs fixed (see commit 11)
