### PR TITLE
cluster: preserve replacement endpoint down handling

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -333,13 +333,17 @@ class _HostLivenessState(_EventFenceState):
     _UP = "up"
     _DOWN = "down"
     _PENDING_UP = "pending_up"
+    _PENDING_DOWN = "pending_down"
 
-    __slots__ = ("up_endpoint", "pending_up_endpoint")
+    __slots__ = ("up_endpoint", "down_endpoint",
+                 "pending_up_endpoint", "pending_down_endpoint")
 
     def __init__(self):
         _EventFenceState.__init__(self)
         self.up_endpoint = None
+        self.down_endpoint = None
         self.pending_up_endpoint = None
+        self.pending_down_endpoint = None
 
     @property
     def up_epoch(self):
@@ -364,6 +368,14 @@ class _HostLivenessState(_EventFenceState):
     @pending_up_epoch.setter
     def pending_up_epoch(self, epoch):
         self._set_or_clear_event(self._PENDING_UP, epoch)
+
+    @property
+    def pending_down_epoch(self):
+        return self.get_event(self._PENDING_DOWN)
+
+    @pending_down_epoch.setter
+    def pending_down_epoch(self, epoch):
+        self._set_or_clear_event(self._PENDING_DOWN, epoch)
 
 
 class _PoolCreationState(_EventFenceState):
@@ -2193,7 +2205,42 @@ class Cluster(object):
 
     def _clear_down_handling(self, host, down_epoch=None):
         state = self._get_host_liveness_state(host)
