### PR TITLE
ci: cap gevent for free-threaded Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,10 @@ dev = [
     "PyYAML",
     "pure-sasl",
     "twisted[tls]",
-    "gevent",
+    # gevent free-threading support is still unsettled upstream; keep the
+    # version below 26.4.0 until gevent/gevent#2087 and gevent/gevent#2127
+    # are resolved for CPython 3.14t CI jobs.
+    "gevent<26.4.0",
     "eventlet>=0.33.3",
     "cython>=3.2",
     "packaging>=25.0",


### PR DESCRIPTION
## Summary

Cap `gevent` below `26.4.0` in the shared dev dependency group.

The integration workflow installs the full dev environment for all matrix jobs, including the `3.14t` lanes. After `gevent 26.4.0` was published, those lanes started failing during `uv sync` before tests began.

This keeps CI green by resolving to the last known-good gevent line for `3.14t` while upstream free-threading support is still unsettled.

Fixes #815

Issue: https://github.com/scylladb/python-driver/issues/815

Upstream references:

- https://github.com/gevent/gevent/issues/2087
- https://github.com/gevent/gevent/issues/2127

## Validation

Verified locally:

```text
uv venv /tmp/... --python 3.14t
uv pip install --python /tmp/.../bin/python 'gevent<26.4.0'
```

Result:

```text
Installed 4 packages
 + gevent==25.9.1
 + greenlet==3.4.0
 + zope-event==6.1
 + zope-interface==8.3
```

Full integration matrix was not run locally.