### PR TITLE
test: drop USE_CASS_EXTERNAL integration mode

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -93,12 +93,6 @@ Or you can specify a scylla/cassandra directory (to test unreleased versions)::
 
     SCYLLA_VERSION=/path/to/scylla uv run pytest tests/integration/standard/
 
-Specifying the usage of an already running Scylla cluster
-------------------------------------------------------------
-The test will start the appropriate Scylla clusters when necessary  but if you don't want this to happen because a Scylla cluster is already running the flag ``USE_CASS_EXTERNAL`` can be used, for example::
-
-    USE_CASS_EXTERNAL=1 SCYLLA_VERSION='release:5.1' uv run pytest tests/integration/standard
-
 Specify a Protocol Version for Tests
 ------------------------------------
 The protocol version defaults to:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -122,7 +122,6 @@ def cmd_line_args_to_dict(env_var):
             args[cmd_arg.lstrip('-')] = cmd_arg_value
     return args
 
-USE_CASS_EXTERNAL = bool(os.getenv('USE_CASS_EXTERNAL', False))
 KEEP_TEST_CLUSTER = bool(os.getenv('KEEP_TEST_CLUSTER', False))
 SIMULACRON_JAR = os.getenv('SIMULACRON_JAR', None)
 
@@ -250,7 +249,7 @@ PROTOCOL_VERSION = int(os.getenv('PROTOCOL_VERSION', default_protocol_version))
 
 
 def local_decorator_creator():
-    if USE_CASS_EXTERNAL or not CASSANDRA_IP.startswith("127.0.0."):
+    if not CASSANDRA_IP.startswith("127.0.0."):
         return unittest.skip('Tests only runs against local C*')
 
     def _id_and_mark(f):
@@ -373,7 +372,7 @@ def check_log_error():
 
 
 def remove_cluster():
-    if USE_CASS_EXTERNAL or KEEP_TEST_CLUSTER:
+    if KEEP_TEST_CLUSTER:
         return
 
     global CCM_CLUSTER
@@ -430,21 +429,6 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None, 
     cassandra_version = ccm_options.get('version', CCM_VERSION)
 
     global CCM_CLUSTER
-    if USE_CASS_EXTERNAL:
-        if CCM_CLUSTER:
-            log.debug("Using external CCM cluster {0}".format(CCM_CLUSTER.name))
-        else:
-            ccm_path = os.getenv("CCM_PATH", None)
-            ccm_name = os.getenv("CCM_NAME", None)
-            if ccm_path and ccm_name:
-                CCM_CLUSTER = CCMClusterFactory.load(ccm_path, ccm_name)
-                log.debug("Using external CCM cluster {0}".format(CCM_CLUSTER.name))
-            else:
-                log.debug("Using unnamed external cluster")
-        if set_keyspace and start:
-            setup_keyspace(ipformat=ipformat)
-        return
-
     if is_current_cluster(cluster_name, nodes, workloads):
         log.debug("Using existing cluster, matching topology: {0}".format(cluster_name))
     else:
@@ -549,7 +533,7 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None, 
 
 
 def teardown_package():
-    if USE_CASS_EXTERNAL or KEEP_TEST_CLUSTER:
+    if KEEP_TEST_CLUSTER:
         return
     # when multiple modules are run explicitly, this runs between them
     # need to make sure CCM_CLUSTER is properly cleared for that case

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,7 @@ def cleanup_clusters():
                              'cluster_tests', 'shared_aware', 'sni_proxy', 'test_ip_change', 'test_client_routes_replacement']:
             try:
                 cluster = CCMClusterFactory.load(ccm_path, cluster_name)
-                logging.debug("Using external CCM cluster {0}".format(cluster.name))
+                logging.debug("Clearing CCM cluster {0}".format(cluster.name))
                 cluster.clear()
             except FileNotFoundError:
                 pass

--- a/tests/integration/standard/test_authentication.py
+++ b/tests/integration/standard/test_authentication.py
@@ -22,7 +22,7 @@ from cassandra.cluster import NoHostAvailable
 from cassandra.auth import PlainTextAuthProvider, SASLClient, SaslAuthProvider
 
 from tests.integration import use_singledc, get_cluster, remove_cluster, PROTOCOL_VERSION, \
-    CASSANDRA_IP, CASSANDRA_VERSION, USE_CASS_EXTERNAL, start_cluster_wait_for_up, TestCluster
+    CASSANDRA_IP, CASSANDRA_VERSION, start_cluster_wait_for_up, TestCluster
 from tests.integration.util import assert_quiescent_pool_state
 
 import unittest
@@ -40,7 +40,7 @@ _saved_scylla_ext_opts = None
 def setup_module():
     global _saved_scylla_ext_opts
     _saved_scylla_ext_opts = os.environ.get('SCYLLA_EXT_OPTS')
-    if CASSANDRA_IP.startswith("127.0.0.") and not USE_CASS_EXTERNAL:
+    if CASSANDRA_IP.startswith("127.0.0."):
         use_singledc(start=False)
         ccm_cluster = get_cluster()
         ccm_cluster.stop()

--- a/tests/integration/standard/test_authentication_misconfiguration.py
+++ b/tests/integration/standard/test_authentication_misconfiguration.py
@@ -15,7 +15,7 @@
 import unittest
 import pytest
 
