### PR TITLE
Reduce nesting depth in tests to respect server CQL limit

### DIFF
--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -663,20 +663,22 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
 
         # create a table with multiple sizes of nested tuples
-        # Note: Scylla limits CQL expression nesting depth to 12, so the
-        # deepest tuple tested here is 12 levels deep.
+        # Note: Scylla limits CQL expression nesting depth to 12 (every
+        # recursive `term` counts, including the innermost scalar value), so a
+        # nested tuple literal can be at most 11 levels deep before the server
+        # rejects it with "expression nested too deeply".
         s.execute("CREATE TABLE nested_tuples ("
                   "k int PRIMARY KEY, "
                   "v_1 frozen<%s>,"
                   "v_2 frozen<%s>,"
                   "v_3 frozen<%s>,"
-                  "v_12 frozen<%s>"
+                  "v_11 frozen<%s>"
                   ")" % (self.nested_tuples_schema_helper(1),
                          self.nested_tuples_schema_helper(2),
                          self.nested_tuples_schema_helper(3),
-                         self.nested_tuples_schema_helper(12)))
+                         self.nested_tuples_schema_helper(11)))
 
-        for i in (1, 2, 3, 12):
+        for i in (1, 2, 3, 11):
             # create tuple
             created_tuple = self.nested_tuples_creator_helper(i)
 

--- a/tests/integration/standard/test_udts.py
+++ b/tests/integration/standard/test_udts.py
@@ -389,7 +389,12 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         with self._cluster_default_dict_factory() as c:
             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
-            max_nesting_depth = 12
+            # Scylla caps CQL expression nesting depth at 12 (every recursive
+            # `term` counts). A UDT literal `{value: ...}` adds two term levels
+            # per nesting, so a UDT literal inserted via a simple statement can
+            # be at most 10 levels deep before the server rejects it with
+            # "expression nested too deeply".
+            max_nesting_depth = 10
 
             # create the schema
             self.nested_udt_schema_helper(s, max_nesting_depth)
@@ -454,7 +459,12 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         with self._cluster_default_dict_factory() as c:
             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
-            max_nesting_depth = 12
+            # Scylla caps CQL expression nesting depth at 12 (every recursive
+            # `term` counts). A UDT literal `{value: ...}` adds two term levels
+            # per nesting, so a UDT literal inserted via a simple statement can
+            # be at most 10 levels deep before the server rejects it with
+            # "expression nested too deeply".
+            max_nesting_depth = 10
 
             # create the schema
             self.nested_udt_schema_helper(s, max_nesting_depth)


### PR DESCRIPTION
Scylla now limits CQL expression nesting depth to 12 (CVE-2026-31948, scylladb commit e35c388), rejecting deeper literals with the error "expression nested too deeply".

The limit counts every recursive `term`, including the innermost scalar value:
- nested tuple literals max out at 11 levels deep
- nested UDT literals max out at 10 levels deep (a UDT literal {value: ...} adds two term levels per nesting)

Prepared statements serialize values and bypass the parser limit, so only simple-statement/literal inserts are affected.

Adjust test_can_insert_nested_tuples to depth 11 and the nested UDT tests to depth 10.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.