### PR TITLE
Mark non-security md5 usage to allow for compatibility with fips environments

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1967,7 +1967,7 @@ class MD5Token(HashToken):
     def hash_fn(cls, key):
         if isinstance(key, str):
             key = key.encode('UTF-8')
-        return abs(varint_unpack(md5(key).digest()))
+        return abs(varint_unpack(md5(key,usedforsecurity=False).digest()))
 
 
 class BytesToken(Token):


### PR DESCRIPTION
## Summary
- Cherry-pick of [apache/cassandra-python-driver@f685c2c](https://github.com/apache/cassandra-python-driver/commit/f685c2c73f2e84c1a0f267a34949949058a12404)
- Marks the non-security `md5` usage in `MD5Token.hash_fn` with `usedforsecurity=False` so the driver works in FIPS-enforced Python environments, which reject non-approved hash algorithms unless explicitly marked as not used for security purposes.

## Test plan
- [x] Ran the unit test suite (`tests/unit`) locally; `test_metadata.py` passes in full, including all `MD5Token`/`Token` tests
- [x] Remaining failures in the full suite are pre-existing environment gaps (missing optional Cython/Twisted/lz4 dependencies), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)