### PR TITLE
tests: use tablets-disabled keyspace instead of xfail for scylladb/scylladb#22677

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -707,6 +707,17 @@ def xfail_scylla_version_lt(reason, scylla_version, *args, **kwargs):
     return pytest.mark.xfail(current_version < Version(scylla_version), reason=reason, *args, **kwargs)
 
 
+def get_tablets_disabled_ddl_suffix(scylla_version='2026.1'):
+    """
+    Returns DDL option string for disabling tablets on ScyllaDB versions older than scylla_version.
+    Used to work around features not yet supported with tablets (e.g. MVs, secondary indexes, counters).
+    :param scylla_version: str, version from which tablets support the feature
+    """
+    if SCYLLA_VERSION is not None and Version(get_scylla_version(SCYLLA_VERSION)) < Version(scylla_version):
+        return " AND tablets = {'enabled': false}"
+    return ""
+
+
 def skip_scylla_version_lt(reason, scylla_version):
     """
     Skip tests on scylla versions older than the specified thresholds.

--- a/tests/integration/cqlengine/query/test_named.py
+++ b/tests/integration/cqlengine/query/test_named.py
@@ -27,7 +27,7 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine.query.test_queryset import BaseQuerySetUsage
 
 
-from tests.integration import BasicSharedKeyspaceUnitTestCase, greaterthanorequalcass30, requires_collection_indexes, xfail_scylla_version_lt
+from tests.integration import BasicSharedKeyspaceUnitTestCase, greaterthanorequalcass30, requires_collection_indexes, get_tablets_disabled_ddl_suffix, execute_with_long_wait_retry
 import pytest
 
 
@@ -281,6 +281,12 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
 class TestNamedWithMV(BasicSharedKeyspaceUnitTestCase):
 
     @classmethod
+    def create_keyspace(cls, rf):
+        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '{1}'}}{2}".format(
+            cls.ks_name, rf, get_tablets_disabled_ddl_suffix())
+        execute_with_long_wait_retry(cls.session, ddl)
+
+    @classmethod
     def setUpClass(cls):
         super(TestNamedWithMV, cls).setUpClass()
         cls.default_keyspace = models.DEFAULT_KEYSPACE
@@ -292,8 +298,6 @@ class TestNamedWithMV(BasicSharedKeyspaceUnitTestCase):
         super(TestNamedWithMV, cls).tearDownClass()
 
     @greaterthanorequalcass30
-    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Materialized views and secondary indexes are not supported on base tables with tablets.',
-                             scylla_version='2026.1')
     @execute_count(5)
     def test_named_table_with_mv(self):
         """

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -45,7 +45,7 @@ from tests.integration import (get_cluster, use_singledc, PROTOCOL_VERSION, exec
                                lessthancass40,
                                TestCluster, requires_java_udf, requires_composite_type,
                                requires_collection_indexes, SCYLLA_VERSION, xfail_scylla, xfail_scylla_version_lt,
-                               requirescompactstorage)
+                               requirescompactstorage, get_tablets_disabled_ddl_suffix, execute_with_long_wait_retry)
 
 from tests.util import wait_until, assertRegex, assertDictEqual, assertListEqual, assert_startswith_diff
 
@@ -140,6 +140,12 @@ class MetaDataRemovalTest(unittest.TestCase):
 
 
 class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+
+    @classmethod
+    def create_keyspace(cls, rf):
+        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '{1}'}}{2}".format(
+            cls.ks_name, rf, get_tablets_disabled_ddl_suffix())
+        execute_with_long_wait_retry(cls.session, ddl)
 
     def test_schema_metadata_disable(self):
         """
@@ -448,8 +454,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         tablemeta = self.get_table_metadata()
         self.check_create_statement(tablemeta, create_statement)
 
-    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Counters are not yet supported with tablets',
-                             scylla_version="2026.1")
     def test_counter(self):
         create_statement = (
             "CREATE TABLE {keyspace}.{table} ("
@@ -724,8 +728,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         cluster2.shutdown()
 
     @greaterthanorequalcass30
-    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                             scylla_version="2026.1")
     def test_refresh_metadata_for_mv(self):
         """
         test for synchronously refreshing materialized view metadata
@@ -935,8 +937,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
     @greaterthanorequalcass30
     @requires_collection_indexes
-    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                             scylla_version="2026.1")
     def test_multiple_indices(self):
         """
         test multiple indices on the same column.
@@ -970,8 +970,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         assert index_2.keyspace_name == "schemametadatatests"
 
     @greaterthanorequalcass30
-    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                             scylla_version="2026.1")
     def test_table_extensions(self):
         s = self.session
         ks = self.keyspace_name
@@ -1204,8 +1202,6 @@ CREATE TABLE export_udts.users (
         cluster.shutdown()
 
     @greaterthancass21
-    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                             scylla_version="2026.1")
     def test_case_sensitivity(self):
         """
         Test that names that need to be escaped in CREATE statements are
