### PR TITLE
Replace SimpleStrategy with NetworkTopologyStrategy in integration tests

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -651,17 +651,17 @@ def setup_keyspace(ipformat=None, protocol_version=None, port=9042):
 
         ddl = '''
             CREATE KEYSPACE test3rf
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}'''
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}'''
         execute_with_long_wait_retry(session, ddl)
 
         ddl = '''
             CREATE KEYSPACE test2rf
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '2'}'''
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '2'}'''
         execute_with_long_wait_retry(session, ddl)
 
         ddl = '''
             CREATE KEYSPACE test1rf
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}'''
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'} AND tablets = {'enabled': false}'''
         execute_with_long_wait_retry(session, ddl)
 
         ddl_3f = '''
@@ -779,7 +779,7 @@ class BasicKeyspaceUnitTestCase(unittest.TestCase):
 
     @classmethod
     def create_keyspace(cls, rf):
-        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '{1}'}}".format(cls.ks_name, rf)
+        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '{1}'}} AND tablets = {{'enabled': false}}".format(cls.ks_name, rf)
         execute_with_long_wait_retry(cls.session, ddl)
 
     @classmethod

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -651,17 +651,17 @@ def setup_keyspace(ipformat=None, protocol_version=None, port=9042):
 
         ddl = '''
             CREATE KEYSPACE test3rf
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}'''
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}'''
         execute_with_long_wait_retry(session, ddl)
 
         ddl = '''
             CREATE KEYSPACE test2rf
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '2'}'''
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '2'}'''
         execute_with_long_wait_retry(session, ddl)
 
         ddl = '''
             CREATE KEYSPACE test1rf
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}'''
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}'''
         execute_with_long_wait_retry(session, ddl)
 
         ddl_3f = '''
@@ -774,7 +774,7 @@ class BasicKeyspaceUnitTestCase(unittest.TestCase):
 
     @classmethod
     def create_keyspace(cls, rf):
-        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '{1}'}}".format(cls.ks_name, rf)
+        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '{1}'}}".format(cls.ks_name, rf)
         execute_with_long_wait_retry(cls.session, ddl)
 
     @classmethod

--- a/tests/integration/cqlengine/query/test_named.py
+++ b/tests/integration/cqlengine/query/test_named.py
@@ -27,7 +27,7 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine.query.test_queryset import BaseQuerySetUsage
 
 
-from tests.integration import BasicSharedKeyspaceUnitTestCase, greaterthanorequalcass30, requires_collection_indexes
+from tests.integration import BasicSharedKeyspaceUnitTestCase, greaterthanorequalcass30, requires_collection_indexes, xfail_scylla_version_lt
 import pytest
 
 
@@ -292,6 +292,8 @@ class TestNamedWithMV(BasicSharedKeyspaceUnitTestCase):
         super(TestNamedWithMV, cls).tearDownClass()
 
     @greaterthanorequalcass30
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Materialized views and secondary indexes are not supported on base tables with tablets.',
+                             scylla_version='2026.1')
     @execute_count(5)
     def test_named_table_with_mv(self):
         """

--- a/tests/integration/standard/column_encryption/test_policies.py
+++ b/tests/integration/standard/column_encryption/test_policies.py
@@ -30,7 +30,7 @@ class ColumnEncryptionPolicyTest(unittest.TestCase):
 
     def _recreate_keyspace(self, session):
         session.execute("drop keyspace if exists foo")
-        session.execute("CREATE KEYSPACE foo WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}")
+        session.execute("CREATE KEYSPACE foo WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}")
         session.execute("CREATE TABLE foo.bar(encrypted blob, unencrypted int, primary key(unencrypted))")
 
     def _create_policy(self, key, iv = None):

--- a/tests/integration/standard/test_client_routes.py
+++ b/tests/integration/standard/test_client_routes.py
@@ -1137,7 +1137,7 @@ class TestFullNodeReplacementThroughNlb(unittest.TestCase):
     def test_should_survive_full_node_replacement_through_nlb(self):
         """
         1. Start with 3 nodes behind the NLB
-        2. Bootstrap 2 new nodes, add to NLB, update routes
+        2. Bootstrap 3 new nodes, add to NLB, update routes
         3. Decommission the original 3 nodes one-by-one, updating NLB/routes
         4. Verify the session survives with only new nodes
         """
@@ -1173,7 +1173,7 @@ class TestFullNodeReplacementThroughNlb(unittest.TestCase):
                          len(original_node_ids))
 
                 # ---- Stage 3: Bootstrap new nodes ----
-                new_node_ids = [max(original_node_ids) + 1, max(original_node_ids) + 2]
+                new_node_ids = [max(original_node_ids) + 1, max(original_node_ids) + 2, max(original_node_ids) + 3]
                 log.info("Stage 3: Adding nodes %s", new_node_ids)
                 ccm_cluster = get_cluster()
 

--- a/tests/integration/standard/test_client_routes.py
+++ b/tests/integration/standard/test_client_routes.py
@@ -729,7 +729,7 @@ class TestPrivateLinkConnectivity(unittest.TestCase):
             session = cluster.connect()
             session.execute(
                 "CREATE KEYSPACE IF NOT EXISTS test_cr_ks "
-                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}"
+                "WITH replication = {'class':'NetworkTopologyStrategy', 'replication_factor': 3}"
             )
             session.execute(
                 "CREATE TABLE IF NOT EXISTS test_cr_ks.t (k int PRIMARY KEY, v text)"

--- a/tests/integration/standard/test_client_routes.py
+++ b/tests/integration/standard/test_client_routes.py
@@ -1154,7 +1154,7 @@ class TestFullNodeReplacementThroughNlb(unittest.TestCase):
     def test_should_survive_full_node_replacement_through_nlb(self):
         """
         1. Start with 3 nodes behind the NLB
-        2. Bootstrap 2 new nodes, add to NLB, update routes
+        2. Bootstrap 3 new nodes, add to NLB, update routes
         3. Decommission the original 3 nodes one-by-one, updating NLB/routes
         4. Verify the session survives with only new nodes
         """
@@ -1190,7 +1190,7 @@ class TestFullNodeReplacementThroughNlb(unittest.TestCase):
                          len(original_node_ids))
 
                 # ---- Stage 3: Bootstrap new nodes ----
-                new_node_ids = [max(original_node_ids) + 1, max(original_node_ids) + 2]
+                new_node_ids = [max(original_node_ids) + 1, max(original_node_ids) + 2, max(original_node_ids) + 3]
                 log.info("Stage 3: Adding nodes %s", new_node_ids)
                 ccm_cluster = get_cluster()
 

--- a/tests/integration/standard/test_client_routes.py
+++ b/tests/integration/standard/test_client_routes.py
@@ -741,7 +741,7 @@ class TestPrivateLinkConnectivity(unittest.TestCase):
             session = cluster.connect()
             session.execute(
                 "CREATE KEYSPACE IF NOT EXISTS test_cr_ks "
-                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}"
+                "WITH replication = {'class':'NetworkTopologyStrategy', 'replication_factor': 3}"
             )
             session.execute(
                 "CREATE TABLE IF NOT EXISTS test_cr_ks.t (k int PRIMARY KEY, v text)"

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -180,7 +180,7 @@ class ClusterTests(unittest.TestCase):
         result = execute_until_pass(session,
             """
             CREATE KEYSPACE clustertests
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}
             """)
         assert not result
 
@@ -1506,7 +1506,7 @@ class DontPrepareOnIgnoredHostsTest(unittest.TestCase):
         hosts = cluster.metadata.all_hosts()
         session.execute("CREATE KEYSPACE clustertests "
                         "WITH replication = "
-                        "{'class': 'SimpleStrategy', 'replication_factor': '1'}")
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}")
         session.execute("CREATE TABLE clustertests.tab (a text, PRIMARY KEY (a))")
         # assign to an unused variable so cluster._prepared_statements retains
         # reference

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -168,7 +168,7 @@ class ClusterTests(unittest.TestCase):
         result = execute_until_pass(session,
             """
             CREATE KEYSPACE clustertests
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}
             """)
         assert not result
 
@@ -1491,7 +1491,7 @@ class DontPrepareOnIgnoredHostsTest(unittest.TestCase):
         hosts = cluster.metadata.all_hosts()
         session.execute("CREATE KEYSPACE clustertests "
                         "WITH replication = "
-                        "{'class': 'SimpleStrategy', 'replication_factor': '1'}")
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}")
         session.execute("CREATE TABLE clustertests.tab (a text, PRIMARY KEY (a))")
         # assign to an unused variable so cluster._prepared_statements retains
         # reference

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -1195,27 +1195,35 @@ class ClusterTests(unittest.TestCase):
         Then using HostFilterPolicy the replica is excluded from the considered hosts.
         By checking the trace we verify that there are no more replicas.
 
+        Requires tablets feature disabled.
+
         @since 3.5
         @jira_ticket PYTHON-653
         @expected_result the replicas are queried for HostFilterPolicy
 
         @test_category metadata
         """
+        ks_name = 'test_replicas_queried_ks'
         queried_hosts = set()
         tap_profile = ExecutionProfile(
             load_balancing_policy=TokenAwarePolicy(RoundRobinPolicy())
         )
         with TestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: tap_profile}) as cluster:
             session = cluster.connect(wait_for_all_pools=True)
+            session.execute("DROP KEYSPACE IF EXISTS {}".format(ks_name))
+            session.execute(
+                "CREATE KEYSPACE {} WITH replication = {{'class': 'NetworkTopologyStrategy', "
+                "'replication_factor': '1'}} AND tablets = {{'enabled': false}}".format(ks_name)
+            )
             session.execute('''