-        return state.clear_event(_HostLivenessState._DOWN, down_epoch)
+        if state.clear_event(_HostLivenessState._DOWN, down_epoch):
+            state.down_endpoint = None
+            return True
+        return False
+
+    def _clear_pending_down(self, state):
+        state.pending_down_epoch = None
+        state.pending_down_endpoint = None
+
+    def _pop_pending_node_down_if_ready(self, host):
+        state = self._get_host_liveness_state(host)
+        if state.pending_down_epoch is None:
+            state.pending_down_endpoint = None
+            return None
+        if host.is_up or state.up_epoch is not None or state.down_epoch is not None:
+            return None
+
+        pending_down_epoch = state.pending_down_epoch
+        pending_down_endpoint = state.pending_down_endpoint
+        if state.epoch != pending_down_epoch:
+            self._clear_pending_down(state)
+            return None
+
+        self._clear_pending_down(state)
+        return pending_down_epoch, pending_down_endpoint
+
+    def _handle_pending_node_down(self, host, pending_down, is_host_addition):
+        if pending_down is None:
+            return False
+        _pending_down_epoch, pending_down_endpoint = pending_down
+        log.debug("Handling queued down status of node %s", host)
+        self.on_down(
+            host, is_host_addition=is_host_addition,
+            expect_host_to_be_down=True,
+            expected_endpoint=pending_down_endpoint)
+        return True
 
     def _finish_superseded_up_handling(self, host, up_epoch, expected_endpoint=None):
         self._cleanup_superseded_up_handling(
@@ -2515,6 +2562,7 @@ class Cluster(object):
                         return
                     down_epoch = state.epoch
                     state.down_epoch = down_epoch
+                    state.down_endpoint = expected_endpoint
                 elif not owns_reserved_down_handling:
                     log.debug("Ignoring stale down handling for host %s", host)
                     return
@@ -2576,12 +2624,16 @@ class Cluster(object):
             else:
                 log.debug("Not starting reconnector for removed host %s", host)
         finally:
+            pending_down = None
             pending_up_epoch = None
             with host.lock:
                 if down_epoch is not None and self._clear_down_handling(host, down_epoch):
-                    pending_up_epoch = self._pop_pending_node_up_if_ready(host)
+                    pending_down = self._pop_pending_node_down_if_ready(host)
+                    if pending_down is None:
+                        pending_up_epoch = self._pop_pending_node_up_if_ready(host)
 
-            self._handle_pending_node_up(host, pending_up_epoch)
+            if not self._handle_pending_node_down(host, pending_down, is_host_addition):
+                self._handle_pending_node_up(host, pending_up_epoch)
 
     def on_down(self, host, is_host_addition, expect_host_to_be_down=False,
                 expected_endpoint=None):
@@ -2591,7 +2643,8 @@ class Cluster(object):
         if self.is_shutdown:
             return
 
-        if (self._discount_down_events and
+        if (not expect_host_to_be_down and
+                self._discount_down_events and
                 self.profile_manager.distance(host) != HostDistance.IGNORED):
             with host.lock:
                 host_endpoint = host.endpoint
@@ -2626,6 +2679,20 @@ class Cluster(object):
 
             was_up = host.is_up
             state = self._get_host_liveness_state(host)
+            pending_down_endpoint = None
+            if state.down_endpoint is not None:
+                target_endpoint = expected_endpoint if expected_endpoint is not None else host.endpoint
+                if not self._endpoints_match(state.down_endpoint, target_endpoint):
+                    pending_down_endpoint = target_endpoint
+
+            if pending_down_endpoint is not None:
+                state.advance()
+                state.pending_up_epoch = None
+                state.pending_up_endpoint = None
+                state.pending_down_epoch = state.epoch
+                state.pending_down_endpoint = pending_down_endpoint
+                host.set_down()
+                return
 
             if not expect_host_to_be_down:
                 if was_up is False:
@@ -2639,6 +2706,7 @@ class Cluster(object):
             state.advance()
             state.pending_up_epoch = None
             state.pending_up_endpoint = None
+            self._clear_pending_down(state)
             host.set_down()
             down_epoch = state.epoch
             if state.down_epoch is not None:
@@ -2648,16 +2716,21 @@ class Cluster(object):
                     state.up_epoch is None):
                 return
             state.down_epoch = down_epoch
+            state.down_endpoint = expected_endpoint
         log.warning("Host %s has been marked down", host)
 
         future = self.on_down_potentially_blocking(
             host, is_host_addition, down_epoch, expected_endpoint)
         if future is None:
+            pending_down = None
             pending_up_epoch = None
             with host.lock:
                 if self._clear_down_handling(host, down_epoch):
-                    pending_up_epoch = self._pop_pending_node_up_if_ready(host)
-            self._handle_pending_node_up(host, pending_up_epoch)
+                    pending_down = self._pop_pending_node_down_if_ready(host)
+                    if pending_down is None:
+                        pending_up_epoch = self._pop_pending_node_up_if_ready(host)
+            if not self._handle_pending_node_down(host, pending_down, is_host_addition):
+                self._handle_pending_node_up(host, pending_up_epoch)
 
     def on_add(self, host, refresh_nodes=True):
         if self.is_shutdown:
@@ -2742,9 +2815,11 @@ class Cluster(object):
             state.advance()
             state.pending_up_epoch = None
             state.pending_up_endpoint = None
+            self._clear_pending_down(state)
             state.up_epoch = None
             state.up_endpoint = None
             state.down_epoch = None
+            state.down_endpoint = None
             host.set_down()
             self._set_non_retryable_auth_failure(host, False)
         self.profile_manager.on_remove(host)

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2679,11 +2679,11 @@ class Cluster(object):
 
             was_up = host.is_up
             state = self._get_host_liveness_state(host)
+            down_endpoint = expected_endpoint if expected_endpoint is not None else host.endpoint
             pending_down_endpoint = None
             if state.down_endpoint is not None:
-                target_endpoint = expected_endpoint if expected_endpoint is not None else host.endpoint
-                if not self._endpoints_match(state.down_endpoint, target_endpoint):
-                    pending_down_endpoint = target_endpoint
+                if not self._endpoints_match(state.down_endpoint, down_endpoint):
+                    pending_down_endpoint = down_endpoint
 
             if pending_down_endpoint is not None:
                 state.advance()
@@ -2716,11 +2716,11 @@ class Cluster(object):
                     state.up_epoch is None):
                 return
             state.down_epoch = down_epoch
-            state.down_endpoint = expected_endpoint
+            state.down_endpoint = down_endpoint
         log.warning("Host %s has been marked down", host)
 
         future = self.on_down_potentially_blocking(
-            host, is_host_addition, down_epoch, expected_endpoint)
+            host, is_host_addition, down_epoch, down_endpoint)
         if future is None:
             pending_down = None
             pending_up_epoch = None

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1150,6 +1150,29 @@ class HostStateRaceTest(unittest.TestCase):
         assert host.is_up
         cluster.on_down_potentially_blocking.assert_not_called()
 
