### PR TITLE
CI: skip 32-bit Windows wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ skip = [
     "cp3*t-*",
     "pp3*t-*",
     "*i686",
+    "*win32",
     "*musllinux*",
 ]
 build = ["cp3*", "pp3*"]


### PR DESCRIPTION
The `*i686` skip pattern in cibuildwheel config only matches Linux 32-bit identifiers (e.g. `cp310-manylinux_i686`), not Windows 32-bit which uses `win32` (e.g. `cp310-win32`). Add `*win32` to skip 32-bit Windows builds, which fail because:
- `c_shard_info.c` uses `__uint128_t` (GCC extension, unsupported by MSVC)
- `cryptography` test dependency fails to build for `i686-pc-windows-msvc` due to missing OpenSSL

Fixes: https://github.com/scylladb/python-driver/issues/906