### PR TITLE
Small fixes for reconnect policy and hearbeat

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -1888,13 +1888,13 @@ class ConnectionHeartbeat(Thread):
                     self._raise_if_stopped()
 
                 # Wait max `self._timeout` seconds for all HeartbeatFutures to complete
-                timeout = self._timeout
+                timeout_left = self._timeout
                 start_time = time.time()
                 for f in futures:
                     self._raise_if_stopped()
                     connection = f.connection
                     try:
-                        f.wait(timeout)
+                        f.wait(timeout_left)
                         # TODO: move this, along with connection locks in pool, down into Connection
                         with connection.lock:
                             connection.in_flight -= 1
@@ -1904,7 +1904,7 @@ class ConnectionHeartbeat(Thread):
                                     id(connection), connection.endpoint)
                         failed_connections.append((f.connection, f.owner, e))
 
-                    timeout = self._timeout - (time.time() - start_time)
+                    timeout_left = self._timeout - (time.time() - start_time)
 
                 for connection, owner, exc in failed_connections:
                     self._raise_if_stopped()

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -1821,15 +1821,15 @@ class HeartbeatFuture(object):
                 self._exception = Exception("Failed to send heartbeat because connection 'in_flight' exceeds threshold")
                 self._event.set()
 
-    def wait(self, timeout):
+    def wait(self, timeout, original_timeout):
         self._event.wait(timeout)
         if self._event.is_set():
             if self._exception:
                 raise self._exception
         else:
-            raise OperationTimedOut("Connection heartbeat timeout after %s seconds" % (timeout,),
+            raise OperationTimedOut("Connection heartbeat timeout (total wait=%s seconds, this wait call=%s seconds)" % (original_timeout, timeout),
                                     self.connection.endpoint,
-                                    timeout=timeout,
+                                    timeout=original_timeout,
                                     in_flight=self.connection.in_flight)
 
     def _options_callback(self, response):
@@ -1894,7 +1894,7 @@ class ConnectionHeartbeat(Thread):
                     self._raise_if_stopped()
                     connection = f.connection
                     try:
-                        f.wait(timeout_left)
+                        f.wait(timeout_left, self._timeout)
                         # TODO: move this, along with connection locks in pool, down into Connection
                         with connection.lock:
                             connection.in_flight -= 1

--- a/cassandra/policies.py
+++ b/cassandra/policies.py
@@ -773,7 +773,7 @@ class ConstantReconnectionPolicy(ReconnectionPolicy):
     in-between each reconnection attempt.
     """
 
-    def __init__(self, delay, max_attempts=64):
+    def __init__(self, delay, max_attempts=None):
         """
         `delay` should be a floating point number of seconds to wait in-between
         each attempt.
@@ -807,10 +807,7 @@ class ExponentialReconnectionPolicy(ReconnectionPolicy):
     trying to reconnect at exactly the same time.
     """
 
-    # TODO: max_attempts is 64 to preserve legacy default behavior
-    # consider changing to None in major release to prevent the policy
-    # giving up forever
-    def __init__(self, base_delay, max_delay, max_attempts=64):
+    def __init__(self, base_delay, max_delay, max_attempts=None):
         """
         `base_delay` and `max_delay` should be in floating point units of
         seconds.

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -518,7 +518,7 @@ class ConnectionHeartbeatTest(unittest.TestCase):
         connection.defunct.assert_has_calls([call(ANY)] * get_holders.call_count)
         exc = connection.defunct.call_args_list[0][0][0]
         assert isinstance(exc, OperationTimedOut)
-        assert exc.errors == 'Connection heartbeat timeout after 0.05 seconds'
+        assert exc.errors == 'Connection heartbeat timeout (total wait=0.05 seconds, this wait call=0.05 seconds)'
         assert exc.last_host == DefaultEndPoint('localhost')
         assert exc.timeout == 0.05
         assert isinstance(exc.in_flight, int)


### PR DESCRIPTION
When looking into https://github.com/scylladb/python-driver/issues/295 and https://scylladb.atlassian.net/browse/SCYLLADB-1251 I found some minor issues that this PR fixes.
1. Heartbeat exceptions showed some absurd values like `Connection heartbeat timeout after -56.143085956573486 seconds, last_host=127.0.16.3:19042`. This is because they used `timeout` argument passed to `wait`, which is not the whole timeout duration, but the duration LEFT after waiting for other futures.
2. Reconnect policies had by default a maximum number of attempts. After that, the driver would just give up connecting.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.