-                    CREATE TABLE test1rf.table_with_big_key (
+                    CREATE TABLE {}.table_with_big_key (
                         k1 int,
                         k2 int,
                         k3 int,
                         k4 int,
-                        PRIMARY KEY((k1, k2, k3), k4))''')
-            prepared = session.prepare("""SELECT * from test1rf.table_with_big_key
-                                          WHERE k1 = ? AND k2 = ? AND k3 = ? AND k4 = ?""")
+                        PRIMARY KEY((k1, k2, k3), k4))'''.format(ks_name))
+            prepared = session.prepare("""SELECT * from {}.table_with_big_key
+                                          WHERE k1 = ? AND k2 = ? AND k3 = ? AND k4 = ?""".format(ks_name))
             for i in range(10):
                 result = session.execute(prepared, (i, i, i, i), trace=True)
                 trace = result.response_future.get_query_trace(query_cl=ConsistencyLevel.ALL)
@@ -1234,14 +1242,14 @@ class ClusterTests(unittest.TestCase):
                          execution_profiles={EXEC_PROFILE_DEFAULT: hfp_profile}) as cluster:
 
             session = cluster.connect(wait_for_all_pools=True)
-            prepared = session.prepare("""SELECT * from test1rf.table_with_big_key
-                                          WHERE k1 = ? AND k2 = ? AND k3 = ? AND k4 = ?""")
+            prepared = session.prepare("""SELECT * from {}.table_with_big_key
+                                          WHERE k1 = ? AND k2 = ? AND k3 = ? AND k4 = ?""".format(ks_name))
             for _ in range(10):
                 result = session.execute(prepared, (last_i, last_i, last_i, last_i), trace=True)
                 trace = result.response_future.get_query_trace(query_cl=ConsistencyLevel.ALL)
                 self._assert_replica_queried(trace, only_replicas=False)
 
