### PR TITLE
PYTHON-1354: do not set timeout to None when calling execute_async in execute_concurrent

### DIFF
--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -143,7 +143,7 @@ class _ConcurrentExecutor(object):
             while self._pending_executions:
                 p_idx, p_statement, p_params = self._pending_executions.pop(0)
                 try:
-                    future = self.session.execute_async(p_statement, p_params, timeout=None, execution_profile=self._execution_profile)
+                    future = self.session.execute_async(p_statement, p_params, execution_profile=self._execution_profile)
                     args = (future, p_idx)
                     future.add_callbacks(
                         callback=self._on_success, callback_args=args,


### PR DESCRIPTION
## Summary
- Cherry-pick of [apache/cassandra-python-driver@d0407ea0](https://github.com/apache/cassandra-python-driver/commit/d0407ea0a9d51be1498a93d9d62ac3a9a0bacfa2).
- `_ConcurrentExecutor._execute` hardcoded `timeout=None` when calling `execute_async`, which disables the per-request timeout entirely instead of falling back to the `request_timeout` configured on the execution profile. This silently changes the timeout behavior for anyone using `execute_concurrent`/`execute_concurrent_with_args`.
- Removes the `timeout=None` override so the execution profile's `request_timeout` is honored, matching the documented behavior of `execute_async`.

## Test plan
- [x] Cherry-picked onto current `master` (conflicted with the local synchronous-errback recursion guard in `cassandra/concurrent.py`; resolved by keeping the local recursion-guard structure and only removing the `timeout=None` argument)
- [x] `tests/unit/test_concurrent.py` — 10/10 passed
- [x] `tests/unit` (excluding unrelated cython/column_encryption import errors caused by missing optional deps in this sandbox) — 749 passed, 40 skipped