### PR TITLE
tests: replace SimpleStrategy with NetworkTopologyStrategy

### DIFF
--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -97,7 +97,7 @@ def setup(options):
         try:
             session.execute("""
                 CREATE KEYSPACE %s
-                WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': '2' }
+                WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': '2' }
                 """ % options.keyspace)
 
             log.debug("Setting keyspace...")

--- a/cassandra/cqlengine/management.py
+++ b/cassandra/cqlengine/management.py
@@ -56,7 +56,7 @@ def _get_context(keyspaces, connections):
 
 def create_keyspace_simple(name, replication_factor, durable_writes=True, connections=None):
     """
-    Creates a keyspace with SimpleStrategy for replica placement
+    Creates a keyspace with NetworkTopologyStrategy for replica placement
 
     If the keyspace already exists, it will not be modified.
 
@@ -66,11 +66,11 @@ def create_keyspace_simple(name, replication_factor, durable_writes=True, connec
     *There are plans to guard schema-modifying functions with an environment-driven conditional.*
 
     :param str name: name of keyspace to create
-    :param int replication_factor: keyspace replication factor, used with :attr:`~.SimpleStrategy`
+    :param int replication_factor: keyspace replication factor, used with :attr:`~.NetworkTopologyStrategy`
     :param bool durable_writes: Write log is bypassed if set to False
     :param list connections: List of connection names
     """
-    _create_keyspace(name, durable_writes, 'SimpleStrategy',
+    _create_keyspace(name, durable_writes, 'NetworkTopologyStrategy',
                      {'replication_factor': replication_factor}, connections=connections)
 
 

--- a/docs/scylla-specific.rst
+++ b/docs/scylla-specific.rst
@@ -91,7 +91,7 @@ New Error Types
     session = cluster.connect()
     session.execute("""
         CREATE KEYSPACE IF NOT EXISTS keyspace1 
-        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
+        WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}
     """)
 
     session.execute("USE keyspace1")

--- a/examples/concurrent_executions/execute_async_with_queue.py
+++ b/examples/concurrent_executions/execute_async_with_queue.py
@@ -31,7 +31,7 @@ cluster = Cluster()
 session = cluster.connect()
 
 session.execute(("CREATE KEYSPACE IF NOT EXISTS examples "
-                 "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1' }"))
+                 "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1' }"))
 session.execute("USE examples")
 session.execute("CREATE TABLE IF NOT EXISTS tbl_sample_kv (id uuid, value text, PRIMARY KEY (id))")
 prepared_insert = session.prepare("INSERT INTO tbl_sample_kv (id, value) VALUES (?, ?)")

--- a/examples/concurrent_executions/execute_with_threads.py
+++ b/examples/concurrent_executions/execute_with_threads.py
@@ -34,7 +34,7 @@ cluster = Cluster()
 session = cluster.connect()
 
 session.execute(("CREATE KEYSPACE IF NOT EXISTS examples "
-                 "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1' }"))
+                 "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1' }"))
 session.execute("USE examples")
 session.execute("CREATE TABLE IF NOT EXISTS tbl_sample_kv (id uuid, value text, PRIMARY KEY (id))")
 prepared_insert = session.prepare("INSERT INTO tbl_sample_kv (id, value) VALUES (?, ?)")

--- a/examples/example_core.py
+++ b/examples/example_core.py
@@ -36,7 +36,7 @@ def main():
     log.info("creating keyspace...")
     session.execute("""
         CREATE KEYSPACE IF NOT EXISTS %s
-        WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': '2' }
+        WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': '2' }
         """ % KEYSPACE)
 
     log.info("setting keyspace...")

--- a/tests/integration/cqlengine/connections/test_connection.py
+++ b/tests/integration/cqlengine/connections/test_connection.py
@@ -76,9 +76,9 @@ class SeveralConnectionsTest(BaseCassEngTestCase):
         super(SeveralConnectionsTest, cls).setUpClass()
         cls.setup_cluster = TestCluster()
         cls.setup_session = cls.setup_cluster.connect()
-        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '{1}'}}".format(cls.keyspace1, 1)
+        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '{1}'}}".format(cls.keyspace1, 1)
         execute_with_long_wait_retry(cls.setup_session, ddl)
-        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '{1}'}}".format(cls.keyspace2, 1)
+        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '{1}'}}".format(cls.keyspace2, 1)
         execute_with_long_wait_retry(cls.setup_session, ddl)
 
     @classmethod