-            session.execute('''DROP TABLE test1rf.table_with_big_key''')
+            session.execute('DROP KEYSPACE {}'.format(ks_name))
 
     @greaterthanorequalcass30
     @lessthanorequalcass40

--- a/tests/integration/standard/test_concurrent_schema_change_and_node_kill.py
+++ b/tests/integration/standard/test_concurrent_schema_change_and_node_kill.py
@@ -27,7 +27,7 @@ class TestConcurrentSchemaChangeAndNodeKill(unittest.TestCase):
             "DROP KEYSPACE IF EXISTS ks_deadlock;")
         self.session.execute(
             "CREATE KEYSPACE IF NOT EXISTS ks_deadlock "
-            "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '2' };")
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '2' };")
         self.session.set_keyspace('ks_deadlock')
         self.session.execute("CREATE TABLE IF NOT EXISTS some_table(k int, c int, v int, PRIMARY KEY (k, v));")
         self.session.execute("INSERT INTO some_table (k, c, v) VALUES (1, 2, 3);")

--- a/tests/integration/standard/test_control_connection.py
+++ b/tests/integration/standard/test_control_connection.py
@@ -68,7 +68,7 @@ class ControlConnectionTests(unittest.TestCase):
         self.session = self.cluster.connect()
         self.session.execute("""
             CREATE KEYSPACE keyspacetodrop
-            WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1' }
+            WITH replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor': '1' }
             """)
         self.session.set_keyspace("keyspacetodrop")
         self.session.execute("CREATE TYPE user (age int, name text)")

--- a/tests/integration/standard/test_custom_protocol_handler.py
+++ b/tests/integration/standard/test_custom_protocol_handler.py
@@ -42,8 +42,9 @@ class CustomProtocolHandlerTest(unittest.TestCase):
     def setUpClass(cls):
         cls.cluster = TestCluster()
         cls.session = cls.cluster.connect()
-        cls.session.execute("CREATE KEYSPACE custserdes WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}")
+        cls.session.execute("CREATE KEYSPACE custserdes WITH replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor': '1'}")
         cls.session.set_keyspace("custserdes")
+        cls.session.execute("CREATE TABLE IF NOT EXISTS custserdes.test (k int PRIMARY KEY, v int)")
 
     @classmethod
     def tearDownClass(cls):
@@ -165,7 +166,7 @@ class CustomProtocolHandlerTest(unittest.TestCase):
                                                         int_flag=False)
 
     def _send_query_message(self, session, timeout, **kwargs):
-        query = "SELECT * FROM test3rf.test"
+        query = "SELECT * FROM custserdes.test"
         message = QueryMessage(query=query, **kwargs)
         future = ResponseFuture(session, message, query=None, timeout=timeout)
         future.send_request()
@@ -175,8 +176,8 @@ class CustomProtocolHandlerTest(unittest.TestCase):
         cluster = TestCluster(protocol_version=version, allow_beta_protocol_version=beta)
         session = cluster.connect()
 
-        query_one = SimpleStatement("INSERT INTO test3rf.test (k, v) VALUES (1, 1)")
-        query_two = SimpleStatement("INSERT INTO test3rf.test (k, v) VALUES (2, 2)")
+        query_one = SimpleStatement("INSERT INTO custserdes.test (k, v) VALUES (1, 1)")
+        query_two = SimpleStatement("INSERT INTO custserdes.test (k, v) VALUES (2, 2)")
 
         execute_with_long_wait_retry(session, query_one)
         execute_with_long_wait_retry(session, query_two)
@@ -190,7 +191,7 @@ class CustomProtocolHandlerTest(unittest.TestCase):
             # This means the flag are not handled as they are meant by the server if uses_int=False
             assert response.has_more_pages == uses_int_query_flag
 
-        execute_with_long_wait_retry(session, SimpleStatement("TRUNCATE test3rf.test"))
+        execute_with_long_wait_retry(session, SimpleStatement("TRUNCATE custserdes.test"))
         cluster.shutdown()
 
 

--- a/tests/integration/standard/test_cython_protocol_handlers.py
+++ b/tests/integration/standard/test_cython_protocol_handlers.py
@@ -34,7 +34,7 @@ class CythonProtocolHandlerTest(unittest.TestCase):
         cls.cluster = TestCluster()
         cls.session = cls.cluster.connect()
         cls.session.execute("CREATE KEYSPACE testspace WITH replication = "
-                            "{ 'class' : 'SimpleStrategy', 'replication_factor': '1'}")
+                            "{ 'class' : 'NetworkTopologyStrategy', 'replication_factor': '1'} AND tablets = {'enabled': false}")
         cls.session.set_keyspace("testspace")
         cls.colnames = create_table_with_all_types("test_table", cls.session, cls.N_ITEMS)
 