-from tests.integration import USE_CASS_EXTERNAL, use_cluster, TestCluster
+from tests.integration import use_cluster, TestCluster
 
 
 @pytest.mark.skip(reason="Flaky test - needs investigation whether its Scylla's or driver's fault."
@@ -24,16 +24,15 @@ class MisconfiguredAuthenticationTests(unittest.TestCase):
     """ One node (not the contact point) has password auth. The rest of the nodes have no auth """
     @classmethod
     def setUpClass(cls):
-        if not USE_CASS_EXTERNAL:
-            ccm_cluster = use_cluster(cls.__name__, [3], start=False)
-            node3 = ccm_cluster.nodes['node3']
-            node3.set_configuration_options(values={
-                'authenticator': 'PasswordAuthenticator',
-                'authorizer': 'CassandraAuthorizer',
-            })
-            ccm_cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
+        ccm_cluster = use_cluster(cls.__name__, [3], start=False)
+        node3 = ccm_cluster.nodes['node3']
+        node3.set_configuration_options(values={
+            'authenticator': 'PasswordAuthenticator',
+            'authorizer': 'CassandraAuthorizer',
+        })
+        ccm_cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
 
-            cls.ccm_cluster = ccm_cluster
+        cls.ccm_cluster = ccm_cluster
 
     def test_connect_no_auth_provider(self):
         cluster = TestCluster()
@@ -45,5 +44,4 @@ class MisconfiguredAuthenticationTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if not USE_CASS_EXTERNAL:
-            cls.ccm_cluster.stop()
+        cls.ccm_cluster.stop()

--- a/tests/integration/standard/test_control_connection_query_fallback.py
+++ b/tests/integration/standard/test_control_connection_query_fallback.py
@@ -18,7 +18,7 @@ import pytest
 
 from cassandra.cluster import ControlConnectionQueryFallback, NoHostAvailable
 
-from tests.integration import USE_CASS_EXTERNAL, TestCluster, local, remove_cluster, use_cluster
+from tests.integration import TestCluster, local, remove_cluster, use_cluster
 
 
 _CLUSTER_NAME = "control_connection_query_fallback"
@@ -26,9 +26,6 @@ _UNREACHABLE_BROADCAST_RPC_ADDRESS = "127.255.255.1"
 
 
 def setup_module():
-    if USE_CASS_EXTERNAL:
-        return
-
     remove_cluster()
 
     ccm_cluster = use_cluster(_CLUSTER_NAME, [1], start=False)
@@ -39,9 +36,6 @@ def setup_module():
 
 
 def teardown_module():
-    if USE_CASS_EXTERNAL:
-        return
-
     remove_cluster()
 
 

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -26,7 +26,7 @@ from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DE
 from cassandra.policies import RoundRobinPolicy, WhiteListRoundRobinPolicy
 from tests.integration import use_singledc, PROTOCOL_VERSION, BasicSharedKeyspaceUnitTestCase, \
     greaterthanprotocolv3, MockLoggingHandler, get_supported_protocol_versions, local, get_cluster, setup_keyspace, \
-    USE_CASS_EXTERNAL, greaterthanorequalcass40, TestCluster, xfail_scylla, xfail_scylla_version_lt, \
+    greaterthanorequalcass40, TestCluster, xfail_scylla, xfail_scylla_version_lt, \
     get_tablets_disabled_ddl_suffix, execute_with_long_wait_retry
 from tests import notwindows
 from tests.integration import greaterthanorequalcass30, get_node
@@ -43,15 +43,14 @@ log = logging.getLogger(__name__)
 
 
 def setup_module():
-    if not USE_CASS_EXTERNAL:
-        use_singledc(start=False)
-        ccm_cluster = get_cluster()
-        ccm_cluster.stop()
-        # This is necessary because test_too_many_statements may
-        # timeout otherwise
-        config_options = {'write_request_timeout_in_ms': '20000'}
-        ccm_cluster.set_configuration_options(config_options)
-        ccm_cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
+    use_singledc(start=False)
+    ccm_cluster = get_cluster()
+    ccm_cluster.stop()
+    # This is necessary because test_too_many_statements may
+    # timeout otherwise
+    config_options = {'write_request_timeout_in_ms': '20000'}
+    ccm_cluster.set_configuration_options(config_options)
+    ccm_cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
 
     setup_keyspace()
 


### PR DESCRIPTION
## Summary
- remove the USE_CASS_EXTERNAL integration-test mode and CCM_PATH/CCM_NAME loading path
- make affected integration setup code always use managed CCM clusters
- remove the CONTRIBUTING.rst documentation for external-cluster test runs

## Testing
- uv run python -m py_compile tests/integration/__init__.py tests/integration/conftest.py tests/integration/standard/test_query.py tests/integration/standard/test_authentication.py tests/integration/standard/test_authentication_misconfiguration.py tests/integration/standard/test_control_connection_query_fallback.py
- CASSANDRA_VERSION=3.11.4 uv run pytest --collect-only tests/integration/standard/test_query.py tests/integration/standard/test_authentication.py tests/integration/standard/test_authentication_misconfiguration.py tests/integration/standard/test_control_connection_query_fallback.py