### PR TITLE
CI: remove dead upload_pypi job from reusable workflow, rename to lib-build.yml

### DIFF
--- a/.github/workflows/build-pre-release.yml
+++ b/.github/workflows/build-pre-release.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-and-publish:
-    uses: ./.github/workflows/lib-build-and-push.yml
+    uses: ./.github/workflows/lib-build.yml
     with:
       python-version: ${{ inputs.python-version }}
       target: ${{ inputs.target }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -10,11 +10,12 @@ on:
 jobs:
   build-and-publish:
     name: "Build wheels"
-    uses: ./.github/workflows/lib-build-and-push.yml
-    with:
-      upload: false
+    uses: ./.github/workflows/lib-build.yml
 
-  # TODO: Remove when https://github.com/pypa/gh-action-pypi-publish/issues/166 is fixed and update build-and-publish.with.upload to ${{ endsWith(github.event.ref, 'scylla') }}
+  # Publishing is a separate job (not inside the reusable workflow) because PyPI Trusted Publishing
+  # requires the *caller* workflow path in the OIDC token. A reusable workflow would embed its own
+  # path instead, causing an `invalid-publisher` error on the PyPI side.
+  # See: https://github.com/pypa/gh-action-pypi-publish/issues/166
   publish:
     name: "Publish wheels to PyPi"
     if: ${{ endsWith(github.event.ref, 'scylla') }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,8 +18,4 @@ jobs:
   test-wheels-build:
     name: "Test wheels building"
     if: "!contains(github.event.pull_request.labels.*.name, 'disable-test-build')"
-    uses: ./.github/workflows/lib-build-and-push.yml
-    permissions:
-      id-token: write
-    with:
-      upload: false
+    uses: ./.github/workflows/lib-build.yml

--- a/.github/workflows/lib-build.yml
+++ b/.github/workflows/lib-build.yml
@@ -140,12 +140,12 @@ jobs:
         if: matrix.target != 'linux-aarch64'
         shell: bash
         run: |
-          GITHUB_WORKFLOW_REF="scylladb/python-driver/.github/workflows/lib-build.yml@refs/heads/master" cibuildwheel --output-dir wheelhouse
+          cibuildwheel --output-dir wheelhouse
 
       - name: Build wheels for linux aarch64
         if: matrix.target == 'linux-aarch64'
         run: |
-          GITHUB_WORKFLOW_REF="scylladb/python-driver/.github/workflows/lib-build.yml@refs/heads/master" CIBW_BUILD="cp3*" cibuildwheel --archs aarch64 --output-dir wheelhouse
+          CIBW_BUILD="cp3*" cibuildwheel --archs aarch64 --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/lib-build.yml
+++ b/.github/workflows/lib-build.yml
@@ -1,14 +1,8 @@
-name: Build and upload to PyPi
+name: Build wheels
 
 on:
   workflow_call:
     inputs:
-      upload:
-        description: 'Upload to PyPI'
-        type: boolean
-        required: false
-        default: false
-
       python-version:
         description: 'Python version to run on'
         type: string
@@ -146,12 +140,12 @@ jobs:
         if: matrix.target != 'linux-aarch64'
         shell: bash
         run: |
-          GITHUB_WORKFLOW_REF="scylladb/python-driver/.github/workflows/lib-build-and-push.yml@refs/heads/master" cibuildwheel --output-dir wheelhouse
+          GITHUB_WORKFLOW_REF="scylladb/python-driver/.github/workflows/lib-build.yml@refs/heads/master" cibuildwheel --output-dir wheelhouse
 
       - name: Build wheels for linux aarch64
         if: matrix.target == 'linux-aarch64'
         run: |
-          GITHUB_WORKFLOW_REF="scylladb/python-driver/.github/workflows/lib-build-and-push.yml@refs/heads/master" CIBW_BUILD="cp3*" cibuildwheel --archs aarch64 --output-dir wheelhouse
+          GITHUB_WORKFLOW_REF="scylladb/python-driver/.github/workflows/lib-build.yml@refs/heads/master" CIBW_BUILD="cp3*" cibuildwheel --archs aarch64 --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v7
         with:
@@ -176,20 +170,3 @@ jobs:
         with:
           name: source-dist
           path: dist/*.tar.gz
-
-  upload_pypi:
-    if: inputs.upload
-    needs: [build-wheels, build-sdist]
-    runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
-
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: dist
-          merge-multiple: true
-
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true

--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -39,15 +39,17 @@ on:
 jobs:
   build-and-publish:
     name: "Build wheels"
-    uses: ./.github/workflows/lib-build-and-push.yml
+    uses: ./.github/workflows/lib-build.yml
     with:
-      upload: false
       python-version: ${{ inputs.python-version }}
       ignore_tests: ${{ inputs.ignore_tests }}
       target_tag: ${{ inputs.target_tag }}
       target: ${{ inputs.target }}
 
-  # TODO: Remove when https://github.com/pypa/gh-action-pypi-publish/issues/166 is fixed and update build-and-publish.with.upload to ${{ inputs.upload }}
+  # Publishing is a separate job (not inside the reusable workflow) because PyPI Trusted Publishing
+  # requires the *caller* workflow path in the OIDC token. A reusable workflow would embed its own
+  # path instead, causing an `invalid-publisher` error on the PyPI side.
+  # See: https://github.com/pypa/gh-action-pypi-publish/issues/166
   publish:
     name: "Publish wheels to PyPi"
     needs: build-and-publish


### PR DESCRIPTION
## Summary

Closes #824. Follow-up to #820, addressing @Lorak-mmk's review concern.

The `upload_pypi` job in `lib-build-and-push.yml` was **never reachable**: none of the four caller workflows pass `upload: true`. `build-push.yml` and `publish-manually.yml` already publish from their own separate jobs — this is required by how PyPI Trusted Publishing works: the OIDC token embeds the *caller* workflow path, so the `pypa/gh-action-pypi-publish` action must run in the caller, not inside a reusable workflow (see [pypa/gh-action-pypi-publish#166](https://github.com/pypa/gh-action-pypi-publish/issues/166)).

Because the reusable workflow declared `permissions: id-token: write` for `upload_pypi`, GitHub's **static** permission validation (which runs before evaluating any `if:` conditions) forced `build-test.yml` — a `pull_request` workflow, where `id-token` defaults to `none` — to also declare `id-token: write`. This granted unnecessary privileges to a job that only builds wheels.

## Changes

**Commit 1: remove dead upload_pypi job, rename to lib-build.yml**
- **Rename** `lib-build-and-push.yml` → `lib-build.yml` (it only builds now)
- **Remove** `upload` input and `upload_pypi` job from the reusable workflow
- **Remove** `permissions: id-token: write` and `with: upload: false` from `build-test.yml` — no longer needed, principle of least privilege restored
- **Update** all callers (`build-push.yml`, `publish-manually.yml`, `build-pre-release.yml`) to reference the new workflow path and drop the now-nonexistent `upload: false` from `with:` blocks
- **Replace** TODO comments in `build-push.yml` and `publish-manually.yml`: the separate publish job is now intentional design, not a temporary workaround pending an upstream fix

**Commit 2: remove ineffective `GITHUB_WORKFLOW_REF` override**

`GITHUB_WORKFLOW_REF` was set as a shell env var prefix on the `cibuildwheel` invocations, introduced in #439 as a workaround for the same issue #166. It does not work for two reasons:
1. `GITHUB_WORKFLOW_REF` is set by GitHub's runner infrastructure to populate the OIDC token — overriding it in a child process's environment has no effect on the token GitHub's servers mint.
2. The OIDC token is minted when `pypa/gh-action-pypi-publish` runs (in the `publish` job), not when `cibuildwheel` runs (in `build-wheels`). The variable was being set in the wrong job entirely.

The actual working workaround is already in place: `pypa/gh-action-pypi-publish` runs directly in the caller workflows (`build-push.yml`, `publish-manually.yml`). This variable override was dead code with no effect.

## Result

| | Before | After |
|---|---|---|
| `build-test.yml` permissions | `id-token: write` (unnecessary) | none (default, minimal) |
| `lib-build-and-push.yml` `upload_pypi` job | Present but never runs | Removed |
| Publish responsibility | Dead code in reusable + real publish in callers | Real publish in callers only |
| `GITHUB_WORKFLOW_REF` env var | Set in cibuildwheel steps (no effect) | Removed |