### PR TITLE
Prevent libev watchers running on closed socket

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -986,6 +986,8 @@ class Connection(object):
             conn.close()
             raise OperationTimedOut("Timed out creating connection (%s seconds)" % timeout,
                                     timeout=timeout)
+        elif conn.is_closed:
+            raise ConnectionShutdown("Connection to %s was closed by server" % conn.endpoint)
         else:
             return conn
 

--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -124,6 +124,7 @@ class LibevLoop(object):
             for watcher in (conn._write_watcher, conn._read_watcher):
                 if watcher:
                     watcher.stop()
+            conn._socket.close()
 
         self.notify()  # wake the timer watcher
 
@@ -221,6 +222,8 @@ class LibevLoop(object):
                     conn._read_watcher.stop()
                     # clear reference cycles from IO callback
                     del conn._read_watcher
+                conn._socket.close()
+                log.debug("Closed socket to %s", conn.endpoint)
 
             changed = True
 
@@ -233,7 +236,7 @@ class LibevLoop(object):
 
 def _atexit_cleanup():
     """Cleanup function called by atexit that uses the current _global_loop value.
-    
+
     This wrapper ensures that cleanup receives the actual LibevLoop instance
     instead of None, which was the value of _global_loop when the module was
     imported.
@@ -308,8 +311,6 @@ class LibevConnection(Connection):
         log.debug("Closing connection (%s) to %s", id(self), self.endpoint)
 
         _global_loop.connection_destroyed(self)
-        self._socket.close()
-        log.debug("Closed socket to %s", self.endpoint)
 
         # don't leave in-progress operations hanging
         if not self.is_defunct:

--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -321,6 +321,8 @@ class LibevConnection(Connection):
             self.connected_event.set()
 
     def handle_write(self, watcher, revents, errno=None):
+        if self.is_closed:
+            return
         if revents & libev.EV_ERROR:
             if errno:
                 exc = IOError(errno, os.strerror(errno))
@@ -362,6 +364,8 @@ class LibevConnection(Connection):
                         return
 
     def handle_read(self, watcher, revents, errno=None):
+        if self.is_closed:
+            return
         if revents & libev.EV_ERROR:
             if errno:
                 exc = IOError(errno, os.strerror(errno))


### PR DESCRIPTION
The way I understand Connection semantics, `close` can be called from any thread at any time.
It may happen when `handle_write` / `handle_read` are already running. If `close` closes the socket, and one of watchers uses it, we may get `EBADF`.
Apart from this specific error, it just seems conceptually weird that resources operating on socket (watchers) are closed later than the socket itself.
The solution for this issue that I implemented here is quite simple: close the TCP socket only after watchers are stopped.

`close` calls `connection_destroyed`, which registers connection to be destroyed. Some time later, `_loop_will_run` is called which goes trough all connections that are registered to be destroyed, and stops their watchers. I moved socket close from `close` to after watchers are stopped for the connection in `_loop_will_run`.

Additionally, I took the early returns from PRs of @vponomaryov and @fruch .
I'm not 100% convinced they are necessary for correctness, but:
- If connection is closed, it makes sense to avoid additional work
- If both watchers are scheduled in a single loop iteration, and first one closes connection, then there is no point in executing the second one. 

I decided to not take @vponomaryov change that sets `last_error` when connection is gracefully closed by the server. After a brief look at other reactors, it looks like its an established convention that graceful close does not set `last_error` - only Twisted does not abide by this.

I did pick up another optimization, in slightly changed form: `factory` now checks if connection is closed without `last_error`, and raises if so.
This is not necessary for correctness at all imo, because the connection may get closed just after being returned from factory, so we are not preventing any scenarios. It may however be an optimization in some cases, because we'll learn quicker that connection is dead.

Fixes: #614 (hopefully)

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.