@@ -225,7 +225,7 @@ class NumpyWideTableTest(unittest.TestCase):
         cls.cluster = TestCluster()
         cls.session = cls.cluster.connect()
         cls.session.execute("CREATE KEYSPACE IF NOT EXISTS test_wide_table WITH replication = "
-                            "{ 'class' : 'SimpleStrategy', 'replication_factor': '1'}")
+                            "{ 'class' : 'NetworkTopologyStrategy', 'replication_factor': '1'}")
         cls.session.set_keyspace("test_wide_table")
 
         # Create a wide table with many int columns

--- a/tests/integration/standard/test_cython_protocol_handlers.py
+++ b/tests/integration/standard/test_cython_protocol_handlers.py
@@ -34,7 +34,7 @@ class CythonProtocolHandlerTest(unittest.TestCase):
         cls.cluster = TestCluster()
         cls.session = cls.cluster.connect()
         cls.session.execute("CREATE KEYSPACE testspace WITH replication = "
-                            "{ 'class' : 'SimpleStrategy', 'replication_factor': '1'}")
+                            "{ 'class' : 'NetworkTopologyStrategy', 'replication_factor': '1'}")
         cls.session.set_keyspace("testspace")
         cls.colnames = create_table_with_all_types("test_table", cls.session, cls.N_ITEMS)
 
@@ -225,7 +225,7 @@ class NumpyWideTableTest(unittest.TestCase):
         cls.cluster = TestCluster()
         cls.session = cls.cluster.connect()
         cls.session.execute("CREATE KEYSPACE IF NOT EXISTS test_wide_table WITH replication = "
-                            "{ 'class' : 'SimpleStrategy', 'replication_factor': '1'}")
+                            "{ 'class' : 'NetworkTopologyStrategy', 'replication_factor': '1'}")
         cls.session.set_keyspace("test_wide_table")
 
         # Create a wide table with many int columns

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -601,7 +601,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         assert "new_keyspace" not in cluster2.metadata.keyspaces
 
         # Cluster metadata modification
-        self.session.execute("CREATE KEYSPACE new_keyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}")
+        self.session.execute("CREATE KEYSPACE new_keyspace WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}")
         assert "new_keyspace" not in cluster2.metadata.keyspaces
 
         cluster2.refresh_schema_metadata()
@@ -1077,7 +1077,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         for ks in keyspaces:
             self.session.execute(
-                f"CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 3 }}"
+                f"CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }}"
             )
 
         self.cluster.schema_metadata_page_size = 2000
@@ -1138,7 +1138,7 @@ class TestCodeCoverage(unittest.TestCase):
 
         session.execute("""
             CREATE KEYSPACE export_udts
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}
             AND durable_writes = true;
         """)
         session.execute("""
@@ -1162,7 +1162,7 @@ class TestCodeCoverage(unittest.TestCase):
             addresses map<text, frozen<address>>)
         """)
 
-        expected_prefix = """CREATE KEYSPACE export_udts WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
+        expected_prefix = """CREATE KEYSPACE export_udts WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}  AND durable_writes = true;
 
 CREATE TYPE export_udts.street (
     street_number int,
@@ -1212,7 +1212,7 @@ CREATE TABLE export_udts.users (
         session.execute("DROP KEYSPACE IF EXISTS {0}".format(ksname))
         session.execute("""
             CREATE KEYSPACE "%s"
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'} AND tablets = {'enabled': false}
             """ % (ksname,))
         session.execute("""
             CREATE TABLE "%s"."%s" (
@@ -1256,7 +1256,7 @@ CREATE TABLE export_udts.users (
 
         ddl = '''
             CREATE KEYSPACE %s
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}'''
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}'''
         with pytest.raises(AlreadyExists):
             session.execute(ddl % ksname)
 
@@ -1387,7 +1387,7 @@ class KeyspaceAlterMetadata(unittest.TestCase):
         self.session = self.cluster.connect()
         name = self._testMethodName.lower()
         crt_ks = '''
-                CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} AND durable_writes = true''' % name
+                CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND durable_writes = true''' % name
         self.session.execute(crt_ks)
 
     def tearDown(self):
@@ -1437,7 +1437,7 @@ class IndexMapTests(unittest.TestCase):
             cls.session.execute(
                 """
                 CREATE KEYSPACE %s
-                WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
+                WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'} AND tablets = {'enabled': false};
                 """ % cls.keyspace_name)
             cls.session.set_keyspace(cls.keyspace_name)
         except Exception:
@@ -1540,7 +1540,7 @@ class FunctionTest(unittest.TestCase):
             cls.cluster = TestCluster()
             cls.keyspace_name = cls.__name__.lower()
             cls.session = cls.cluster.connect()
-            cls.session.execute("CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}" % cls.keyspace_name)
+            cls.session.execute("CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}" % cls.keyspace_name)
             cls.session.set_keyspace(cls.keyspace_name)
             cls.keyspace_function_meta = cls.cluster.metadata.keyspaces[cls.keyspace_name].functions
             cls.keyspace_aggregate_meta = cls.cluster.metadata.keyspaces[cls.keyspace_name].aggregates
@@ -2007,7 +2007,7 @@ class BadMetaTest(unittest.TestCase):
         cls.cluster = TestCluster()
         cls.keyspace_name = cls.__name__.lower()
         cls.session = cls.cluster.connect()
-        cls.session.execute("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}" % cls.keyspace_name)
+        cls.session.execute("CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'} AND tablets = {'enabled': false}" % cls.keyspace_name)
         cls.session.set_keyspace(cls.keyspace_name)
         connection = cls.cluster.control_connection._connection
 

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -449,7 +449,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.check_create_statement(tablemeta, create_statement)
 
     @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Counters are not yet supported with tablets',
-                             oss_scylla_version="7.0", ent_scylla_version="2026.1")
+                             scylla_version="2026.1")
     def test_counter(self):
         create_statement = (
             "CREATE TABLE {keyspace}.{table} ("
@@ -725,7 +725,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
     @greaterthanorequalcass30
     @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                             oss_scylla_version="7.0", ent_scylla_version="2026.1")
+                             scylla_version="2026.1")
     def test_refresh_metadata_for_mv(self):
         """
         test for synchronously refreshing materialized view metadata
@@ -936,7 +936,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
     @greaterthanorequalcass30
     @requires_collection_indexes
     @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                             oss_scylla_version="7.0", ent_scylla_version="2026.1")
+                             scylla_version="2026.1")
     def test_multiple_indices(self):
         """
         test multiple indices on the same column.
@@ -971,7 +971,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
     @greaterthanorequalcass30
     @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                             oss_scylla_version="7.0", ent_scylla_version="2026.1")
+                             scylla_version="2026.1")
     def test_table_extensions(self):
         s = self.session
         ks = self.keyspace_name
@@ -1204,8 +1204,8 @@ CREATE TABLE export_udts.users (
         cluster.shutdown()
 
     @greaterthancass21
-    @xfail_scylla_version_lt(reason='scylladb/scylladb#10707 - Column name in CREATE INDEX is not quoted',
-                             scylla_version="2023.1.1")
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
+                             scylla_version="2026.1")
     def test_case_sensitivity(self):
         """
         Test that names that need to be escaped in CREATE statements are
@@ -1465,6 +1465,8 @@ class IndexMapTests(unittest.TestCase):
     def drop_basic_table(self):
         self.session.execute("DROP TABLE %s" % self.table_name)
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
+                             scylla_version="2026.1")
     def test_index_updates(self):
         self.create_basic_table()
 
