### PR TITLE
ci: run unit tests in CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,6 +77,9 @@ jobs:
     - name: Build driver
       run: uv sync
 
+    - name: Unit tests
+      run: uv run pytest tests/unit/test_*.py -x
+
     - name: Cache Scylla download
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -591,6 +591,7 @@ class SessionTest(unittest.TestCase):
         assert self._host_query_count(session, hosts[0]) == 0
         assert self._host_query_count(session, hosts[1]) == 1
 
+    @pytest.mark.xfail(reason="scope validation not implemented (#917)", strict=False)
     @mock_session_pools
     def test_wait_for_schema_agreement_rejects_unknown_scope(self, *_):
         session, _, _ = self._new_schema_agreement_session(["a"])
@@ -598,6 +599,7 @@ class SessionTest(unittest.TestCase):
         with pytest.raises(ValueError):
             session.wait_for_schema_agreement(wait_time=1, scope='planet')
 
+    @pytest.mark.xfail(reason="_set_keyspace_for_all_pools passes only last pool errors (#915)", strict=False)
     @mock_session_pools
     def test_set_keyspace_for_all_pools_reports_all_errors(self, *_):
         cluster = Cluster()


### PR DESCRIPTION
## Problem

Unit tests (`tests/unit/`) are **never executed in any CI workflow**. The `integration-tests.yml` only runs `tests/integration/standard/` and `tests/integration/cqlengine/` — which require a running Scylla cluster via ccm.

This means bugs in unit-testable code can go undetected for weeks. Example: `Session.wait_for_schema_agreement` was added in commit `0d215f45b` with a docstring and test promising `ValueError` for invalid scope, but the validation was never implemented. It was only caught now because a human looked at the test output.

## Solution

Add a `uv run pytest tests/unit/test_*.py -x` step after the build and before the Scylla download/start. Unit tests:

- Have **zero external dependencies** (no Scylla, no ccm, no JDK)
- Run in **~30 seconds** (vs ~15 minutes for the Scylla download alone)
- Would have caught both pre-existing bugs immediately

## Pre-existing test failures

Two tests fail on `master` due to bugs introduced before CI was running them:

| Test | Bug | Fix PR |
|------|-----|--------|
| `test_wait_for_schema_agreement_rejects_unknown_scope` | Scope validation never implemented | #917 |
| `test_set_keyspace_for_all_pools_reports_all_errors` | `callback(host_errors)` should pass accumulated errors | #915 |

Both are marked `@pytest.mark.xfail(strict=False)` referencing their fix PRs. Once those PRs merge, these xfail markers should be removed.