+    def test_forced_down_is_not_discounted_by_connected_pool(self):
+        host = self._make_host()
+        host.set_up()
+        endpoint = host.endpoint
+        pool = Mock()
+        pool.host = host
+        pool.endpoint = endpoint
+        pool.open_count = 1
+        session = self._make_session_with_pool(host, pool)
+        cluster = self._make_cluster(session=session)
+        cluster._discount_down_events = True
+        cluster.profile_manager.distance.return_value = HostDistance.LOCAL
+        cluster.on_down_potentially_blocking = Mock(return_value=None)
+        session.cluster = cluster
+
+        Cluster.on_down(
+            cluster, host, is_host_addition=False,
+            expect_host_to_be_down=True, expected_endpoint=endpoint)
+
+        assert not host.is_up
+        cluster.on_down_potentially_blocking.assert_called_once_with(
+            host, False, ANY, endpoint)
+
     @staticmethod
     def _state(cluster, host):
         return cluster._get_host_liveness_state(host)
@@ -1908,6 +1931,93 @@ class HostStateRaceTest(unittest.TestCase):
         cluster.profile_manager.on_up.assert_called_once_with(host)
         cluster.control_connection.on_up.assert_called_once_with(host)
         assert host.is_up
+        assert state.down_epoch is None
+        assert state.up_epoch is None
+        assert state.pending_up_epoch is None
+
+    def test_down_for_replacement_endpoint_during_pending_old_down_is_handled(self):
+        executor = _QueuedExecutor()
+        session = Mock()
+        listener = Mock()
+        cluster = self._make_cluster(session=session, listener=listener)
+        cluster.executor = executor
+        cluster.profile_manager.distance.return_value = HostDistance.LOCAL
+        host = self._make_host()
+        host.set_up()
+        old_endpoint = host.endpoint
+        new_endpoint = DefaultEndPoint("127.0.0.2")
+
+        Cluster.on_down(
+            cluster, host, is_host_addition=False,
+            expected_endpoint=old_endpoint)
+        state = self._state(cluster, host)
+        assert state.down_epoch == state.epoch
+
+        host.endpoint = new_endpoint
+        Cluster.on_up(cluster, host)
+        assert state.pending_up_epoch == state.epoch
+
+        Cluster.on_down(
+            cluster, host, is_host_addition=False,
+            expected_endpoint=new_endpoint)
+
+        executor.run_next()
+
+        assert len(executor.submissions) == 1
+        executor.run_next()
+
+        session.on_down.assert_any_call(
+            host, expected_endpoint=old_endpoint)
+        session.on_down.assert_any_call(
+            host, expected_endpoint=new_endpoint)
+        listener.on_down.assert_called_once_with(host)
+        cluster._start_reconnector.assert_called_once_with(
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=new_endpoint)
+        cluster.profile_manager.on_up.assert_not_called()
+        cluster.control_connection.on_up.assert_not_called()
+        assert not host.is_up
+        assert state.down_epoch is None
+        assert state.up_epoch is None
+        assert state.pending_up_epoch is None
+
+    def test_forced_down_for_replacement_endpoint_during_old_down_is_handled(self):
+        executor = _QueuedExecutor()
+        session = Mock()
+        listener = Mock()
+        cluster = self._make_cluster(session=session, listener=listener)
+        cluster.executor = executor
+        cluster.profile_manager.distance.return_value = HostDistance.LOCAL
+        host = self._make_host()
+        host.set_up()
+        old_endpoint = host.endpoint
+        new_endpoint = DefaultEndPoint("127.0.0.2")
+
+        Cluster.on_down(
+            cluster, host, is_host_addition=False,
+            expected_endpoint=old_endpoint)
+        state = self._state(cluster, host)
+        assert state.down_epoch == state.epoch
+
+        host.endpoint = new_endpoint
+        Cluster.on_down(
+            cluster, host, is_host_addition=False,
+            expect_host_to_be_down=True, expected_endpoint=new_endpoint)
+
+        executor.run_next()
+
+        assert len(executor.submissions) == 1
+        executor.run_next()
+
+        session.on_down.assert_any_call(
+            host, expected_endpoint=old_endpoint)
+        session.on_down.assert_any_call(
+            host, expected_endpoint=new_endpoint)
+        listener.on_down.assert_called_once_with(host)
+        cluster._start_reconnector.assert_called_once_with(
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=new_endpoint)
+        assert not host.is_up
         assert state.down_epoch is None
         assert state.up_epoch is None
         assert state.pending_up_epoch is None

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1209,6 +1209,31 @@ class HostStateRaceTest(unittest.TestCase):
         listener.on_down.assert_not_called()
         cluster._start_reconnector.assert_not_called()
 