--- a/tests/integration/long/test_failure_types.py
+++ b/tests/integration/long/test_failure_types.py
@@ -187,7 +187,7 @@ class ClientExceptionTests(unittest.TestCase):
         self._perform_cql_statement(
             """
             CREATE KEYSPACE testksfail
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}
             """, consistency_level=ConsistencyLevel.ALL, expected_exception=None)
 
         # create table

--- a/tests/integration/long/test_policies.py
+++ b/tests/integration/long/test_policies.py
@@ -48,7 +48,7 @@ class RetryPolicyTests(unittest.TestCase):
         cluster = TestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: ep})
         session = cluster.connect()
 
-        session.execute("CREATE KEYSPACE test_retry_policy_cas WITH replication = {'class':'SimpleStrategy','replication_factor': 3};")
+        session.execute("CREATE KEYSPACE test_retry_policy_cas WITH replication = {'class':'NetworkTopologyStrategy','replication_factor': 3};")
         session.execute("CREATE TABLE test_retry_policy_cas.t (id int PRIMARY KEY, data text);")
         session.execute('INSERT INTO test_retry_policy_cas.t ("id", "data") VALUES (%(0)s, %(1)s)', {'0': 42, '1': 'testing'})
 

--- a/tests/integration/long/test_schema.py
+++ b/tests/integration/long/test_schema.py
@@ -57,7 +57,7 @@ class SchemaTests(unittest.TestCase):
                     log.debug(drop)
                     execute_until_pass(session, drop)
 
-                create = "CREATE KEYSPACE {0} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 3}}".format(keyspace)
+                create = "CREATE KEYSPACE {0} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}".format(keyspace)
                 log.debug(create)
                 execute_until_pass(session, create)
 
@@ -82,7 +82,7 @@ class SchemaTests(unittest.TestCase):
         session = self.session
 
         for i in range(30):
-            execute_until_pass(session, "CREATE KEYSPACE test_{0} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}".format(i))
+            execute_until_pass(session, "CREATE KEYSPACE test_{0} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}".format(i))
             execute_until_pass(session, "CREATE TABLE test_{0}.cf (key int PRIMARY KEY, value int)".format(i))
 
             for j in range(100):
@@ -100,10 +100,10 @@ class SchemaTests(unittest.TestCase):
 
         for i in range(30):
             try:
