### PR TITLE
fix: guard handle_read against closed socket race (#614)

### DIFF
--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -361,6 +361,8 @@ class LibevConnection(Connection):
                         return
 
     def handle_read(self, watcher, revents, errno=None):
+        if self.is_closed:
+            return
         if revents & libev.EV_ERROR:
             if errno:
                 exc = IOError(errno, os.strerror(errno))


### PR DESCRIPTION
## Minimal fix for issue #614 — Bad file descriptor

**2-line change.** Adds `if self.is_closed: return` at the top of `LibevConnection.handle_read()`.

### Root Cause

Thread race between `close()` and `handle_read()`:

- `close()` calls `self._socket.close()` **synchronously** (from any thread)
- Watcher stop is **asynchronous** (batched in `_loop_will_run()`, next loop iteration)
- If the reactor has already dispatched `handle_read()` for that connection before the watcher is stopped, `recv()` hits a closed FD → EBADF

```
Thread A (app):    close() → _socket.close()     [immediate]
Thread B (reactor): handle_read() → recv()       [EBADF - socket already closed]
                    ...
                    _loop_will_run() → watcher.stop()  [too late]
```

### The Fix

```diff
 def handle_read(self, watcher, revents, errno=None):
+    if self.is_closed:
+        return
     if revents & libev.EV_ERROR:
```

### Why this is safe

- `is_closed` is set under `self.lock` in `close()` before `_socket.close()` is called
- Reading a boolean attribute is atomic in CPython (GIL guarantees)
- If `is_closed` is True, the socket is either already closed or about to be — no useful work can be done

### Reproducer

100% reproduction rate: https://github.com/scylladb/scylla-dtest/pull/7079

### Note on existing fix branches

- `fix/factory-close-race-614` — fixes factory returning dead connections (different race)
- `fix/asyncio-close-race-614` — fixes AsyncioConnection race (different reactor)

Neither adds the `handle_read` guard for LibevConnection. This PR is complementary.

### How to test with SCT/Hydra

```bash
# In SCT requirements, point python-driver to this branch:
pip install git+https://github.com/scylladb/python-driver.git@fruch/fix-614-handle-read-guard

# Or in hydra, override the driver version in the test config
```

@vponomaryov — could you try building hydra with this branch and check if it fixes the EBADF reports in longevity runs? This is the minimal possible fix (2 lines). If it works, we can merge this independently of the other #614 fix branches.

Closes #614
