### PR TITLE
fix: _set_keyspace_for_all_pools passes only the last pool's errors to callback

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3439,7 +3439,7 @@ class Session(object):
                 errors[pool.host] = host_errors
 
             if not remaining_callbacks:
-                callback(host_errors)
+                callback(errors)
 
         for pool in tuple(self._pools.values()):
             pool._set_keyspace_for_all_conns(keyspace, pool_finished_setting_keyspace)


### PR DESCRIPTION
Fixes #914

`pool_finished_setting_keyspace` was calling `callback(host_errors)` (the last pool to finish) instead of `callback(errors)` (all accumulated errors).

This caused keyspace changes to silently report success when the last pool finished without errors, even if other pools had failures.

Introduced in `d281b50c9` (2013-10-11).