-                execute_until_pass(session, "CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+                execute_until_pass(session, "CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
             except AlreadyExists:
                 execute_until_pass(session, "DROP KEYSPACE test")
-                execute_until_pass(session, "CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+                execute_until_pass(session, "CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
 
             execute_until_pass(session, "CREATE TABLE test.cf (key int PRIMARY KEY, value int)")
 
@@ -132,7 +132,7 @@ class SchemaTests(unittest.TestCase):
         cluster = TestCluster(max_schema_agreement_wait=0.001)
         session = cluster.connect(wait_for_all_pools=True)
 
-        rs = session.execute("CREATE KEYSPACE test_schema_disagreement WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}")
+        rs = session.execute("CREATE KEYSPACE test_schema_disagreement WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}")
         self.check_and_wait_for_agreement(session, rs, False)
         rs = session.execute(SimpleStatement("CREATE TABLE test_schema_disagreement.cf (key int PRIMARY KEY, value int)",
                                              consistency_level=ConsistencyLevel.ALL))
@@ -144,7 +144,7 @@ class SchemaTests(unittest.TestCase):
         # These should have schema agreement
         cluster = TestCluster(max_schema_agreement_wait=100)
         session = cluster.connect()
-        rs = session.execute("CREATE KEYSPACE test_schema_disagreement WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}")
+        rs = session.execute("CREATE KEYSPACE test_schema_disagreement WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}")
         self.check_and_wait_for_agreement(session, rs, True)
         rs = session.execute(SimpleStatement("CREATE TABLE test_schema_disagreement.cf (key int PRIMARY KEY, value int)",
                                              consistency_level=ConsistencyLevel.ALL))

--- a/tests/integration/long/test_ssl.py
+++ b/tests/integration/long/test_ssl.py
@@ -116,7 +116,7 @@ def validate_ssl_options(**kwargs):
 
         # attempt a few simple commands.
         insert_keyspace = """CREATE KEYSPACE ssltest
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}
             """
         statement = SimpleStatement(insert_keyspace)
         statement.consistency_level = 3
@@ -369,7 +369,7 @@ class SSLSocketErrorTests(unittest.TestCase):
         except:
             pass
         session.execute(
-            "CREATE KEYSPACE ssl_error_test WITH replication = {'class':'SimpleStrategy','replication_factor':1};")
+            "CREATE KEYSPACE ssl_error_test WITH replication = {'class':'NetworkTopologyStrategy','replication_factor':1};")
         session.execute("CREATE TABLE ssl_error_test.big_text (id uuid PRIMARY KEY, data text);")
 
         params = {

--- a/tests/integration/long/utils.py
+++ b/tests/integration/long/utils.py
@@ -63,7 +63,7 @@ def create_schema(cluster, session, keyspace, simple_strategy=True,
 
     if simple_strategy:
         ddl = "CREATE KEYSPACE %s WITH replication" \
-              " = {'class': 'SimpleStrategy', 'replication_factor': '%s'}"
+              " = {'class': 'NetworkTopologyStrategy', 'replication_factor': '%s'}"
         session.execute(ddl % (keyspace, replication_factor), timeout=10)
     else:
         if not replication_strategy:

--- a/tests/integration/simulacron/test_empty_column.py
+++ b/tests/integration/simulacron/test_empty_column.py
@@ -140,9 +140,9 @@ class EmptyColumnTests(SimulacronCluster):
             'delay_in_ms': 0,
             'rows': [
                 {
-                    "strategy_class": "SimpleStrategy",  # C* 2.2
+                    "strategy_class": "NetworkTopologyStrategy",  # C* 2.2
                     "strategy_options": '{}',  # C* 2.2
-                    "replication": {'strategy': 'SimpleStrategy', 'replication_factor': 1},
+                    "replication": {'strategy': 'NetworkTopologyStrategy', 'replication_factor': 1},
                     "durable_writes": True,
                     "keyspace_name": "testks"
                 }

--- a/tests/unit/advanced/test_metadata.py
+++ b/tests/unit/advanced/test_metadata.py
@@ -34,8 +34,8 @@ class GraphMetadataToCQLTests(unittest.TestCase):
 
     def _create_keyspace_metadata(self, graph_engine):
         return KeyspaceMetadata(
-            'keyspace', True, 'org.apache.cassandra.locator.SimpleStrategy',
-            {'replication_factor': 1}, graph_engine=graph_engine)
+            'keyspace', True, 'org.apache.cassandra.locator.NetworkTopologyStrategy',
+            {'dc1': 1}, graph_engine=graph_engine)
 
     def _create_table_metadata(self, with_vertex=False, with_edge=False):
         tm = TableMetadataDSE68('keyspace', 'table')

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -25,7 +25,7 @@ from cassandra.cqltypes import strip_frozen
 from cassandra.marshal import uint16_unpack, uint16_pack
 from cassandra.metadata import (Murmur3Token, MD5Token,
                                 BytesToken, ReplicationStrategy,
-                                NetworkTopologyStrategy, SimpleStrategy,
+                                NetworkTopologyStrategy,
                                 LocalStrategy, protect_name,
                                 protect_names, protect_value, is_valid_name,
                                 UserType, KeyspaceMetadata, get_schema_parser,
@@ -96,14 +96,14 @@ class StrategiesTest(unittest.TestCase):
         assert rs.create('NetworkTopologyStrategy', fake_options_map).dc_replication_factors == NetworkTopologyStrategy(fake_options_map).dc_replication_factors
 
         fake_options_map = {'options': 'map'}
-        assert rs.create('SimpleStrategy', fake_options_map) is None
+        assert rs.create('NetworkTopologyStrategy', fake_options_map) is None
 
         fake_options_map = {'options': 'map'}
         assert isinstance(rs.create('LocalStrategy', fake_options_map), LocalStrategy)
 
-        fake_options_map = {'options': 'map', 'replication_factor': 3}
-        assert isinstance(rs.create('SimpleStrategy', fake_options_map), SimpleStrategy)
-        assert rs.create('SimpleStrategy', fake_options_map).replication_factor == SimpleStrategy(fake_options_map).replication_factor
+        fake_options_map = {'dc1': 3}
+        assert isinstance(rs.create('NetworkTopologyStrategy', fake_options_map), NetworkTopologyStrategy)
+        assert rs.create('NetworkTopologyStrategy', fake_options_map).dc_replication_factors == NetworkTopologyStrategy(fake_options_map).dc_replication_factors
 
         assert rs.create('xxxxxxxx', fake_options_map) == _UnknownStrategy('xxxxxxxx', fake_options_map)
 
@@ -113,38 +113,38 @@ class StrategiesTest(unittest.TestCase):
             rs.export_for_schema()
 
     def test_simple_replication_type_parsing(self):
-        """ Test equality between passing numeric and string replication factor for simple strategy """
+        """ Test equality between passing numeric and string replication factor for NTS """
         rs = ReplicationStrategy()
 
-        simple_int = rs.create('SimpleStrategy', {'replication_factor': 3})
-        simple_str = rs.create('SimpleStrategy', {'replication_factor': '3'})
+        nts_int = rs.create('NetworkTopologyStrategy', {'dc1': 3})
+        nts_str = rs.create('NetworkTopologyStrategy', {'dc1': '3'})
 
-        assert simple_int.export_for_schema() == simple_str.export_for_schema()
-        assert simple_int == simple_str
+        assert nts_int.export_for_schema() == nts_str.export_for_schema()
+        assert nts_int == nts_str
 
         # make token replica map
         ring = [MD5Token(0), MD5Token(1), MD5Token(2)]
-        hosts = [Host('dc1.{}'.format(host), SimpleConvictionPolicy, host_id=uuid.uuid4()) for host in range(3)]
+        hosts = [Host('dc1.{}'.format(host), SimpleConvictionPolicy, datacenter='dc1', rack='rack1', host_id=uuid.uuid4()) for host in range(3)]
         token_to_host = dict(zip(ring, hosts))
-        assert simple_int.make_token_replica_map(token_to_host, ring) == simple_str.make_token_replica_map(token_to_host, ring)
+        assert nts_int.make_token_replica_map(token_to_host, ring) == nts_str.make_token_replica_map(token_to_host, ring)
 
     def test_transient_replication_parsing(self):
-        """ Test that we can PARSE a transient replication factor for SimpleStrategy """
+        """ Test that we can PARSE a transient replication factor for NetworkTopologyStrategy """
         rs = ReplicationStrategy()
 
-        simple_transient = rs.create('SimpleStrategy', {'replication_factor': '3/1'})
-        assert simple_transient.replication_factor_info == ReplicationFactor(3, 1)
-        assert simple_transient.replication_factor == 2
-        assert "'replication_factor': '3/1'" in simple_transient.export_for_schema()
+        nts_transient = rs.create('NetworkTopologyStrategy', {'dc1': '3/1'})
+        assert nts_transient.dc_replication_factors_info['dc1'] == ReplicationFactor(3, 1)
+        assert nts_transient.dc_replication_factors['dc1'] == 2
+        assert "'dc1': '3/1'" in nts_transient.export_for_schema()
 
-        simple_str = rs.create('SimpleStrategy', {'replication_factor': '2'})
-        assert simple_transient != simple_str
+        nts_str = rs.create('NetworkTopologyStrategy', {'dc1': '2'})
+        assert nts_transient != nts_str
 
         # make token replica map
         ring = [MD5Token(0), MD5Token(1), MD5Token(2)]
-        hosts = [Host('dc1.{}'.format(host), SimpleConvictionPolicy, host_id=uuid.uuid4()) for host in range(3)]
+        hosts = [Host('dc1.{}'.format(host), SimpleConvictionPolicy, datacenter='dc1', rack='rack1', host_id=uuid.uuid4()) for host in range(3)]
         token_to_host = dict(zip(ring, hosts))
-        assert simple_transient.make_token_replica_map(token_to_host, ring) == simple_str.make_token_replica_map(token_to_host, ring)
+        assert nts_transient.make_token_replica_map(token_to_host, ring) == nts_str.make_token_replica_map(token_to_host, ring)
 
     def test_nts_replication_parsing(self):
         """ Test equality between passing numeric and string replication factor for NTS """
@@ -318,9 +318,9 @@ class StrategiesTest(unittest.TestCase):
         assert "{'class': 'NetworkTopologyStrategy', 'dc1': '1', 'dc2': '2'}" == strategy.export_for_schema()
 
     def test_simple_strategy_make_token_replica_map(self):
-        host1 = Host('1', SimpleConvictionPolicy, host_id=uuid.uuid4())
-        host2 = Host('2', SimpleConvictionPolicy, host_id=uuid.uuid4())
-        host3 = Host('3', SimpleConvictionPolicy, host_id=uuid.uuid4())
+        host1 = Host('1', SimpleConvictionPolicy, datacenter='dc1', rack='rack1', host_id=uuid.uuid4())
+        host2 = Host('2', SimpleConvictionPolicy, datacenter='dc1', rack='rack1', host_id=uuid.uuid4())
+        host3 = Host('3', SimpleConvictionPolicy, datacenter='dc1', rack='rack1', host_id=uuid.uuid4())
         token_to_host_owner = {
             MD5Token(0): host1,
             MD5Token(100): host2,
@@ -328,23 +328,23 @@ class StrategiesTest(unittest.TestCase):
         }
         ring = [MD5Token(0), MD5Token(100), MD5Token(200)]
 
-        rf1_replicas = SimpleStrategy({'replication_factor': '1'}).make_token_replica_map(token_to_host_owner, ring)
+        rf1_replicas = NetworkTopologyStrategy({'dc1': '1'}).make_token_replica_map(token_to_host_owner, ring)
         assertCountEqual(rf1_replicas[MD5Token(0)], [host1])
         assertCountEqual(rf1_replicas[MD5Token(100)], [host2])
         assertCountEqual(rf1_replicas[MD5Token(200)], [host3])
 
-        rf2_replicas = SimpleStrategy({'replication_factor': '2'}).make_token_replica_map(token_to_host_owner, ring)
+        rf2_replicas = NetworkTopologyStrategy({'dc1': '2'}).make_token_replica_map(token_to_host_owner, ring)
         assertCountEqual(rf2_replicas[MD5Token(0)], [host1, host2])
         assertCountEqual(rf2_replicas[MD5Token(100)], [host2, host3])
         assertCountEqual(rf2_replicas[MD5Token(200)], [host3, host1])
 
-        rf3_replicas = SimpleStrategy({'replication_factor': '3'}).make_token_replica_map(token_to_host_owner, ring)
+        rf3_replicas = NetworkTopologyStrategy({'dc1': '3'}).make_token_replica_map(token_to_host_owner, ring)
         assertCountEqual(rf3_replicas[MD5Token(0)], [host1, host2, host3])
         assertCountEqual(rf3_replicas[MD5Token(100)], [host2, host3, host1])
         assertCountEqual(rf3_replicas[MD5Token(200)], [host3, host1, host2])
 
     def test_ss_equals(self):
-        assert SimpleStrategy({'replication_factor': '1'}) != NetworkTopologyStrategy({'dc1': 2})
+        assert NetworkTopologyStrategy({'dc1': '1'}) != NetworkTopologyStrategy({'dc1': 2})
 
 
 class NameEscapingTest(unittest.TestCase):
@@ -409,9 +409,9 @@ class NameEscapingTest(unittest.TestCase):
 class GetReplicasTest(unittest.TestCase):
     def _get_replicas(self, token_klass):
         tokens = [token_klass(i) for i in range(0, (2 ** 127 - 1), 2 ** 125)]
-        hosts = [Host("ip%d" % i, SimpleConvictionPolicy, host_id=uuid.uuid4()) for i in range(len(tokens))]
+        hosts = [Host("ip%d" % i, SimpleConvictionPolicy, datacenter="dc1", rack="rack1", host_id=uuid.uuid4()) for i in range(len(tokens))]
         token_to_primary_replica = dict(zip(tokens, hosts))
-        keyspace = KeyspaceMetadata("ks", True, "SimpleStrategy", {"replication_factor": "1"})
+        keyspace = KeyspaceMetadata("ks", True, "NetworkTopologyStrategy", {"dc1": "1"})
         metadata = Mock(spec=Metadata, keyspaces={'ks': keyspace})
         token_map = TokenMap(token_klass, token_to_primary_replica, tokens, metadata)
 
@@ -524,13 +524,13 @@ class KeyspaceMetadataTest(unittest.TestCase):
 
     def test_export_as_string_user_types(self):
         keyspace_name = 'test'
-        keyspace = KeyspaceMetadata(keyspace_name, True, 'SimpleStrategy', dict(replication_factor=3))
+        keyspace = KeyspaceMetadata(keyspace_name, True, 'NetworkTopologyStrategy', dict(dc1=3))
         keyspace.user_types['a'] = UserType(keyspace_name, 'a', ['one', 'two'], ['c', 'int'])
         keyspace.user_types['b'] = UserType(keyspace_name, 'b', ['one', 'two', 'three'], ['d', 'int', 'a'])
         keyspace.user_types['c'] = UserType(keyspace_name, 'c', ['one'], ['int'])
         keyspace.user_types['d'] = UserType(keyspace_name, 'd', ['one'], ['c'])
 
-        assert """CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;
+        assert """CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': '3'}  AND durable_writes = true;
 
 CREATE TYPE test.c (
     one int
@@ -662,7 +662,7 @@ class UnicodeIdentifiersTests(unittest.TestCase):
     name = b'\'_-()"\xc2\xac'.decode('utf-8')
 
     def test_keyspace_name(self):
-        km = KeyspaceMetadata(self.name, False, 'SimpleStrategy', {'replication_factor': 1})
+        km = KeyspaceMetadata(self.name, False, 'NetworkTopologyStrategy', {'dc1': 1})
         km.export_as_string()
 
     def test_table_name(self):


### PR DESCRIPTION
ScyllaDB has dropped support for SimpleStrategy. Update all tests to use NetworkTopologyStrategy instead. Hosts in token replica map tests now include datacenter and rack attributes as required by NTS.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.