@@ -1506,6 +1508,8 @@ class IndexMapTests(unittest.TestCase):
         assert 'a_idx' not in ks_meta.indexes
         assert 'b_idx' not in ks_meta.indexes
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
+                             scylla_version="2026.1")
     def test_index_follows_alter(self):
         self.create_basic_table()
 
@@ -2047,6 +2051,8 @@ class BadMetaTest(unittest.TestCase):
             assert m._exc_info[0] is self.BadMetaException
             assert "/*\nWarning:" in m.export_as_string()
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
+                             scylla_version="2026.1")
     def test_bad_index(self):
         self.session.execute('CREATE TABLE %s (k int PRIMARY KEY, v int)' % self.function_name)
         self.session.execute('CREATE INDEX ON %s(v)' % self.function_name)
@@ -2138,6 +2144,8 @@ class DynamicCompositeTypeTest(BasicSharedKeyspaceUnitTestCase):
 
 
 @greaterthanorequalcass30
+@xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
+                         scylla_version="2026.1")
 class MaterializedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
 
     def setUp(self):
@@ -2226,6 +2234,8 @@ class MaterializedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
 
 
 @greaterthanorequalcass30
+@xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
+                             scylla_version="2026.1")
 class MaterializedViewMetadataTestComplex(BasicSegregatedKeyspaceUnitTestCase):
     def test_create_view_metadata(self):
         """

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -230,8 +230,8 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         assert ksmeta.name == self.keyspace_name
         assert ksmeta.durable_writes
-        assert ksmeta.replication_strategy.name == 'SimpleStrategy'
-        assert ksmeta.replication_strategy.replication_factor == 1
+        assert ksmeta.replication_strategy.name == 'NetworkTopologyStrategy'
+        assert ksmeta.replication_strategy.dc_replication_factors["dc1"] == 1
 
         assert self.function_table_name in ksmeta.tables
         tablemeta = ksmeta.tables[self.function_table_name]
@@ -448,6 +448,8 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         tablemeta = self.get_table_metadata()
         self.check_create_statement(tablemeta, create_statement)
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Counters are not yet supported with tablets',
+                             oss_scylla_version="7.0", ent_scylla_version="2026.1")
     def test_counter(self):
         create_statement = (
             "CREATE TABLE {keyspace}.{table} ("
@@ -601,7 +603,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         assert "new_keyspace" not in cluster2.metadata.keyspaces
 
         # Cluster metadata modification
-        self.session.execute("CREATE KEYSPACE new_keyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}")
+        self.session.execute("CREATE KEYSPACE new_keyspace WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}")
         assert "new_keyspace" not in cluster2.metadata.keyspaces
 
         cluster2.refresh_schema_metadata()
@@ -722,6 +724,8 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         cluster2.shutdown()
 
     @greaterthanorequalcass30
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
+                             oss_scylla_version="7.0", ent_scylla_version="2026.1")
     def test_refresh_metadata_for_mv(self):
         """
         test for synchronously refreshing materialized view metadata
