### PR TITLE
CI: fix id-token permission for "Test wheels building"

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,5 +19,7 @@ jobs:
     name: "Test wheels building"
     if: "!contains(github.event.pull_request.labels.*.name, 'disable-test-build')"
     uses: ./.github/workflows/lib-build-and-push.yml
+    permissions:
+      id-token: write
     with:
       upload: false


### PR DESCRIPTION
## Summary

Fixes #819.

`build-test.yml` is triggered by `pull_request`, which implicitly grants `id-token: none`. The reusable `lib-build-and-push.yml` contains an `upload_pypi` job declaring `id-token: write`. GitHub enforces permissions at parse time — before evaluating any `if:` conditions — so the entire workflow is rejected even though `upload: false` means `upload_pypi` never actually runs.

## Fix

Add `permissions: id-token: write` to the `test-wheels-build` job in `build-test.yml`. This satisfies GitHub's static validation while keeping the runtime behaviour unchanged — `upload_pypi` is still skipped via `if: inputs.upload`.

## Verification
Tested on PR #770 by temporarily applying this change; the `Test wheels building` jobs transitioned from immediate parse-time failure to successful completion across all platforms (linux, linux-aarch64, macos-arm, macos-x86, windows).
* Successful run: [link](https://github.com/scylladb/python-driver/actions/runs/24450353938)
* Run without fix: [link](https://github.com/scylladb/python-driver/actions/runs/24446155882)