### PR TITLE
Remove unused OpnSSL installs from the wheel builds

### DIFF
--- a/.github/workflows/lib-build.yml
+++ b/.github/workflows/lib-build.yml
@@ -104,10 +104,10 @@ jobs:
         run: |
           uv tool install 'cibuildwheel==3.2.1'
 
-      - name: Install OpenSSL for Windows
-        if: runner.os == 'Windows'
-        run: |
-          choco install openssl.light --no-progress -y
+      # - name: Install OpenSSL for Windows
+      #   if: runner.os == 'Windows'
+      #   run: |
+      #     choco install openssl.light --no-progress -y
 
       - name: Install Conan
         if: runner.os == 'Windows'

--- a/.github/workflows/lib-build.yml
+++ b/.github/workflows/lib-build.yml
@@ -104,11 +104,6 @@ jobs:
         run: |
           uv tool install 'cibuildwheel==3.2.1'
 
-      - name: Install OpenSSL for Windows
-        if: runner.os == 'Windows'
-        run: |
-          choco install openssl.light --no-progress -y
-
       - name: Install Conan
         if: runner.os == 'Windows'
         uses: turtlebrowser/get-conan@c171f295f3f507360ee018736a6608731aa2109d # v1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,8 @@ manylinux-pypy_aarch64-image = "manylinux_2_28"
 enable = ["pypy"]
 [tool.cibuildwheel.linux]
 
-before-build = "rm -rf ~/.pyxbld && rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux && yum install -y libffi-devel libev libev-devel openssl openssl-devel"
+# Original: yum install -y libffi-devel libev libev-devel openssl openssl-devel
+before-build = "rm -rf ~/.pyxbld && rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux && yum install -y libffi-devel libev libev-devel"
 # Install the optional lz4 compression dependency so the lz4 segment tests run
 # (and fail loudly under CASS_DRIVER_NO_SKIP) instead of skipping silently.
 test-extras = ["compress-lz4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ manylinux-pypy_aarch64-image = "manylinux_2_28"
 enable = ["pypy"]
 [tool.cibuildwheel.linux]
 
-before-build = "rm -rf ~/.pyxbld && rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux && yum install -y libffi-devel libev libev-devel openssl openssl-devel lz4-devel"
+before-build = "rm -rf ~/.pyxbld && rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux && yum install -y libffi-devel libev libev-devel lz4-devel"
 # Install the optional lz4 compression dependency so the lz4 segment tests run
 # (and fail loudly under CASS_DRIVER_NO_SKIP) instead of skipping silently.
 test-extras = ["compress-lz4"]


### PR DESCRIPTION
## Changes

Removes the Windows `Install OpenSSL for Windows` step and `openssl openssl-devel` from the Linux `before-build` in `pyproject.toml`. 

## Pre-review checklist


- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.