+    def test_stale_generic_down_handling_uses_original_endpoint_after_endpoint_swap(self):
+        executor = _QueuedExecutor()
+        session = Mock()
+        listener = Mock()
+        cluster = self._make_cluster(session=session, listener=listener)
+        cluster.executor = executor
+        cluster.profile_manager.distance.return_value = HostDistance.LOCAL
+        host = self._make_host()
+        host.set_up()
+        old_endpoint = host.endpoint
+        new_endpoint = DefaultEndPoint("127.0.0.2")
+
+        Cluster.on_down(cluster, host, is_host_addition=False)
+        host.endpoint = new_endpoint
+
+        executor.run_next()
+
+        cluster.profile_manager.on_down.assert_not_called()
+        cluster.control_connection.on_down.assert_not_called()
+        session.on_down.assert_called_once_with(
+            host, expected_endpoint=old_endpoint)
+        listener.on_down.assert_not_called()
+        cluster._start_reconnector.assert_not_called()
+        assert self._state(cluster, host).down_epoch is None
+
     def test_unreserved_down_handling_is_ignored_during_host_up_handling(self):
         session = Mock()
         cluster = self._make_cluster(session=session)
@@ -1377,7 +1402,9 @@ class HostStateRaceTest(unittest.TestCase):
         session.on_down.assert_called_once_with(
             host, expected_endpoint=host.endpoint)
         listener.on_down.assert_called_once_with(host)
-        cluster._start_reconnector.assert_called_once_with(host, False, expected_down_epoch=ANY)
+        cluster._start_reconnector.assert_called_once_with(
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=host.endpoint)
         assert state.epoch > first_up_epoch
         assert state.up_epoch == first_up_epoch
         assert not host.is_up
@@ -1411,7 +1438,9 @@ class HostStateRaceTest(unittest.TestCase):
         session.on_down.assert_called_once_with(
             host, expected_endpoint=host.endpoint)
         listener.on_down.assert_called_once_with(host)
-        cluster._start_reconnector.assert_called_once_with(host, False, expected_down_epoch=ANY)
+        cluster._start_reconnector.assert_called_once_with(
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=host.endpoint)
         listener.on_up.assert_not_called()
         assert not host.is_up
         assert self._state(cluster, host).up_epoch is None
@@ -1445,7 +1474,8 @@ class HostStateRaceTest(unittest.TestCase):
             host, expected_endpoint=host.endpoint)
         listener.on_down.assert_called_once_with(host)
         cluster._start_reconnector.assert_called_once_with(
-            host, False, expected_down_epoch=ANY)
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=host.endpoint)
         assert session.remove_pool.call_count == 1
         listener.on_up.assert_not_called()
         assert not host.is_up
@@ -1503,7 +1533,9 @@ class HostStateRaceTest(unittest.TestCase):
         session.on_down.assert_called_once_with(
             host, expected_endpoint=host.endpoint)
         listener.on_down.assert_called_once_with(host)
-        cluster._start_reconnector.assert_called_once_with(host, False, expected_down_epoch=ANY)
+        cluster._start_reconnector.assert_called_once_with(
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=host.endpoint)
         cluster.profile_manager.on_up.assert_not_called()
         cluster.control_connection.on_up.assert_not_called()
         old_reconnector.cancel.assert_called_once_with()
@@ -1527,7 +1559,9 @@ class HostStateRaceTest(unittest.TestCase):
         session.on_down.assert_called_once_with(
             host, expected_endpoint=host.endpoint)
         listener.on_down.assert_called_once_with(host)
-        cluster._start_reconnector.assert_called_once_with(host, False, expected_down_epoch=ANY)
+        cluster._start_reconnector.assert_called_once_with(
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=host.endpoint)
         assert self._state(cluster, host).down_epoch is None
 
     def test_newer_down_before_up_side_effects_suppresses_stale_up(self):