@@ -931,6 +935,8 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
     @greaterthanorequalcass30
     @requires_collection_indexes
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
+                             oss_scylla_version="7.0", ent_scylla_version="2026.1")
     def test_multiple_indices(self):
         """
         test multiple indices on the same column.
@@ -964,6 +970,8 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         assert index_2.keyspace_name == "schemametadatatests"
 
     @greaterthanorequalcass30
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
+                             oss_scylla_version="7.0", ent_scylla_version="2026.1")
     def test_table_extensions(self):
         s = self.session
         ks = self.keyspace_name
@@ -1077,7 +1085,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         for ks in keyspaces:
             self.session.execute(
-                f"CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 3 }}"
+                f"CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }}"
             )
 
         self.cluster.schema_metadata_page_size = 2000
@@ -1138,7 +1146,7 @@ class TestCodeCoverage(unittest.TestCase):
 
         session.execute("""
             CREATE KEYSPACE export_udts
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}
             AND durable_writes = true;
         """)
         session.execute("""
@@ -1162,7 +1170,7 @@ class TestCodeCoverage(unittest.TestCase):
             addresses map<text, frozen<address>>)
         """)
 
-        expected_prefix = """CREATE KEYSPACE export_udts WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
+        expected_prefix = """CREATE KEYSPACE export_udts WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}  AND durable_writes = true;
 
 CREATE TYPE export_udts.street (
     street_number int,
@@ -1212,7 +1220,7 @@ CREATE TABLE export_udts.users (
         session.execute("DROP KEYSPACE IF EXISTS {0}".format(ksname))
         session.execute("""
             CREATE KEYSPACE "%s"
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}
             """ % (ksname,))
         session.execute("""
             CREATE TABLE "%s"."%s" (
@@ -1256,7 +1264,7 @@ CREATE TABLE export_udts.users (
 
         ddl = '''
             CREATE KEYSPACE %s
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}'''
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}'''
         with pytest.raises(AlreadyExists):
             session.execute(ddl % ksname)
 
@@ -1387,7 +1395,7 @@ class KeyspaceAlterMetadata(unittest.TestCase):
         self.session = self.cluster.connect()
         name = self._testMethodName.lower()
         crt_ks = '''
-                CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} AND durable_writes = true''' % name
+                CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND durable_writes = true''' % name
         self.session.execute(crt_ks)
 
     def tearDown(self):
@@ -1437,7 +1445,7 @@ class IndexMapTests(unittest.TestCase):
             cls.session.execute(
                 """
                 CREATE KEYSPACE %s
-                WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
+                WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'};
                 """ % cls.keyspace_name)
             cls.session.set_keyspace(cls.keyspace_name)
         except Exception:
@@ -1540,7 +1548,7 @@ class FunctionTest(unittest.TestCase):
             cls.cluster = TestCluster()
             cls.keyspace_name = cls.__name__.lower()
             cls.session = cls.cluster.connect()
-            cls.session.execute("CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}" % cls.keyspace_name)
+            cls.session.execute("CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}" % cls.keyspace_name)
             cls.session.set_keyspace(cls.keyspace_name)
             cls.keyspace_function_meta = cls.cluster.metadata.keyspaces[cls.keyspace_name].functions
             cls.keyspace_aggregate_meta = cls.cluster.metadata.keyspaces[cls.keyspace_name].aggregates
@@ -2007,7 +2015,7 @@ class BadMetaTest(unittest.TestCase):
         cls.cluster = TestCluster()
         cls.keyspace_name = cls.__name__.lower()
         cls.session = cls.cluster.connect()
-        cls.session.execute("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}" % cls.keyspace_name)
+        cls.session.execute("CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}" % cls.keyspace_name)
         cls.session.set_keyspace(cls.keyspace_name)
         connection = cls.cluster.control_connection._connection
 

--- a/tests/integration/standard/test_policies.py
+++ b/tests/integration/standard/test_policies.py
@@ -104,5 +104,5 @@ class ExponentialRetryPolicyTests(unittest.TestCase):
         self.session.execute(
             """
             CREATE KEYSPACE preparedtests
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}
             """)

--- a/tests/integration/standard/test_prepared_statements.py
+++ b/tests/integration/standard/test_prepared_statements.py
@@ -62,7 +62,7 @@ class PreparedStatementTests(unittest.TestCase):
         self.session.execute(
             """
             CREATE KEYSPACE preparedtests
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}
             """)
 
         self.session.set_keyspace("preparedtests")
@@ -437,7 +437,7 @@ class PreparedStatementTests(unittest.TestCase):
         keyspace = "test_fail_if_different_query_id_on_reprepare"
         self.session.execute(
             "CREATE KEYSPACE IF NOT EXISTS {} WITH replication = "
-            "{{'class': 'SimpleStrategy', 'replication_factor': 1}}".format(keyspace)
+            "{{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}".format(keyspace)
         )
         self.session.execute("CREATE TABLE IF NOT EXISTS {}.foo(k int PRIMARY KEY)".format(keyspace))
         prepared = self.session.prepare("SELECT * FROM {}.foo WHERE k=?".format(keyspace))

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -1359,12 +1359,12 @@ class BaseKeyspaceTests():
         cls.table_name = "table_query_keyspace_tests"
 
         ddl = """CREATE KEYSPACE {0} WITH replication =
-                        {{'class': 'SimpleStrategy',
+                        {{'class': 'NetworkTopologyStrategy',
                         'replication_factor': '{1}'}}""".format(cls.ks_name, 1)
         cls.session.execute(ddl)
 
         ddl = """CREATE KEYSPACE {0} WITH replication =
-                                {{'class': 'SimpleStrategy',
+                                {{'class': 'NetworkTopologyStrategy',
                                 'replication_factor': '{1}'}}""".format(cls.alternative_ks, 1)
         cls.session.execute(ddl)
 

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -26,7 +26,7 @@ from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DE
 from cassandra.policies import HostDistance, RoundRobinPolicy, WhiteListRoundRobinPolicy
 from tests.integration import use_singledc, PROTOCOL_VERSION, BasicSharedKeyspaceUnitTestCase, \
     greaterthanprotocolv3, MockLoggingHandler, get_supported_protocol_versions, local, get_cluster, setup_keyspace, \