@@ -1218,10 +1214,9 @@ CREATE TABLE export_udts.users (
         cfname = 'AnInterestingTable'
 
         session.execute("DROP KEYSPACE IF EXISTS {0}".format(ksname))
-        session.execute("""
-            CREATE KEYSPACE "%s"
-            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}
-            """ % (ksname,))
+        session.execute(
+            ("CREATE KEYSPACE \"%s\" WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}" +
+             get_tablets_disabled_ddl_suffix()) % (ksname,))
         session.execute("""
             CREATE TABLE "%s"."%s" (
                 k int,
@@ -1442,11 +1437,9 @@ class IndexMapTests(unittest.TestCase):
             if cls.keyspace_name in cls.cluster.metadata.keyspaces:
                 cls.session.execute("DROP KEYSPACE %s" % cls.keyspace_name)
 
-            cls.session.execute(
-                """
-                CREATE KEYSPACE %s
-                WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'};
-                """ % cls.keyspace_name)
+            ddl = ("CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}" +
+                   get_tablets_disabled_ddl_suffix())
+            cls.session.execute(ddl % cls.keyspace_name)
             cls.session.set_keyspace(cls.keyspace_name)
         except Exception:
             cls.cluster.shutdown()
@@ -1465,8 +1458,6 @@ class IndexMapTests(unittest.TestCase):
     def drop_basic_table(self):
         self.session.execute("DROP TABLE %s" % self.table_name)
 
-    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                             scylla_version="2026.1")
     def test_index_updates(self):
         self.create_basic_table()
 
@@ -1508,8 +1499,6 @@ class IndexMapTests(unittest.TestCase):
         assert 'a_idx' not in ks_meta.indexes
         assert 'b_idx' not in ks_meta.indexes
 
-    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                             scylla_version="2026.1")
     def test_index_follows_alter(self):
         self.create_basic_table()
 
@@ -2019,7 +2008,8 @@ class BadMetaTest(unittest.TestCase):
         cls.cluster = TestCluster()
         cls.keyspace_name = cls.__name__.lower()
         cls.session = cls.cluster.connect()
-        cls.session.execute("CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}" % cls.keyspace_name)
+        ddl = "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}" + get_tablets_disabled_ddl_suffix()
+        cls.session.execute(ddl % cls.keyspace_name)
         cls.session.set_keyspace(cls.keyspace_name)
         connection = cls.cluster.control_connection._connection
 
@@ -2051,8 +2041,6 @@ class BadMetaTest(unittest.TestCase):
             assert m._exc_info[0] is self.BadMetaException
             assert "/*\nWarning:" in m.export_as_string()
 
-    @xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                             scylla_version="2026.1")
     def test_bad_index(self):
         self.session.execute('CREATE TABLE %s (k int PRIMARY KEY, v int)' % self.function_name)
         self.session.execute('CREATE INDEX ON %s(v)' % self.function_name)
@@ -2144,9 +2132,14 @@ class DynamicCompositeTypeTest(BasicSharedKeyspaceUnitTestCase):
 
 
 @greaterthanorequalcass30
-@xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                         scylla_version="2026.1")
 class MaterializedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
+
+    @classmethod
+    def create_keyspace(cls, rf):
+        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '{1}'}}{2}".format(
+            cls.ks_name, rf, get_tablets_disabled_ddl_suffix())
+        execute_with_long_wait_retry(cls.session, ddl)
+
 
     def setUp(self):
         self.session.execute("CREATE TABLE {0}.{1} (pk int PRIMARY KEY, c int)".format(self.keyspace_name, self.function_table_name))
@@ -2234,9 +2227,14 @@ class MaterializedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
 
 
 @greaterthanorequalcass30
-@xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Secondary indexes are not supported on base tables with tablets',
-                             scylla_version="2026.1")
 class MaterializedViewMetadataTestComplex(BasicSegregatedKeyspaceUnitTestCase):
+
+    @classmethod
+    def create_keyspace(cls, rf):
+        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '{1}'}}{2}".format(
+            cls.ks_name, rf, get_tablets_disabled_ddl_suffix())
+        execute_with_long_wait_retry(cls.session, ddl)
+
     def test_create_view_metadata(self):
         """
         test to ensure that materialized view metadata is properly constructed

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -26,7 +26,8 @@ from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DE
 from cassandra.policies import HostDistance, RoundRobinPolicy, WhiteListRoundRobinPolicy
 from tests.integration import use_singledc, PROTOCOL_VERSION, BasicSharedKeyspaceUnitTestCase, \
     greaterthanprotocolv3, MockLoggingHandler, get_supported_protocol_versions, local, get_cluster, setup_keyspace, \
-    USE_CASS_EXTERNAL, greaterthanorequalcass40, TestCluster, xfail_scylla, xfail_scylla_version_lt
+    USE_CASS_EXTERNAL, greaterthanorequalcass40, TestCluster, xfail_scylla, xfail_scylla_version_lt, \
+    get_tablets_disabled_ddl_suffix, execute_with_long_wait_retry
 from tests import notwindows
 from tests.integration import greaterthanorequalcass30, get_node
 from tests.util import assertListEqual, wait_until
@@ -1166,9 +1167,13 @@ class BatchStatementDefaultRoutingKeyTests(unittest.TestCase):
 
 
 @greaterthanorequalcass30
-@xfail_scylla_version_lt(reason='scylladb/scylladb#22677 - Materialized views and secondary indexes are not supported on base tables with tablets.',
-                         scylla_version='2026.1')
 class MaterializedViewQueryTest(BasicSharedKeyspaceUnitTestCase):
+
+    @classmethod
+    def create_keyspace(cls, rf):
+        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '{1}'}}{2}".format(
+            cls.ks_name, rf, get_tablets_disabled_ddl_suffix())
+        execute_with_long_wait_retry(cls.session, ddl)
 
     def test_mv_filtering(self):
         """


### PR DESCRIPTION
Tests that previously xfailed on ScyllaDB < 2026.1 due to MVs, secondary indexes, and counters not being supported on tables with tablets now create their keyspace with `'AND tablets = {"enabled": false}'` for those older versions, so the tests run and pass rather than being expected to fail.

A new helper `get_tablets_disabled_ddl_suffix()` is added to `tests/integration/__init__.py` to return the appropriate DDL suffix.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.