### PR TITLE
tests: avoid assertNoLogs on Python 3.9

### DIFF
--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -16,7 +16,7 @@ import unittest
 
 from collections import deque
 from threading import RLock
-from unittest.mock import Mock, MagicMock, ANY
+from unittest.mock import Mock, MagicMock, ANY, patch
 
 from cassandra import ConsistencyLevel, Unavailable, SchemaTargetType, SchemaChangeType, OperationTimedOut
 from cassandra.cluster import Session, ResponseFuture, NoHostAvailable, ProtocolVersion, ControlConnectionQueryFallback
@@ -1316,8 +1316,9 @@ class ResponseFutureTests(unittest.TestCase):
         )
 
         # Ordinary METADATA_CHANGED handling, so no anomaly warning either.
-        with self.assertNoLogs('cassandra.cluster', level='WARNING'):
+        with patch('cassandra.cluster.log.warning') as warning:
             rf._set_result(None, None, None, response)
+        warning.assert_not_called()
 
         assert ps.result_metadata_and_id == (new_meta, b'new_id')
 
@@ -1351,8 +1352,9 @@ class ResponseFutureTests(unittest.TestCase):
         assert sum('result_metadata_id' in msg for msg in first.output) == 1
 
         # Second identical anomalous response: no new warning (deduped).
-        with self.assertNoLogs('cassandra.cluster', level='WARNING'):
+        with patch('cassandra.cluster.log.warning') as warning:
             rf._set_result(None, None, None, anomalous)
+        warning.assert_not_called()
         assert ps.result_metadata_and_id == (old_meta, b'old_id')
 
         # A genuine METADATA_CHANGED recovers the metadata and re-arms the warning.


### PR DESCRIPTION
## Summary

- replace the two Python 3.10-only `TestCase.assertNoLogs` uses with mocked warning assertions
- preserve coverage that normal metadata changes and deduplicated anomalies do not emit warnings
- keep the unit tests compatible with the declared Python 3.9 minimum

This is test-only and has no driver protocol or runtime compatibility impact.

## Testing

- `uv run --isolated --python /usr/bin/python3.9 pytest -rf tests/unit/test_response_future.py::ResponseFutureTests::test_set_result_no_metadata_statement_adopts_metadata_changed tests/unit/test_response_future.py::ResponseFutureTests::test_set_result_anomalous_metadata_id_warns_once_and_rearms` (2 passed on Python 3.9.25)
- `uv run pytest -rf tests/unit/test_response_future.py` (52 passed on Python 3.14.6)
- `git diff --check`

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] Existing tests cover the compatibility fix.
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] Public-item docstrings are not applicable.
- [x] Documentation changes are not applicable.
- [x] I added an appropriate `Fixes:` annotation.

Fixes: #951