-    USE_CASS_EXTERNAL, greaterthanorequalcass40, TestCluster, xfail_scylla
+    USE_CASS_EXTERNAL, greaterthanorequalcass40, TestCluster, xfail_scylla, xfail_scylla_version_lt
 from tests import notwindows
 from tests.integration import greaterthanorequalcass30, get_node
 from tests.util import assertListEqual, wait_until
@@ -804,6 +804,9 @@ class SerialConsistencyTests(unittest.TestCase):
     def tearDown(self):
         self.cluster.shutdown()
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
+                             oss_scylla_version='6.4', ent_scylla_version='2025.4',
+                             raises=InvalidRequest)
     def test_conditional_update(self):
         self.session.execute("INSERT INTO test3rf.test (k, v) VALUES (0, 0)")
         statement = SimpleStatement(
@@ -828,6 +831,9 @@ class SerialConsistencyTests(unittest.TestCase):
         assert result
         assert result.one().applied
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
+                             oss_scylla_version='6.4', ent_scylla_version='2025.4',
+                             raises=InvalidRequest)
     def test_conditional_update_with_prepared_statements(self):
         self.session.execute("INSERT INTO test3rf.test (k, v) VALUES (0, 0)")
         statement = self.session.prepare(
@@ -850,6 +856,9 @@ class SerialConsistencyTests(unittest.TestCase):
         assert result
         assert result.one().applied
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
+                             oss_scylla_version='6.4', ent_scylla_version='2025.4',
+                             raises=InvalidRequest)
     def test_conditional_update_with_batch_statements(self):
         self.session.execute("INSERT INTO test3rf.test (k, v) VALUES (0, 0)")
         statement = BatchStatement(serial_consistency_level=ConsistencyLevel.SERIAL)
@@ -915,6 +924,9 @@ class LightweightTransactionTests(unittest.TestCase):
         self.session.execute("DROP TABLE test3rf.lwt_clustering")
         self.cluster.shutdown()
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
+                             oss_scylla_version='6.4', ent_scylla_version='2025.4',
+                             raises=AttributeError)
     def test_no_connection_refused_on_timeout(self):
         """
         Test for PYTHON-91 "Connection closed after LWT timeout"

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -26,7 +26,7 @@ from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DE
 from cassandra.policies import HostDistance, RoundRobinPolicy, WhiteListRoundRobinPolicy
 from tests.integration import use_singledc, PROTOCOL_VERSION, BasicSharedKeyspaceUnitTestCase, \
     greaterthanprotocolv3, MockLoggingHandler, get_supported_protocol_versions, local, get_cluster, setup_keyspace, \
-    USE_CASS_EXTERNAL, greaterthanorequalcass40, TestCluster, xfail_scylla
+    USE_CASS_EXTERNAL, greaterthanorequalcass40, TestCluster, xfail_scylla, xfail_scylla_version_lt
 from tests import notwindows
 from tests.integration import greaterthanorequalcass30, get_node
 from tests.util import assertListEqual, wait_until
@@ -804,6 +804,9 @@ class SerialConsistencyTests(unittest.TestCase):
     def tearDown(self):
         self.cluster.shutdown()
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
+                             scylla_version='2025.4',
+                             raises=InvalidRequest)
     def test_conditional_update(self):
         self.session.execute("INSERT INTO test3rf.test (k, v) VALUES (0, 0)")
         statement = SimpleStatement(
@@ -828,6 +831,9 @@ class SerialConsistencyTests(unittest.TestCase):
         assert result
         assert result.one().applied
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
+                             scylla_version='2025.4',
+                             raises=InvalidRequest)
     def test_conditional_update_with_prepared_statements(self):
         self.session.execute("INSERT INTO test3rf.test (k, v) VALUES (0, 0)")
         statement = self.session.prepare(
@@ -850,6 +856,9 @@ class SerialConsistencyTests(unittest.TestCase):
         assert result
         assert result.one().applied
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
+                             scylla_version='2025.4',
+                             raises=InvalidRequest)
     def test_conditional_update_with_batch_statements(self):
         self.session.execute("INSERT INTO test3rf.test (k, v) VALUES (0, 0)")
         statement = BatchStatement(serial_consistency_level=ConsistencyLevel.SERIAL)
@@ -915,6 +924,9 @@ class LightweightTransactionTests(unittest.TestCase):
         self.session.execute("DROP TABLE test3rf.lwt_clustering")
         self.cluster.shutdown()
 
+    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
+                             scylla_version='2025.4',
+                             raises=AttributeError)
     def test_no_connection_refused_on_timeout(self):
         """
         Test for PYTHON-91 "Connection closed after LWT timeout"

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -1166,6 +1166,8 @@ class BatchStatementDefaultRoutingKeyTests(unittest.TestCase):
 
 
 @greaterthanorequalcass30
+@xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Materialized views and secondary indexes are not supported on base tables with tablets.',
+                         scylla_version='2026.1')
 class MaterializedViewQueryTest(BasicSharedKeyspaceUnitTestCase):
 
     def test_mv_filtering(self):

