### PR TITLE
Remove oss/ent_scylla_version params from xfail_scylla_version_lt

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -687,29 +687,24 @@ def is_scylla_enterprise(version: Version) -> bool:
     return version > Version('2000.1.1')
 
 
-def xfail_scylla_version_lt(reason, oss_scylla_version, ent_scylla_version, *args, **kwargs):
+def xfail_scylla_version_lt(reason, scylla_version, *args, **kwargs):
     """
     It is used to mark tests that are going to fail on certain scylla versions.
     :param reason: message to fail test with
-    :param oss_scylla_version: str, oss version from which test supposed to succeed
-    :param ent_scylla_version: str, enterprise version from which test supposed to succeed
+    :param scylla_version: str, version from which test supposed to succeed
     """
     if not (reason.startswith("scylladb/scylladb#") or reason.startswith("scylladb/scylla-enterprise#")):
         raise ValueError('reason should start with scylladb/scylladb#<issue-id> or scylladb/scylla-enterprise#<issue-id> to reference issue in scylla repo')
 
-    if not isinstance(ent_scylla_version, str):
-        raise ValueError('ent_scylla_version should be a str')
+    if not isinstance(scylla_version, str):
+        raise ValueError('scylla_version should be a str')
 
     if SCYLLA_VERSION is None:
         return pytest.mark.skipif(False, reason="It is just a NoOP Decor, should not skip anything")
 
     current_version = Version(get_scylla_version(SCYLLA_VERSION))
 
-    if is_scylla_enterprise(current_version):
-        return pytest.mark.xfail(current_version < Version(ent_scylla_version),
-                                 reason=reason, *args, **kwargs)
-
-    return pytest.mark.xfail(current_version < Version(oss_scylla_version), reason=reason, *args, **kwargs)
+    return pytest.mark.xfail(current_version < Version(scylla_version), reason=reason, *args, **kwargs)
 
 
 def skip_scylla_version_lt(reason, scylla_version):

--- a/tests/integration/standard/test_application_info.py
+++ b/tests/integration/standard/test_application_info.py
@@ -27,7 +27,7 @@ def teardown_module():
 
 
 @xfail_scylla_version_lt(reason='scylladb/scylla-enterprise#5467 - system.client_options is not yet supported',
-                             oss_scylla_version="7.0", ent_scylla_version="2026.1.0")
+                         scylla_version="2026.1.0")
 class ApplicationInfoTest(unittest.TestCase):
     attribute_to_startup_key = {
         'application_name': 'APPLICATION_NAME',

--- a/tests/integration/standard/test_control_connection.py
+++ b/tests/integration/standard/test_control_connection.py
@@ -135,7 +135,7 @@ class ControlConnectionTests(unittest.TestCase):
             assert 7000 == host.broadcast_port
 
     @xfail_scylla_version_lt(reason='scylladb/scylladb#26992 - system.client_routes is not yet supported',
-                             oss_scylla_version="7.0", ent_scylla_version="2026.1.0")
+                             scylla_version="2026.1.0")
     def test_client_routes_change_event(self):
         cluster = TestCluster()
 

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -1197,7 +1197,7 @@ CREATE TABLE export_udts.users (
 
     @greaterthancass21
     @xfail_scylla_version_lt(reason='scylladb/scylladb#10707 - Column name in CREATE INDEX is not quoted',
-                             oss_scylla_version="5.2", ent_scylla_version="2023.1.1")
+                             scylla_version="2023.1.1")
     def test_case_sensitivity(self):
         """
         Test that names that need to be escaped in CREATE statements are


### PR DESCRIPTION
xfail_scylla_version_lt now takes a single scylla_version parameter instead of separate oss_scylla_version and ent_scylla_version params. The enterprise/OSS version branching logic is removed; the decorator simply compares the current version against the single provided version.

Update all call sites accordingly.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.