### PR TITLE
tests: reduce nested type/UDT depth to 12 for new CQL nesting limit

### DIFF
--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -663,18 +663,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
 
         # create a table with multiple sizes of nested tuples
+        # Note: Scylla limits CQL expression nesting depth to 12, so the
+        # deepest tuple tested here is 12 levels deep.
         s.execute("CREATE TABLE nested_tuples ("
                   "k int PRIMARY KEY, "
                   "v_1 frozen<%s>,"
                   "v_2 frozen<%s>,"
                   "v_3 frozen<%s>,"
-                  "v_32 frozen<%s>"
+                  "v_12 frozen<%s>"
                   ")" % (self.nested_tuples_schema_helper(1),
                          self.nested_tuples_schema_helper(2),
                          self.nested_tuples_schema_helper(3),
-                         self.nested_tuples_schema_helper(32)))
+                         self.nested_tuples_schema_helper(12)))
 
-        for i in (1, 2, 3, 32):
+        for i in (1, 2, 3, 12):
             # create tuple
             created_tuple = self.nested_tuples_creator_helper(i)
 

--- a/tests/integration/standard/test_udts.py
+++ b/tests/integration/standard/test_udts.py
@@ -389,7 +389,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         with self._cluster_default_dict_factory() as c:
             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
-            max_nesting_depth = 16
+            max_nesting_depth = 12
 
             # create the schema
             self.nested_udt_schema_helper(s, max_nesting_depth)
@@ -417,7 +417,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         with self._cluster_default_dict_factory() as c:
             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
-            max_nesting_depth = 16
+            max_nesting_depth = 12
 
             # create the schema
             self.nested_udt_schema_helper(s, max_nesting_depth)
@@ -454,7 +454,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         with self._cluster_default_dict_factory() as c:
             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
-            max_nesting_depth = 16
+            max_nesting_depth = 12
 
             # create the schema
             self.nested_udt_schema_helper(s, max_nesting_depth)


### PR DESCRIPTION
Scylla now caps the nesting depth of CQL expressions in the parser, rejecting deeply nested literals with: `SyntaxException code=2000 'expression nested too deeply'`

Cap the deepest case at 12, the maximum depth the server now allows.

Caused by https://github.com/scylladb/scylladb/commit/c27e32299dcd7579fd9d80f5d9c02421b493c40a.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.