--- a/tests/integration/standard/test_rate_limit_exceeded.py
+++ b/tests/integration/standard/test_rate_limit_exceeded.py
@@ -33,7 +33,7 @@ class TestRateLimitExceededException(unittest.TestCase):
         self.session.execute(
             """
             CREATE KEYSPACE IF NOT EXISTS ratetests
-            WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}
+            WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}
             """)
 
         self.session.execute("USE ratetests")

--- a/tests/integration/standard/test_shard_aware.py
+++ b/tests/integration/standard/test_shard_aware.py
@@ -77,7 +77,7 @@ class TestShardAwareIntegration(unittest.TestCase):
         self.session.execute(
             """
             CREATE KEYSPACE preparedtests
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}
             """)
 
         self.session.execute("USE preparedtests")

--- a/tests/integration/standard/test_shard_aware.py
+++ b/tests/integration/standard/test_shard_aware.py
@@ -89,7 +89,7 @@ class TestShardAwareIntegration(unittest.TestCase):
         self.session.execute(
             """
             CREATE KEYSPACE preparedtests
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'} AND tablets = {'enabled': false}
             """)
 
         self.session.execute("USE preparedtests")
@@ -174,6 +174,8 @@ class TestShardAwareIntegration(unittest.TestCase):
 
         using the traces to validate that all the action been executed on the the same shard.
         this test is using prepared SELECT statements for this validation
+
+        Requires tablets to be disabled to ensure shard consistency.
         """
 
         self.create_ks_and_cf()

--- a/tests/integration/standard/test_tablets.py
+++ b/tests/integration/standard/test_tablets.py
@@ -9,7 +9,7 @@ from tests.unit.test_host_connection_pool import LOGGER
 
 
 def setup_module():
-    use_cluster('tablets', [3], start=True)
+    use_cluster('tablets', [3], start=True, set_keyspace=False)
 
 
 class TestTabletsIntegration:

--- a/tests/integration/standard/test_udts.py
+++ b/tests/integration/standard/test_udts.py
@@ -94,7 +94,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         # use the same UDT name in a different keyspace
         s.execute("""
             CREATE KEYSPACE udt_test_unprepared_registered2
-            WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1' }
+            WITH replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor': '1' }
             """)
         s.set_keyspace("udt_test_unprepared_registered2")
         s.execute("CREATE TYPE user (state text, is_cool boolean)")
@@ -124,14 +124,14 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         s.execute("""
             CREATE KEYSPACE udt_test_register_before_connecting
-            WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1' }
+            WITH replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor': '1' }
             """)
         s.execute("CREATE TYPE udt_test_register_before_connecting.user (age int, name text)")
         s.execute("CREATE TABLE udt_test_register_before_connecting.mytable (a int PRIMARY KEY, b frozen<user>)")
 
         s.execute("""
             CREATE KEYSPACE udt_test_register_before_connecting2
-            WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1' }
+            WITH replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor': '1' }
             """)
         s.execute("CREATE TYPE udt_test_register_before_connecting2.user (state text, is_cool boolean)")
         s.execute("CREATE TABLE udt_test_register_before_connecting2.mytable (a int PRIMARY KEY, b frozen<user>)")
@@ -193,7 +193,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         # use the same UDT name in a different keyspace
         s.execute("""
             CREATE KEYSPACE udt_test_prepared_unregistered2
-            WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1' }
+            WITH replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor': '1' }
             """)
         s.set_keyspace("udt_test_prepared_unregistered2")
         s.execute("CREATE TYPE user (state text, is_cool boolean)")
@@ -240,7 +240,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         # use the same UDT name in a different keyspace
         s.execute("""
             CREATE KEYSPACE udt_test_prepared_registered2
-            WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1' }
+            WITH replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor': '1' }
             """)
         s.set_keyspace("udt_test_prepared_registered2")
         s.execute("CREATE TYPE user (state text, is_cool boolean)")

--- a/tests/integration/standard/test_use_keyspace.py
+++ b/tests/integration/standard/test_use_keyspace.py
@@ -54,7 +54,7 @@ class TestUseKeyspace(unittest.TestCase):
             return original_set_keyspace_blocking(*args, **kwargs)
 
         with patch.object(Connection, "set_keyspace_blocking", patched_set_keyspace_blocking):
-            self.session.execute("CREATE KEYSPACE test_set_keyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+            self.session.execute("CREATE KEYSPACE test_set_keyspace WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
             self.session.execute("CREATE TABLE test_set_keyspace.set_keyspace_slow_connection(pk int, PRIMARY KEY(pk))")
 
             session2 = self.cluster.connect()

--- a/tests/integration/standard/test_use_keyspace.py
+++ b/tests/integration/standard/test_use_keyspace.py
@@ -65,7 +65,7 @@ class TestUseKeyspace(unittest.TestCase):
             return original_set_keyspace_blocking(*args, **kwargs)
 
         with patch.object(Connection, "set_keyspace_blocking", patched_set_keyspace_blocking):
-            self.session.execute("CREATE KEYSPACE test_set_keyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+            self.session.execute("CREATE KEYSPACE test_set_keyspace WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
             self.session.execute("CREATE TABLE test_set_keyspace.set_keyspace_slow_connection(pk int, PRIMARY KEY(pk))")
 
             session2 = self.cluster.connect()


### PR DESCRIPTION
In tests/integration/__init__.py, SimpleStrategy is kept but tablets are explicitly disabled to avoid decommission failures.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.