### PR TITLE
connection: fix heartbeat future test timeout arguments

### DIFF
--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -500,7 +500,7 @@ class ConnectionHeartbeatTest(unittest.TestCase):
         future = HeartbeatFuture(connection, owner)
 
         with pytest.raises(ConnectionException):
-            future.wait(0)
+            future.wait(timeout=0, original_timeout=0)
 
         owner.return_connection(connection)
 


### PR DESCRIPTION
## Summary

- pass both required timeout arguments to `HeartbeatFuture.wait()` in the send-failure unit test
- keep the test aligned with the signature introduced by c6b240a635eba31026abaff41094f05416b74552
- fix wheel tests across Linux, Windows, and macOS

Failure: https://github.com/scylladb/python-driver/actions/runs/30623864229/job/91134463410

## Testing

- `uv run pytest tests/unit/test_connection.py::ConnectionHeartbeatTest::test_heartbeat_future_releases_request_id_when_send_fails -q`
- `uv run pytest tests/unit/test_connection.py -q` (32 passed)