### PR TITLE
Remove obsolete __future__ import absolute_import

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -16,7 +16,6 @@
 This module houses the main classes you will interact with,
 :class:`.Cluster` and :class:`.Session`.
 """
-from __future__ import absolute_import
 
 import atexit
 import datetime

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import  # to enable import io from stdlib
 from collections import defaultdict, deque
 import errno
 from functools import wraps, partial, total_ordering

--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -27,7 +27,6 @@ the corresponding CQL or Cassandra type strings.
 # for example), these classes would be a good place to tack on
 # .from_cql_literal() and .as_cql_literal() classmethods (or whatever).
 
-from __future__ import absolute_import  # to enable import io from stdlib
 import ast
 from binascii import unhexlify
 import calendar

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import  # to enable import io from stdlib
 from collections import namedtuple
 import logging
 import socket

--- a/tests/integration/cqlengine/query/test_queryset.py
+++ b/tests/integration/cqlengine/query/test_queryset.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import unittest
 


### PR DESCRIPTION
Cherry-pick of [apache/cassandra-python-driver@2d99b62](https://github.com/apache/cassandra-python-driver/commit/2d99b62348b0a69f6d1fe2053982bb981dc7368e) (apache/cassandra-python-driver#1263).

Removes the now-unnecessary `from __future__ import absolute_import` statements (Python 2 leftover).

## Test plan
- [x] Cherry-picked cleanly, no conflicts
- [x] Full unit test suite passes (765 passed, 45 skipped)