### PR TITLE
fix: add missing scope validation in Session.wait_for_schema_agreement

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3482,6 +3482,11 @@ class Session(object):
         if wait_time is not None and wait_time <= 0:
             raise ValueError("wait_time must be greater than 0")
 
+        if scope not in (SchemaAgreementScope.RACK, SchemaAgreementScope.DC, SchemaAgreementScope.CLUSTER):
+            raise ValueError(
+                "scope must be SchemaAgreementScope.RACK, .DC, or .CLUSTER"
+            )
+
         total_timeout = wait_time if wait_time is not None else self.cluster.max_schema_agreement_wait
         if total_timeout <= 0:
             raise ValueError("total_timeout must be greater than 0")


### PR DESCRIPTION
The docstring and test for `Session.wait_for_schema_agreement` promised that passing an invalid `scope` (e.g. `'planet'`) would raise `ValueError`, but the validation was never implemented in the method body.

Add an explicit check against the three `SchemaAgreementScope` members (`RACK`, `DC`, `CLUSTER`).

```
uv run pytest tests/unit/test_cluster.py::SessionTest::test_wait_for_schema_agreement_rejects_unknown_scope
Pytest: 1 passed
```

Introduced in commit `0d215f45b` — `cluster: add Session.wait_for_schema_agreement` (Dmitry Kropachev, 8 weeks ago). The test was never caught because unit tests are not run in CI.