@@ -1554,7 +1588,9 @@ class HostStateRaceTest(unittest.TestCase):
         cluster.control_connection.on_down.assert_called_once_with(host)
         cluster.profile_manager.on_up.assert_not_called()
         cluster.control_connection.on_up.assert_not_called()
-        cluster._start_reconnector.assert_called_once_with(host, False, expected_down_epoch=ANY)
+        cluster._start_reconnector.assert_called_once_with(
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=host.endpoint)
         assert not host.is_up
         assert self._state(cluster, host).up_epoch is None
         assert self._state(cluster, host).down_epoch is None
@@ -1762,7 +1798,9 @@ class HostStateRaceTest(unittest.TestCase):
         session.on_down.assert_called_once_with(
             host, expected_endpoint=host.endpoint)
         listener.on_down.assert_called_once_with(host)
-        cluster._start_reconnector.assert_called_once_with(host, False, expected_down_epoch=ANY)
+        cluster._start_reconnector.assert_called_once_with(
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=host.endpoint)
         assert not host.is_up
         assert self._state(cluster, host).up_epoch is None
         assert self._state(cluster, host).down_epoch is None
@@ -1886,7 +1924,9 @@ class HostStateRaceTest(unittest.TestCase):
         session.on_down.assert_called_once_with(
             host, expected_endpoint=host.endpoint)
         listener.on_down.assert_called_once_with(host)
-        cluster._start_reconnector.assert_called_once_with(host, False, expected_down_epoch=ANY)
+        cluster._start_reconnector.assert_called_once_with(
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=host.endpoint)
         cluster.profile_manager.on_up.assert_called_once_with(host)
         cluster.control_connection.on_up.assert_called_once_with(host)
         assert host.is_up
@@ -1908,6 +1948,7 @@ class HostStateRaceTest(unittest.TestCase):
         Cluster.on_down(
             cluster, host, is_host_addition=False, expect_host_to_be_down=True)
         state = self._state(cluster, host)
+        old_endpoint = host.endpoint
 
         host.endpoint = DefaultEndPoint("127.0.0.2")
 
@@ -1922,12 +1963,12 @@ class HostStateRaceTest(unittest.TestCase):
 
         executor.run_next()
 
-        cluster.profile_manager.on_down.assert_called_once_with(host)
-        cluster.control_connection.on_down.assert_called_once_with(host)
+        cluster.profile_manager.on_down.assert_not_called()
+        cluster.control_connection.on_down.assert_not_called()
         session.on_down.assert_called_once_with(
-            host, expected_endpoint=host.endpoint)
-        listener.on_down.assert_called_once_with(host)
-        cluster._start_reconnector.assert_called_once_with(host, False, expected_down_epoch=ANY)
+            host, expected_endpoint=old_endpoint)
+        listener.on_down.assert_not_called()
+        cluster._start_reconnector.assert_not_called()
         cluster.profile_manager.on_up.assert_called_once_with(host)
         cluster.control_connection.on_up.assert_called_once_with(host)
         assert host.is_up
@@ -2339,7 +2380,9 @@ class HostStateRaceTest(unittest.TestCase):
         assert host.is_up is False
         cluster.profile_manager.on_down.assert_called_once_with(host)
         cluster.control_connection.on_down.assert_called_once_with(host)
-        cluster._start_reconnector.assert_called_once_with(host, False, expected_down_epoch=ANY)
+        cluster._start_reconnector.assert_called_once_with(
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=host.endpoint)
 
     def test_expected_down_for_unknown_host_marks_host_down(self):
         cluster = self._make_cluster()
@@ -2351,7 +2394,9 @@ class HostStateRaceTest(unittest.TestCase):
         assert host.is_up is False
         cluster.profile_manager.on_down.assert_called_once_with(host)
         cluster.control_connection.on_down.assert_called_once_with(host)
-        cluster._start_reconnector.assert_called_once_with(host, False, expected_down_epoch=ANY)
+        cluster._start_reconnector.assert_called_once_with(
+            host, False, expected_down_epoch=ANY,
+            expected_endpoint=host.endpoint)
 
 
 class SessionTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- track active and pending down handling by endpoint
- queue replacement-endpoint down events while old endpoint down work is still running
- avoid replaying queued up handling when a newer down event should win

## Notes

This is a focused draft split from the host-state/pool race work. The base branch carries prerequisite fencing changes so this PR diff stays scoped to this issue.

Fixes #861

## Testing

Not run for this split branch.