### PR TITLE
Draft: [DRIVER-784] Validate SELECT without FROM support

### DIFF
--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -20,6 +20,7 @@ import logging
 import pytest
 from cassandra import ProtocolVersion
 from cassandra import ConsistencyLevel, Unavailable, InvalidRequest, cluster
+from cassandra.protocol import SyntaxException
 from cassandra.query import (PreparedStatement, BoundStatement, SimpleStatement,
                              BatchStatement, BatchType, dict_factory, TraceUnavailable)
 from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT, Cluster
@@ -35,6 +36,7 @@ from tests.util import assertListEqual, wait_until
 import time
 import random
 import re
+import uuid
 
 from unittest import mock
 
@@ -57,6 +59,25 @@ def setup_module():
 
 
 class QueryTests(BasicSharedKeyspaceUnitTestCase):
+
+    def test_select_without_from(self):
+        try:
+            result_set = self.session.execute("SELECT 1")
+        except (InvalidRequest, SyntaxException):
+            raise unittest.SkipTest("Server does not support SELECT without FROM")
+
+        assert result_set.column_names == ["1"]
+        assert result_set.one()[0] == 1
+
+        result_set = self.session.execute("SELECT now()")
+        assert result_set.column_names == ["now()"]
+        assert isinstance(result_set.one()[0], uuid.UUID)
+
+        prepared = self.session.prepare("SELECT 1")
+        assert self.session.execute(prepared.bind(())).one()[0] == 1
+
+        prepared = self.session.prepare("SELECT now()")
+        assert isinstance(self.session.execute(prepared.bind(())).one()[0], uuid.UUID)
 
     def test_query(self):
 


### PR DESCRIPTION
Jira: https://scylladb.atlassian.net/browse/DRIVER-784
GitHub issue: https://github.com/scylladb/python-driver/issues/929
Parent epic: https://scylladb.atlassian.net/browse/DRIVER-782

Draft PR for validating SELECT without FROM support in this driver.

Refs #929.

Scope:
- Add or update integration tests for SELECT 1.
- Add or update integration tests for SELECT now().
- Cover prepared and non-prepared execution paths where relevant.
- Feature-detect or skip cleanly against servers that do not support SELECT without FROM.
- Document any driver-specific limitation found during implementation.

This draft currently contains an empty setup commit so work can start from a linked branch without adding placeholder source changes.