### PR TITLE
fix(build): use dict-style license for setuptools<77 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = ['geomet>=1.1', 'pyyaml > 5.0']
 dynamic = ["version", "readme"]
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.9"
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Switches `license = "Apache-2.0"` (PEP 639 SPDX string) to `license = {text = "Apache-2.0"}` (dict-style)
- The SPDX string format requires setuptools>=77, but `[build-system]` only requires `>=70`
- Downstream projects constraining setuptools to <75 fail to build from source

Fixes #840