### PR TITLE
Remove unused imports

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -45,8 +45,7 @@ import uuid
 import weakref
 from weakref import WeakValueDictionary
 
-from cassandra import (ConsistencyLevel, AuthenticationFailed, InvalidRequest,
-                       OperationTimedOut, UnsupportedOperation,
+from cassandra import (ConsistencyLevel, AuthenticationFailed, OperationTimedOut, UnsupportedOperation,
                        SchemaTargetType, DriverException, ProtocolVersion,
                        UnresolvableContactPoints, DependencyException)
 from cassandra.auth import _proxy_execute_key, PlainTextAuthProvider
@@ -85,7 +84,7 @@ from cassandra.query import (SimpleStatement, PreparedStatement, BoundStatement,
                              named_tuple_factory, dict_factory, tuple_factory, FETCH_SIZE_UNSET,
                              HostTargetingStatement)
 from cassandra.marshal import int64_pack
-from cassandra.tablets import Tablet, Tablets
+from cassandra.tablets import Tablet
 from cassandra.timestamps import MonotonicTimestampGenerator
 from cassandra.util import _resolve_contact_points_to_string_map, Version, maybe_add_timeout_to_query
 

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -17,7 +17,6 @@ from collections import namedtuple
 from heapq import heappush, heappop
 from itertools import cycle
 from threading import Condition
-import sys
 
 from cassandra.cluster import ResultSet, EXEC_PROFILE_DEFAULT
 

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -51,7 +51,7 @@ from cassandra.protocol import (ReadyMessage, AuthenticateMessage, OptionsMessag
                                 RegisterMessage, ReviseRequestMessage)
 from cassandra.segment import SegmentCodec, CrcException
 from cassandra.util import OrderedDict
-from cassandra.shard_info import ShardingInfo
+from cassandra.shard_info import ShardingInfo  # noqa: F401  # re-exported for cassandra.connection.ShardingInfo
 
 log = logging.getLogger(__name__)
 

--- a/cassandra/cqlengine/connection.py
+++ b/cassandra/cqlengine/connection.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 import logging
 import threading
 
-from cassandra.cluster import Cluster, _ConfigMode, _NOT_SET, NoHostAvailable, UserTypeDoesNotExist, ConsistencyLevel
+from cassandra.cluster import Cluster, _ConfigMode, _NOT_SET, NoHostAvailable, UserTypeDoesNotExist
 from cassandra.query import SimpleStatement, dict_factory
 
 from cassandra.cqlengine import CQLEngineException

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -18,7 +18,7 @@ from functools import partial
 import time
 from warnings import warn
 
-from cassandra.query import SimpleStatement, BatchType as CBatchType, BatchStatement
+from cassandra.query import SimpleStatement, BatchType as CBatchType
 from cassandra.cqlengine import columns, CQLEngineException, ValidationError, UnicodeMixin
 from cassandra.cqlengine import connection as conn
 from cassandra.cqlengine.functions import Token, BaseQueryFunction, QueryValue

--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -44,7 +44,7 @@ import sys
 from uuid import UUID
 
 from cassandra.marshal import (int8_pack, int8_unpack, int16_pack, int16_unpack,
-                               uint16_pack, uint16_unpack, uint32_pack, uint32_unpack,
+                               uint16_unpack, uint32_pack, uint32_unpack,
                                int32_pack, int32_unpack, int64_pack, int64_unpack,
                                float_pack, float_unpack, double_pack, double_unpack,
                                varint_pack, varint_unpack, point_be, point_le,

--- a/cassandra/datastax/cloud/__init__.py
+++ b/cassandra/datastax/cloud/__init__.py
@@ -15,7 +15,6 @@
 import os
 import logging
 import json
-import sys
 import tempfile
 import shutil
 from urllib.request import urlopen

--- a/cassandra/encoder.py
+++ b/cassandra/encoder.py
@@ -25,7 +25,6 @@ from decimal import Decimal
 import calendar
 import datetime
 import math
-import sys
 import types
 from uuid import UUID
 import ipaddress

--- a/cassandra/io/asyncioreactor.py
+++ b/cassandra/io/asyncioreactor.py
@@ -7,7 +7,7 @@ import logging
 import os
 import socket
 import ssl
-from threading import Lock, Thread, get_ident
+from threading import Lock, Thread
 
 
 log = logging.getLogger(__name__)

--- a/cassandra/io/asyncorereactor.py
+++ b/cassandra/io/asyncorereactor.py
@@ -20,7 +20,6 @@ import socket
 import sys
 from threading import Lock, Thread, Event
 import time
-import weakref
 import sys
 import ssl
 

--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -18,11 +18,9 @@ Connection pooling and host management.
 from concurrent.futures import Future
 from functools import total_ordering
 import logging
-import socket
 import time
 import random
 import copy
-import uuid
 from threading import Lock, RLock, Condition
 import weakref
 try:

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -27,14 +27,17 @@ from cassandra import (Unavailable, WriteTimeout, RateLimitReached, ReadTimeout,
                        AlreadyExists, InvalidRequest, Unauthorized,
                        UnsupportedOperation, UserFunctionDescriptor,
                        UserAggregateDescriptor, SchemaTargetType)
-from cassandra.cqltypes import (AsciiType, BytesType, BooleanType,
-                                CounterColumnType, DateType, DecimalType,
-                                DoubleType, FloatType, Int32Type,
-                                InetAddressType, IntegerType, ListType,
-                                LongType, MapType, SetType, TimeUUIDType,
-                                UTF8Type, VarcharType, UUIDType, UserType,
-                                TupleType, lookup_casstype, SimpleDateType,
-                                TimeType, ByteType, ShortType, DurationType)
+# NOTE: many of these names are not referenced directly, but are required in module
+# scope because ResultMessage.type_codes resolves them dynamically via globals()[name]
+# (see the type_codes mapping below). Do not remove as "unused imports".
+from cassandra.cqltypes import (AsciiType, BytesType, BooleanType,  # noqa: F401
+                                CounterColumnType, DateType, DecimalType,  # noqa: F401
+                                DoubleType, FloatType, Int32Type,  # noqa: F401
+                                InetAddressType, IntegerType, ListType,  # noqa: F401
+                                LongType, MapType, SetType, TimeUUIDType,  # noqa: F401
+                                UTF8Type, VarcharType, UUIDType, UserType,  # noqa: F401
+                                TupleType, lookup_casstype, SimpleDateType,  # noqa: F401
+                                TimeType, ByteType, ShortType, DurationType)  # noqa: F401
 from cassandra.marshal import (int32_pack, int32_unpack, uint16_pack, uint16_unpack,
                                uint8_pack, int8_unpack, uint64_pack,
                                v3_header_pack, uint32_pack, uint32_le_unpack, uint32_le_pack)

--- a/tests/integration/cqlengine/__init__.py
+++ b/tests/integration/cqlengine/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import unittest
 from cassandra import ConsistencyLevel
 
 from cassandra.cqlengine import connection

--- a/tests/integration/cqlengine/base.py
+++ b/tests/integration/cqlengine/base.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import unittest
 
-import sys
 
 from cassandra.cqlengine.connection import get_session
 from cassandra.cqlengine.models import Model

--- a/tests/integration/cqlengine/connections/test_connection.py
+++ b/tests/integration/cqlengine/connections/test_connection.py
@@ -23,7 +23,7 @@ from cassandra.cluster import ExecutionProfile, _clusters_for_shutdown, _ConfigM
 from cassandra.policies import RoundRobinPolicy
 from cassandra.query import dict_factory
 
-from tests.integration import CASSANDRA_IP, PROTOCOL_VERSION, execute_with_long_wait_retry, local, TestCluster
+from tests.integration import CASSANDRA_IP, execute_with_long_wait_retry, local, TestCluster
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine import DEFAULT_KEYSPACE, setup_connection
 

--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -14,7 +14,6 @@
 import unittest
 
 from unittest import mock
-import logging
 from packaging.version import Version
 from cassandra.cqlengine.connection import get_session, get_cluster
 from cassandra.cqlengine import CQLEngineException

--- a/tests/integration/cqlengine/model/test_model.py
+++ b/tests/integration/cqlengine/model/test_model.py
@@ -20,7 +20,6 @@ from cassandra.cqlengine.management import sync_table, drop_table, create_keyspa
 from cassandra.cqlengine import models
 from cassandra.cqlengine.models import Model, ModelDefinitionException
 from uuid import uuid1
-from tests.integration import pypy
 from tests.integration.cqlengine.base import TestQueryUpdateModel
 import pytest
 

--- a/tests/integration/cqlengine/model/test_model_io.py
+++ b/tests/integration/cqlengine/model/test_model_io.py
@@ -19,7 +19,6 @@ from datetime import datetime, date, time, timezone
 from decimal import Decimal
 from operator import itemgetter
 
-import cassandra
 from cassandra.cqlengine import columns
 from cassandra.cqlengine import CQLEngineException
 from cassandra.cqlengine.management import sync_table

--- a/tests/integration/cqlengine/query/test_named.py
+++ b/tests/integration/cqlengine/query/test_named.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 
 from cassandra import ConsistencyLevel
 from cassandra.cqlengine import operators
@@ -22,7 +21,7 @@ from cassandra.cqlengine.query import ResultObject
 from cassandra.concurrent import execute_concurrent_with_args
 from cassandra.cqlengine import models
 
-from tests.integration.cqlengine import setup_connection, execute_count
+from tests.integration.cqlengine import execute_count
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine.query.test_queryset import BaseQuerySetUsage
 

--- a/tests/integration/cqlengine/statements/test_select_statement.py
+++ b/tests/integration/cqlengine/statements/test_select_statement.py
@@ -14,7 +14,7 @@
 import unittest
 
 from cassandra.cqlengine.columns import Column
-from cassandra.cqlengine.statements import SelectStatement, WhereClause
+from cassandra.cqlengine.statements import SelectStatement
 from cassandra.cqlengine.operators import *
 
 class SelectStatementTests(unittest.TestCase):

--- a/tests/integration/cqlengine/statements/test_update_statement.py
+++ b/tests/integration/cqlengine/statements/test_update_statement.py
@@ -15,9 +15,7 @@ import unittest
 
 from cassandra.cqlengine.columns import Column, Set, List, Text
 from cassandra.cqlengine.operators import *
-from cassandra.cqlengine.statements import (UpdateStatement, WhereClause,
-                                  AssignmentClause, SetUpdateClause,
-                                  ListUpdateClause)
+from cassandra.cqlengine.statements import (UpdateStatement)
 
 
 class UpdateStatementTests(unittest.TestCase):

--- a/tests/integration/cqlengine/test_connections.py
+++ b/tests/integration/cqlengine/test_connections.py
@@ -17,12 +17,12 @@ from cassandra.cluster import NoHostAvailable
 from cassandra.cqlengine import columns, CQLEngineException
 from cassandra.cqlengine import connection as conn
 from cassandra.cqlengine.management import drop_keyspace, sync_table, drop_table, create_keyspace_simple
-from cassandra.cqlengine.models import Model, QuerySetDescriptor
+from cassandra.cqlengine.models import Model
 from cassandra.cqlengine.query import ContextQuery, BatchQuery, ModelQuerySet
 from tests.integration.cqlengine import setup_connection, DEFAULT_KEYSPACE
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine.query import test_queryset
-from tests.integration import local, CASSANDRA_IP, TestCluster
+from tests.integration import CASSANDRA_IP, TestCluster
 import pytest
 
 

--- a/tests/integration/cqlengine/test_ifexists.py
+++ b/tests/integration/cqlengine/test_ifexists.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.management import sync_table, drop_table
 from cassandra.cqlengine.models import Model
-from cassandra.cqlengine.query import BatchQuery, BatchType, LWTException, IfExistsWithCounterColumn
+from cassandra.cqlengine.query import BatchQuery, LWTException, IfExistsWithCounterColumn
 
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration import PROTOCOL_VERSION

--- a/tests/integration/cqlengine/test_ttl.py
+++ b/tests/integration/cqlengine/test_ttl.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import unittest
 
 from packaging.version import Version
 
@@ -25,7 +24,7 @@ from uuid import uuid4
 from cassandra.cqlengine import columns
 from unittest import mock
 from cassandra.cqlengine.connection import get_session
-from tests.integration import CASSANDRA_VERSION, greaterthancass20
+from tests.integration import CASSANDRA_VERSION
 
 
 class TestTTLModel(Model):

--- a/tests/integration/long/test_large_data.py
+++ b/tests/integration/long/test_large_data.py
@@ -21,7 +21,7 @@ from cassandra import ConsistencyLevel, OperationTimedOut, WriteTimeout
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.query import dict_factory
 from cassandra.query import SimpleStatement
-from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
+from tests.integration import use_singledc, TestCluster
 from tests.integration.long.utils import create_schema
 
 import unittest

--- a/tests/integration/simulacron/__init__.py
+++ b/tests/integration/simulacron/__init__.py
@@ -18,7 +18,6 @@ from tests.integration.simulacron.utils import (
     clear_queries,
     start_and_prime_singledc,
     stop_simulacron,
-    start_and_prime_cluster_defaults,
 )
 
 from cassandra.cluster import Cluster

--- a/tests/integration/simulacron/test_cluster.py
+++ b/tests/integration/simulacron/test_cluster.py
@@ -11,15 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
 
-import logging
-from packaging.version import Version
 
 import cassandra
-from tests.integration.simulacron import SimulacronCluster, SimulacronBase
+from tests.integration.simulacron import SimulacronCluster
 from tests.integration import (requiressimulacron, PROTOCOL_VERSION, MockLoggingHandler)
-from tests.integration.simulacron.utils import prime_query, start_and_prime_singledc
+from tests.integration.simulacron.utils import prime_query
 
 from cassandra import (WriteTimeout, WriteType,
                        ConsistencyLevel, UnresolvableContactPoints)

--- a/tests/integration/simulacron/test_connection.py
+++ b/tests/integration/simulacron/test_connection.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
 
 import logging
 import time

--- a/tests/integration/simulacron/test_empty_column.py
+++ b/tests/integration/simulacron/test_empty_column.py
@@ -11,11 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
 
 from collections import namedtuple, OrderedDict
 
-from cassandra import ProtocolVersion
 from cassandra.cluster import Cluster, EXEC_PROFILE_DEFAULT
 from cassandra.query import (named_tuple_factory, tuple_factory,
                              dict_factory, ordered_dict_factory)

--- a/tests/integration/simulacron/test_endpoint.py
+++ b/tests/integration/simulacron/test_endpoint.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
 
 from functools import total_ordering
 

--- a/tests/integration/simulacron/utils.py
+++ b/tests/integration/simulacron/utils.py
@@ -14,7 +14,6 @@
 
 import json
 import subprocess
-import time
 from urllib.request import build_opener, Request, HTTPHandler
 
 from cassandra.metadata import SchemaParserV4, SchemaParserDSE68

--- a/tests/integration/standard/conftest.py
+++ b/tests/integration/standard/conftest.py
@@ -1,4 +1,3 @@
-import pytest
 import logging
 
 # Cluster topology groups for test ordering.

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -27,10 +27,10 @@ import os
 import pytest
 
 import cassandra
-from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT, ControlConnection, Cluster
+from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT, Cluster
 from cassandra.concurrent import execute_concurrent
 from cassandra.policies import (RoundRobinPolicy, ExponentialReconnectionPolicy,
-                                RetryPolicy, SimpleConvictionPolicy, HostDistance,
+                                SimpleConvictionPolicy, HostDistance,
                                 AddressTranslator, TokenAwarePolicy, HostFilterPolicy)
 from cassandra import ConsistencyLevel
 
@@ -43,7 +43,7 @@ from tests import notwindows, notasyncio
 from tests.integration import use_cluster, get_server_versions, CASSANDRA_VERSION, \
     execute_until_pass, execute_with_long_wait_retry, get_node, MockLoggingHandler, get_unsupported_lower_protocol, \
     get_unsupported_upper_protocol, local, CASSANDRA_IP, greaterthanorequalcass30, \
-    lessthanorequalcass40, TestCluster, PROTOCOL_VERSION, xfail_scylla, incorrect_test
+    lessthanorequalcass40, TestCluster, PROTOCOL_VERSION, incorrect_test
 from tests.integration.util import assert_quiescent_pool_state
 from tests.util import assertListEqual
 import sys

--- a/tests/integration/standard/test_concurrent.py
+++ b/tests/integration/standard/test_concurrent.py
@@ -19,7 +19,6 @@ from cassandra import InvalidRequest, ConsistencyLevel, ReadTimeout, WriteTimeou
     ReadFailure, WriteFailure
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.concurrent import execute_concurrent, execute_concurrent_with_args, ExecutionResult
-from cassandra.policies import HostDistance
 from cassandra.query import dict_factory, tuple_factory, SimpleStatement
 
 from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster

--- a/tests/integration/standard/test_concurrent_schema_change_and_node_kill.py
+++ b/tests/integration/standard/test_concurrent_schema_change_and_node_kill.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import unittest
 

--- a/tests/integration/standard/test_custom_cluster.py
+++ b/tests/integration/standard/test_custom_cluster.py
@@ -14,7 +14,7 @@
 
 from cassandra.cluster import NoHostAvailable
 from tests.integration import use_singledc, get_cluster, remove_cluster, local, TestCluster
-from tests.util import wait_until, wait_until_not_raised
+from tests.util import wait_until
 
 import unittest
 import pytest

--- a/tests/integration/standard/test_custom_payload.py
+++ b/tests/integration/standard/test_custom_payload.py
@@ -17,7 +17,7 @@ import unittest
 
 from cassandra.query import (SimpleStatement, BatchStatement, BatchType)
 
-from tests.integration import (use_singledc, PROTOCOL_VERSION, local, TestCluster,
+from tests.integration import (use_singledc, local, TestCluster,
                               requires_custom_payload)
 import pytest
 

--- a/tests/integration/standard/test_custom_protocol_handler.py
+++ b/tests/integration/standard/test_custom_protocol_handler.py
@@ -16,19 +16,16 @@ import unittest
 
 from cassandra.protocol import ProtocolHandler, ResultMessage, QueryMessage, UUIDType, read_int
 from cassandra.query import tuple_factory, SimpleStatement
-from cassandra.cluster import (ResponseFuture, ExecutionProfile, EXEC_PROFILE_DEFAULT,
-    ContinuousPagingOptions, NoHostAvailable)
+from cassandra.cluster import (ResponseFuture, ExecutionProfile, EXEC_PROFILE_DEFAULT)
 from cassandra import ProtocolVersion, ConsistencyLevel
 
 from tests.integration import use_single_node, drop_keyspace_shutdown_cluster, \
-    greaterthanorequalcass30, execute_with_long_wait_retry, greaterthanorequalcass3_10, \
-    TestCluster, greaterthanorequalcass40
+    greaterthanorequalcass30, execute_with_long_wait_retry, TestCluster, greaterthanorequalcass40
 from tests.integration.datatype_utils import update_datatypes, PRIMITIVE_DATATYPES
 from tests.integration.standard.utils import create_table_with_all_types, get_all_primitive_params
 
 import uuid
 from unittest import mock
-import pytest
 
 
 def setup_module():

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -14,38 +14,31 @@
 
 import unittest
 
-from collections import defaultdict
-import difflib
 import logging
 import sys
 import time
 import os
-from typing import Optional
 
 from packaging.version import Version
 from unittest.mock import Mock, patch
 import pytest
 
 from cassandra import AlreadyExists, SignatureDescriptor, UserFunctionDescriptor, UserAggregateDescriptor
-from cassandra.connection import Connection
 
 from cassandra.encoder import Encoder
 from cassandra.metadata import (IndexMetadata, Token, murmur3, Function, Aggregate, protect_name, protect_names,
                                 RegisteredTableExtension, _RegisteredExtensionType, get_schema_parser,
                                 group_keys_by_replica, NO_VALID_REPLICA)
 from cassandra.protocol import QueryMessage, ProtocolHandler
-from cassandra.util import SortedSet
 
 from tests.integration import (get_cluster, use_singledc, PROTOCOL_VERSION, execute_until_pass,
                                BasicSegregatedKeyspaceUnitTestCase, BasicSharedKeyspaceUnitTestCase,
                                BasicExistingKeyspaceUnitTestCase, drop_keyspace_shutdown_cluster, CASSANDRA_VERSION,
                                greaterthanorequalcass30, lessthancass30, local,
                                get_supported_protocol_versions, greaterthancass20,
-                               greaterthancass21, greaterthanorequalcass40,
-                               lessthancass40,
+                               greaterthancass21, lessthancass40,
                                TestCluster, requires_java_udf, requires_composite_type,
-                               requires_collection_indexes, SCYLLA_VERSION, xfail_scylla, xfail_scylla_version_lt,
-                               requirescompactstorage, get_tablets_disabled_ddl_suffix, execute_with_long_wait_retry)
+                               requires_collection_indexes, SCYLLA_VERSION, xfail_scylla, requirescompactstorage, get_tablets_disabled_ddl_suffix, execute_with_long_wait_retry)
 
 from tests.util import wait_until, assertRegex, assertDictEqual, assertListEqual, assert_startswith_diff
 

--- a/tests/integration/standard/test_policies.py
+++ b/tests/integration/standard/test_policies.py
@@ -15,9 +15,7 @@
 import unittest
 
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
-from cassandra.policies import HostFilterPolicy, RoundRobinPolicy,  SimpleConvictionPolicy, \
-    WhiteListRoundRobinPolicy, ExponentialBackoffRetryPolicy, ColDesc
-from cassandra.pool import Host
+from cassandra.policies import HostFilterPolicy, RoundRobinPolicy,  WhiteListRoundRobinPolicy, ExponentialBackoffRetryPolicy
 from cassandra.connection import DefaultEndPoint
 
 from tests.integration import local, use_singledc, TestCluster

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -23,7 +23,7 @@ from cassandra import ConsistencyLevel, Unavailable, InvalidRequest, cluster
 from cassandra.query import (PreparedStatement, BoundStatement, SimpleStatement,
                              BatchStatement, BatchType, dict_factory, TraceUnavailable)
 from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT, Cluster
-from cassandra.policies import HostDistance, RoundRobinPolicy, WhiteListRoundRobinPolicy
+from cassandra.policies import RoundRobinPolicy, WhiteListRoundRobinPolicy
 from tests.integration import use_singledc, PROTOCOL_VERSION, BasicSharedKeyspaceUnitTestCase, \
     greaterthanprotocolv3, MockLoggingHandler, get_supported_protocol_versions, local, get_cluster, setup_keyspace, \
     USE_CASS_EXTERNAL, greaterthanorequalcass40, TestCluster, xfail_scylla, xfail_scylla_version_lt, \

--- a/tests/integration/standard/test_query_paging.py
+++ b/tests/integration/standard/test_query_paging.py
@@ -25,7 +25,6 @@ import pytest
 from cassandra import ConsistencyLevel
 from cassandra.cluster import EXEC_PROFILE_DEFAULT, ExecutionProfile
 from cassandra.concurrent import execute_concurrent, execute_concurrent_with_args
-from cassandra.policies import HostDistance
 from cassandra.query import SimpleStatement
 
 from tests.util import assertSequenceEqual

--- a/tests/integration/standard/test_shard_aware.py
+++ b/tests/integration/standard/test_shard_aware.py
@@ -23,7 +23,7 @@ import pytest
 
 from cassandra.cluster import Cluster
 from cassandra.policies import TokenAwarePolicy, RoundRobinPolicy, ConstantReconnectionPolicy
-from cassandra import OperationTimedOut, ConsistencyLevel
+from cassandra import OperationTimedOut
 
 from tests.integration import use_cluster, get_node, PROTOCOL_VERSION
 from tests.util import wait_until_not_raised

--- a/tests/integration/standard/test_single_interface.py
+++ b/tests/integration/standard/test_single_interface.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 import unittest
-import pytest
 
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 
 from packaging.version import Version
-from tests.integration import use_singledc, PROTOCOL_VERSION, \
-    remove_cluster, greaterthanorequalcass40, \
+from tests.integration import use_singledc, remove_cluster, greaterthanorequalcass40, \
     CASSANDRA_VERSION, TestCluster, DEFAULT_SINGLE_INTERFACE_PORT
 
 

--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -21,15 +21,13 @@ import string
 import socket
 import uuid
 
-from datetime import datetime, date, time, timedelta
+from datetime import datetime, timedelta
 from decimal import Decimal
 from functools import partial
 
-from packaging.version import Version
 
 import cassandra
 from cassandra import InvalidRequest
-from cassandra import util
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.concurrent import execute_concurrent_with_args
 from cassandra.cqltypes import Int32Type, EMPTY

--- a/tests/integration/upgrade/__init__.py
+++ b/tests/integration/upgrade/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from tests.integration import CCM_KWARGS, use_cluster, remove_cluster, MockLoggingHandler
+from tests.integration import use_cluster, remove_cluster, MockLoggingHandler
 from tests.integration import setup_keyspace
 
 from cassandra.cluster import Cluster

--- a/tests/integration/upgrade/test_upgrade.py
+++ b/tests/integration/upgrade/test_upgrade.py
@@ -21,7 +21,6 @@ from cassandra.policies import ConstantSpeculativeExecutionPolicy
 from tests.integration.upgrade import UpgradeBase, UpgradeBaseAuth, UpgradePath, upgrade_paths
 from tests.util import wait_until
 
-import unittest
 import pytest
 
 

--- a/tests/stress_tests/test_load.py
+++ b/tests/stress_tests/test_load.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
 
 import gc
 

--- a/tests/unit/advanced/test_graph.py
+++ b/tests/unit/advanced/test_graph.py
@@ -19,7 +19,7 @@ import unittest
 
 from cassandra import ConsistencyLevel
 from cassandra.policies import RetryPolicy
-from cassandra.graph import (SimpleGraphStatement, GraphOptions, GraphProtocol, Result,
+from cassandra.graph import (SimpleGraphStatement, GraphOptions, Result,
                        graph_result_row_factory, single_object_row_factory,
                        Vertex, Edge, Path, VertexProperty)
 from cassandra.datastax.graph.query import _graph_options

--- a/tests/unit/advanced/test_insights.py
+++ b/tests/unit/advanced/test_insights.py
@@ -21,18 +21,12 @@ from unittest.mock import sentinel
 
 from cassandra import ConsistencyLevel
 from cassandra.cluster import (
-    ExecutionProfile, GraphExecutionProfile, ProfileManager,
-    GraphAnalyticsExecutionProfile,
-    EXEC_PROFILE_DEFAULT, EXEC_PROFILE_GRAPH_DEFAULT,
-    EXEC_PROFILE_GRAPH_ANALYTICS_DEFAULT,
-    EXEC_PROFILE_GRAPH_SYSTEM_DEFAULT
+    ExecutionProfile, GraphExecutionProfile, GraphAnalyticsExecutionProfile
 )
 from cassandra.datastax.graph.query import GraphOptions
 from cassandra.datastax.insights.registry import insights_registry
 from cassandra.datastax.insights.serializers import initialize_registry
-from cassandra.datastax.insights.util import namespace
 from cassandra.policies import (
-    RoundRobinPolicy,
     LoadBalancingPolicy,
     DCAwareRoundRobinPolicy,
     TokenAwarePolicy,

--- a/tests/unit/advanced/test_metadata.py
+++ b/tests/unit/advanced/test_metadata.py
@@ -16,7 +16,7 @@ import unittest
 
 from cassandra.metadata import (
     KeyspaceMetadata, TableMetadataDSE68,
-    VertexMetadata, EdgeMetadata, SchemaParserV22, _SchemaParser
+    VertexMetadata, EdgeMetadata, _SchemaParser
 )
 from cassandra.protocol import ResultMessage, RESULT_KIND_ROWS
 

--- a/tests/unit/io/test_asyncorereactor.py
+++ b/tests/unit/io/test_asyncorereactor.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import platform
 import unittest
 
 from unittest.mock import patch

--- a/tests/unit/io/test_twistedreactor.py
+++ b/tests/unit/io/test_twistedreactor.py
@@ -19,7 +19,6 @@ from cassandra.connection import DefaultEndPoint
 
 try:
     from twisted.test import proto_helpers
-    from twisted.python.failure import Failure
     from cassandra.io import twistedreactor
     from cassandra.io.twistedreactor import TwistedConnection
 except ImportError:

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -10,7 +10,7 @@ import unittest
 
 import itertools
 
-from cassandra.connection import DefaultEndPoint, SniEndPoint, SniEndPointFactory
+from cassandra.connection import DefaultEndPoint, SniEndPointFactory
 
 from unittest.mock import patch
 

--- a/tests/unit/test_host_connection_pool.py
+++ b/tests/unit/test_host_connection_pool.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from concurrent.futures import ThreadPoolExecutor
 import logging
-import time
 import uuid
 from cassandra.protocol_features import ProtocolFeatures
 

--- a/tests/unit/test_marshalling.py
+++ b/tests/unit/test_marshalling.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
 
 from cassandra import ProtocolVersion
 

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -19,13 +19,9 @@ from unittest.mock import Mock
 from cassandra import ProtocolVersion, UnsupportedOperation
 from cassandra.protocol import (
     PrepareMessage, QueryMessage, ExecuteMessage, UnsupportedOperation,
-    _PAGING_OPTIONS_FLAG, _WITH_SERIAL_CONSISTENCY_FLAG,
-    _PAGE_SIZE_FLAG, _WITH_PAGING_STATE_FLAG,
     BatchMessage
 )
 from cassandra.query import BatchType
-from cassandra.marshal import uint32_unpack
-from cassandra.cluster import ContinuousPagingOptions
 import pytest
 
 


### PR DESCRIPTION
## Summary

Removes unused imports across the driver and the test suite, split into two commits:
- **Remove unused imports from driver code** — `cassandra/` package
- **Remove unused imports from tests** — `tests/`

Detected with `ruff --select F401`.

## Notes on preserved imports
The following "unused" imports were **intentionally kept**, because they are not truly unused:
- **Dynamically resolved**: `cassandra/protocol.py` resolves 21 cqltype classes by name via `globals()[name]` to build `ResultMessage.type_codes`. Removing them breaks import with `KeyError`. Kept with a `# noqa: F401` block and an explanatory comment.
- **Public re-export**: `cassandra/connection.py` re-exports `ShardingInfo` (consumed via `from cassandra.connection import ShardingInfo`, e.g. `tests/unit/test_shard_aware.py`). Kept with `# noqa: F401`.
- **Availability probes**: imports inside `try/except ImportError` used to detect optional dependencies (`kerberos`, `numpy`, `cryptography`, `gremlin_python`, `ccmlib.common`, `make_recv_results_rows`).
- **Package re-export hubs**: genuine public re-exports in `cassandra/datastax/graph/__init__.py`.

## Testing
- Rebuilt the Cython extensions (`build_ext --inplace` / `uv sync --reinstall-package scylla-driver`) so the edited `.py` sources are actually exercised.
- Unit suite: **714 passed**, 37 skipped (2 pre-existing `test_cluster.py` failures unrelated to this change; reactor-timer tests excluded as they hang in the sandbox).
- All 45 modified test files byte-compile cleanly.

> Note: integration tests were not run here (require a live CCM/Scylla environment).