### PR TITLE
Report SESSION_ID and DRIVER_CONFIG in the STARTUP options - stage 1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,12 +3,30 @@ Unreleased
 
 Features
 --------
+* Report the driver's identity and configuration in the ``STARTUP`` options, where
+  ScyllaDB exposes them in the ``client_options`` column of its clients table
+  (DRIVER-950). Every connection now sends ``SESSION_ID``, a UUID identifying the
+  ``Cluster`` it belongs to and readable from the new ``Cluster.session_id``, so all of
+  a client's connections can be correlated with each other and with its own logs. The
+  control connection additionally sends ``DRIVER_CONFIG``, a JSON description of the
+  effective configuration, which for now carries only the schema version it follows.
+  Reporting the configuration can be turned off with the new
+  ``Cluster(driver_config_reporting_enabled=False)``; ``SESSION_ID`` is unaffected by
+  that setting. Reporting is best effort and never prevents a connection from being
+  established.
 * Negotiate and implement the ``SCYLLA_USE_METADATA_ID`` protocol extension: prepared
   statements skip re-sending result metadata on EXECUTE, and the driver automatically
   refreshes cached metadata when the server detects a schema change (DRIVER-153)
 
 Others
 ------
+* The ``STARTUP`` options that describe the driver itself are no longer the
+  application's to set. An ``ApplicationInfoBase.add_startup_options`` that sets
+  ``DRIVER_NAME``, ``DRIVER_VERSION``, ``SESSION_ID`` or ``DRIVER_CONFIG`` now has that
+  value dropped, with a warning naming the option; keys the driver does not own still
+  come through unchanged. Previously ``DRIVER_NAME`` and ``DRIVER_VERSION`` could be
+  overridden, which misreported the driver to the server for the life of the connection
+  and, in the clients table, to the operator reading the row.
 * ``PreparedStatement.result_metadata`` and ``PreparedStatement.result_metadata_id`` are
   now read-only. They are replaced together by
   ``PreparedStatement.update_result_metadata()``, so a request can never observe a metadata

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -93,6 +93,7 @@ from cassandra.datastax.graph import (graph_object_row_factory, GraphOptions, Gr
 from cassandra.datastax.graph.query import _request_timeout_key, _GraphSONContextRowFactory
 from cassandra.datastax import cloud as dscloud
 from cassandra.application_info import ApplicationInfoBase
+from cassandra.driver_config import DriverConfigReporter
 
 try:
     from weakref import WeakSet
@@ -1020,6 +1021,47 @@ class Cluster(object):
     documentation for :meth:`Session.timestamp_generator`.
     """
 
+    driver_config_reporting_enabled = True
+    """
+    A boolean indicating whether the driver describes its effective
+    configuration to the cluster while setting up the control connection, so
+    that operators can inspect the settings of a client while investigating an
+    incident. The description is sent as the ``DRIVER_CONFIG`` startup option
+    and ScyllaDB exposes it in the ``client_options`` column of its clients
+    table.
+
+    :attr:`~.Cluster.session_id`, which every connection reports, is not
+    affected by this setting.
+
+    Read when a connection is opened, so changing it takes effect on the
+    connections established afterwards and leaves the open ones alone.
+
+    Defaults to :const:`True`.
+    """
+
+    _session_id = None
+
+    @property
+    def session_id(self):
+        """
+        A :class:`uuid.UUID` identifying this ``Cluster``, generated when it is
+        created and never changing afterwards.
+
+        Every connection this ``Cluster`` opens -- the control connection as
+        well as the pools of each of its :class:`~.Session` objects -- reports
+        it to the cluster as the ``SESSION_ID`` startup option, where ScyllaDB
+        exposes it in the ``client_options`` column of its clients table.
+        Logging it, or attaching it to a support bundle, is what allows
+        client-side observations to be matched against those rows instead of
+        correlating them by address and port.
+
+        The option is named after the convention shared with the other ScyllaDB
+        drivers, where a "session" is what this driver calls a ``Cluster``. It is
+        unrelated to :attr:`.Session.session_id`, which identifies a ``Session``
+        within the client and is never reported to the cluster.
+        """
+        return self._session_id
+
     cloud = None
     """
     A dict of the cloud configuration. Example::
@@ -1178,7 +1220,8 @@ class Cluster(object):
                  column_encryption_policy=None,
                  application_info:Optional[ApplicationInfoBase]=None,
                  client_routes_config:Optional[ClientRoutesConfig]=None,
-                 allow_control_connection_query_fallback:Optional[ControlConnectionQueryFallback]=ControlConnectionQueryFallback.Disabled
+                 allow_control_connection_query_fallback:Optional[ControlConnectionQueryFallback]=ControlConnectionQueryFallback.Disabled,
+                 driver_config_reporting_enabled=True
                  ):
         """
         ``executor_threads`` defines the number of threads in a pool for handling asynchronous tasks such as
@@ -1467,6 +1510,18 @@ class Cluster(object):
             from cassandra.metrics import Metrics
             self.metrics = Metrics(weakref.proxy(self))
 
+        # Both are read by _make_connection_kwargs, so they have to be in place
+        # before anything can open a connection.
+        #
+        # The session id is generated unconditionally: every connection reports
+        # it, whatever driver_config_reporting_enabled is set to.
+        self._session_id = uuid.uuid4()
+        self.driver_config_reporting_enabled = driver_config_reporting_enabled
+        # Built whatever the flag says, so that the flag is the only thing that
+        # decides whether a connection reports: see _make_connection_kwargs. The
+        # reporter holds no state, so an unused one costs nothing.
+        self._driver_config_reporter = DriverConfigReporter()
+
         self.control_connection = ControlConnection(
             self, self.control_connection_timeout,
             self.schema_event_refresh_window, self.topology_event_refresh_window,
@@ -1642,6 +1697,16 @@ class Cluster(object):
         kwargs_dict.setdefault('allow_beta_protocol_version', self.allow_beta_protocol_version)
         kwargs_dict.setdefault('no_compact', self.no_compact)
         kwargs_dict.setdefault('application_info', self.application_info)
+
+        # Assigned rather than defaulted, unlike everything above: both describe
+        # this Cluster to the server, so a caller must not be able to substitute
+        # them. A connection reports whatever session id it is handed, which
+        # would break the correlation the option exists for, and a reporter
+        # passed in here would report a configuration that
+        # driver_config_reporting_enabled turned off.
+        kwargs_dict['session_id'] = self.session_id
+        kwargs_dict['driver_config_reporter'] = \
+            self._driver_config_reporter if self.driver_config_reporting_enabled else None
 
         return kwargs_dict
 
@@ -2528,6 +2593,10 @@ class Session(object):
     session_id = None
     """
     A UUID that uniquely identifies this Session. This will be generated automatically.
+
+    This is not the identifier reported to the cluster in the ``SESSION_ID``
+    startup option: that one is per-:class:`~.Cluster` and shared by every
+    connection, see :attr:`.Cluster.session_id`.
     """
 
     _lock = None

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -1565,7 +1565,7 @@ class Connection(object):
         log.debug("Sending StartupMessage on %s", self)
         opts = {'DRIVER_NAME': DRIVER_NAME,
                 'DRIVER_VERSION': DRIVER_VERSION,
-                **extra_options}
+                **(extra_options or {})}
         if compression:
             opts['COMPRESSION'] = compression
         if no_compact:

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -31,6 +31,8 @@ import itertools
 from typing import Any, Dict, Optional, Tuple, Union
 
 from cassandra.application_info import ApplicationInfoBase
+from cassandra.driver_config import (DriverConfigReporter, DRIVER_CONFIG_OPTION,
+                                     SESSION_ID_OPTION)
 from cassandra.client_routes import _ClientRoutesHandler
 from cassandra.protocol_features import ProtocolFeatures
 
@@ -878,6 +880,16 @@ class Connection(object):
     features = None
     _application_info: Optional[ApplicationInfoBase] = None
 
+    # Identifier of the cluster this connection belongs to, reported in the
+    # SESSION_ID startup option so that all of a cluster's connections can be
+    # correlated with each other in the clients table.
+    _session_id = None
+
+    # Set on every connection, but only used by the control connection, which is
+    # the only one reporting the driver configuration. Left as None when the
+    # cluster has configuration reporting disabled.
+    _driver_config_reporter: Optional[DriverConfigReporter] = None
+
     @property
     def _iobuf(self):
         # backward compatibility, to avoid any change in the reactors
@@ -888,7 +900,8 @@ class Connection(object):
                  cql_version=None, protocol_version=ProtocolVersion.MAX_SUPPORTED, is_control_connection=False,
                  user_type_map=None, connect_timeout=None, allow_beta_protocol_version=False, no_compact=False,
                  ssl_context=None, owning_pool=None, shard_id=None, total_shards=None,
-                 on_orphaned_stream_released=None, application_info: Optional[ApplicationInfoBase] = None):
+                 on_orphaned_stream_released=None, application_info: Optional[ApplicationInfoBase] = None,
+                 session_id=None, driver_config_reporter: Optional[DriverConfigReporter] = None):
         # TODO next major rename host to endpoint and remove port kwarg.
         self.endpoint = host if isinstance(host, EndPoint) else DefaultEndPoint(host, port)
 
@@ -912,6 +925,8 @@ class Connection(object):
         self.orphaned_request_ids = set()
         self._on_orphaned_stream_released = on_orphaned_stream_released
         self._application_info = application_info
+        self._session_id = session_id
+        self._driver_config_reporter = driver_config_reporter
 
         if ssl_options:
             self.ssl_options.update(self.endpoint.ssl_options or {})
@@ -1506,6 +1521,49 @@ class Connection(object):
         if self._application_info:
             self._application_info.add_startup_options(options)
         self.features.add_startup_options(options)
+
+        # Driver-owned options go in after the application's, so that they can
+        # overwrite them and never the other way round. An application that set
+        # SESSION_ID would break correlating a cluster's connections in the
+        # clients table, which is the only reason the option exists; one that set
+        # DRIVER_CONFIG would have an operator read its value as the driver's
+        # description of itself; and one that set DRIVER_NAME or DRIVER_VERSION
+        # would misreport the driver for the life of the connection, to the same
+        # operator and in the same row.
+        #
+        # They are cleared rather than merely overwritten, so that ownership does
+        # not depend on this connection having something to say: a pool
+        # connection reports no configuration at all, and neither does a control
+        # connection whose report was dropped or turned off. DRIVER_NAME and
+        # DRIVER_VERSION are then put back by _send_startup_message, the only
+        # place that knows them. CQL_VERSION needs no entry here: StartupMessage
+        # writes it after the options map, so it cannot be overridden either.
+        for owned_key in (SESSION_ID_OPTION, DRIVER_CONFIG_OPTION,
+                          'DRIVER_NAME', 'DRIVER_VERSION'):
+            if options.pop(owned_key, None) is not None:
+                # The application info is one object shared by every connection of
+                # a cluster, so an offending key is seen on all of them: warning
+                # on each would mean hosts x shards + 1 lines per connect(), and
+                # as many again on every pool replacement or control connection
+                # reconnect, for a misconfiguration that is in the application's
+                # code and identical on all of them.
+                #
+                # Warn on the control connection, which is established once per
+                # cluster and before the pools, and keep the rest at debug for
+                # whoever is looking at a specific connection.
+                level = logging.WARNING if self.is_control_connection else logging.DEBUG
+                log.log(level,
+                        "Ignoring the application-supplied %s startup option on %s: "
+                        "the option is reserved for the driver", owned_key, self.endpoint)
+
+        if self._session_id is not None:
+            options[SESSION_ID_OPTION] = str(self._session_id)
+
+        # The configuration is the same for every connection of a cluster, so
+        # only the control connection reports it. A reporter left as None means
+        # the cluster has configuration reporting disabled.
+        if self.is_control_connection and self._driver_config_reporter is not None:
+            self._driver_config_reporter.add_startup_options(options)
 
         if self.cql_version:
             if self.cql_version not in supported_cql_versions:

--- a/cassandra/driver_config.py
+++ b/cassandra/driver_config.py
@@ -1,0 +1,132 @@
+# Copyright 2026 ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Reporting of the driver's own identity and configuration to the cluster through
+the CQL ``STARTUP`` options. ScyllaDB echoes those options into the
+``client_options`` column of its clients table, so an operator investigating an
+incident can inspect the settings of a client without access to its host.
+"""
+
+import json
+import logging
+
+log = logging.getLogger(__name__)
+
+
+SESSION_ID_OPTION = 'SESSION_ID'
+"""
+``STARTUP`` option correlating the connections that belong to the same
+:class:`~.Cluster` in the clients table. Every connection reports it, since
+correlating them is the whole point of it.
+
+The name follows the convention shared with the other ScyllaDB drivers, where a
+"session" is what this driver calls a :class:`~.Cluster`; it is unrelated to
+:attr:`.Session.session_id`.
+"""
+
+DRIVER_CONFIG_OPTION = 'DRIVER_CONFIG'
+"""
+``STARTUP`` option holding the JSON description of the effective driver
+configuration. The configuration is the same for every connection of a cluster,
+so only the control connection reports it, keeping the other ``STARTUP`` frames
+small.
+"""
+
+DRIVER_CONFIG_SCHEMA_VERSION = 1
+"""
+Major version of the reported configuration schema. Adding keys to the report is
+backwards compatible and does not bump it, only changing or removing the meaning
+of an existing key does.
+"""
+
+MAX_DRIVER_CONFIG_LENGTH = 32 * 1024
+"""
+Upper bound for the length, in bytes, of the :const:`DRIVER_CONFIG_OPTION` value.
+
+``STARTUP`` options are serialized by :func:`cassandra.protocol.write_string`,
+which prefixes every value with a 16 bit length, so a longer value would fail to
+pack and take the handshake down with it. The report is a handful of bytes for
+now, but the configuration groups added later describe user supplied values,
+such as the settings of custom policies, and can grow arbitrarily large.
+Enforcing a limit here keeps "reporting must never prevent a connection from
+being established" a property of this module rather than of the user's
+configuration.
+
+32 KiB rather than the protocol's own 65535 byte ceiling: real world reports are
+expected to stay well under a couple of kilobytes, so this leaves ample headroom
+while remaining far short of the point where the value would stop protecting
+anything.
+"""
+
+
+class DriverConfigReporter:
+    """
+    Builds the :const:`DRIVER_CONFIG_OPTION` ``STARTUP`` option describing the
+    effective configuration of a :class:`~.Cluster`.
+
+    One instance is created per :class:`~.Cluster` and shared by all of its
+    connections, but only the control connection ever asks it for options. Which
+    connections report is decided by
+    :meth:`cassandra.connection.Connection._handle_options_response`, not here.
+    """
+
+    def add_startup_options(self, options):
+        """
+        Adds the configuration report to the ``STARTUP`` options being built.
+
+        Reporting is best effort: this runs while a connection is being
+        established, so a report that cannot be built or does not fit is logged
+        and left out rather than allowed to fail the connection.
+
+        Everything up to and including the assignment is guarded, not just the
+        building of the report: :meth:`_populate_report` is an extension point,
+        so a subclass returning something that is not a string has to be as
+        harmless as one raising. The assignment comes last, so nothing partial is
+        left in ``options`` either.
+        """
+        try:
+            report = self._build_report()
+            length = len(report.encode('utf8'))
+            if length > MAX_DRIVER_CONFIG_LENGTH:
+                log.warning("The driver configuration report is %d bytes long, which exceeds the "
+                            "%d bytes limit, it will not be reported to the cluster",
+                            length, MAX_DRIVER_CONFIG_LENGTH)
+                return
+
+            options[DRIVER_CONFIG_OPTION] = report
+        except Exception:
+            log.warning("Unable to build the driver configuration report, "
+                        "it will not be reported to the cluster", exc_info=True)
+
+    def _build_report(self):
+        """
+        Returns the JSON configuration report.
+
+        It is built for every control connection rather than cached, so that it
+        always describes the configuration as it is at that point in time. Later
+        configuration groups may well describe state that is only known once the
+        cluster has been contacted.
+        """
+        report = {'version': DRIVER_CONFIG_SCHEMA_VERSION}
+        self._populate_report(report)
+        # Separators without whitespace: the report is a wire value bounded by
+        # MAX_DRIVER_CONFIG_LENGTH, not something meant to be read as it is.
+        return json.dumps(report, separators=(',', ':'))
+
+    def _populate_report(self, report):
+        """
+        Extension point for adding the configuration groups themselves to the
+        report. Empty for now.
+        """
+        pass

--- a/docs/api/cassandra/cluster.rst
+++ b/docs/api/cassandra/cluster.rst
@@ -30,6 +30,11 @@ Clusters and Sessions
 
    .. autoattribute:: address_translator
 
+   .. autoattribute:: session_id
+
+   .. autoattribute:: driver_config_reporting_enabled
+      :annotation: = True
+
    .. autoattribute:: metrics_enabled
 
    .. autoattribute:: metrics

--- a/docs/scylla-specific.rst
+++ b/docs/scylla-specific.rst
@@ -290,3 +290,76 @@ directly from the data.
 
 For full protocol details see the ScyllaDB CQL protocol extensions documentation:
 https://github.com/scylladb/scylladb/blob/master/docs/dev/protocol-extensions.md
+
+
+Client identification and configuration reporting
+-------------------------------------------------
+
+The driver describes itself to the cluster in the CQL ``STARTUP`` options of
+each connection. ScyllaDB echoes those options into the ``client_options``
+column of its clients table, so an operator investigating an incident can
+inspect them without access to the client host:
+
+.. code:: sql
+
+    SELECT address, port, client_options FROM system.clients;
+
+Two of the options are about the driver rather than the protocol:
+
+``SESSION_ID``
+  A UUID identifying the ``Cluster`` object, generated when it is created.
+  *Every* connection the ``Cluster`` opens reports it -- the control connection
+  as well as the pools of each of its ``Session`` objects -- so all of a
+  client's connections can be told apart from those of other clients sharing
+  the same host. Applications can read it back from ``cluster.session_id`` and
+  log it, which is what allows client-side observations to be matched against
+  the rows above instead of correlating them by address and port.
+
+  The option is named after the convention shared with the other ScyllaDB
+  drivers, where a "session" is what this driver calls a ``Cluster``. It is
+  unrelated to ``Session.session_id``, which identifies a ``Session`` within the
+  client and is never sent to the cluster.
+
+``DRIVER_CONFIG``
+  A JSON document describing the effective configuration of the ``Cluster``. It
+  is the same for every one of its connections, so only the control connection
+  reports it, keeping the other ``STARTUP`` frames small. The document carries a
+  ``version`` key naming the schema it follows; further keys are added as the
+  driver learns to describe more of its configuration, and adding one does not
+  bump the version.
+
+.. code:: python
+
+    from cassandra.cluster import Cluster
+
+    cluster = Cluster()
+    session = cluster.connect()
+
+    print(cluster.session_id)  # matches SESSION_ID in the clients table
+
+    for row in session.execute("SELECT client_options FROM system.clients"):
+        # client_options is null for rows the server has not filled in yet.
+        if not row.client_options:
+            continue
+        if row.client_options.get('SESSION_ID') == str(cluster.session_id):
+            print(row.client_options)
+
+Reporting the configuration is a diagnostic aid and never interferes with
+connecting: a report that cannot be built, or that would not fit in a
+``STARTUP`` option, is logged and left out instead of failing the handshake.
+
+It can be turned off with ``driver_config_reporting_enabled``:
+
+.. code:: python
+
+    cluster = Cluster(driver_config_reporting_enabled=False)
+
+``SESSION_ID`` is unaffected by that setting: it carries no configuration, only
+the identity that ties a client's connections together, and every connection
+keeps reporting it.
+
+Alongside these, the ``application_info`` ``Cluster`` argument lets an
+application add its own name, version and identifier to the same options, as
+``APPLICATION_NAME``, ``APPLICATION_VERSION`` and ``CLIENT_ID``. Those are the
+application's to choose; ``SESSION_ID`` and ``DRIVER_CONFIG`` are driver-owned
+and cannot be overridden through it.

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -671,6 +671,26 @@ def is_scylla_enterprise(version: Version) -> bool:
     return version > Version('2000.1.1')
 
 
+def get_client_options(session):
+    """
+    The ``client_options`` of every connection listed in the cluster's clients
+    table, skipping the rows the server has not filled in yet.
+
+    The table has lived in both ``system`` and ``system_views`` across versions,
+    so try each in turn. Only :exc:`.InvalidRequest` is caught, which is what an
+    absent table answers with: catching more would report a timeout or a
+    ``NoHostAvailable`` on the first query as a failure of the second, and this
+    runs inside polling loops where that would repeat.
+    """
+    try:
+        rows = list(session.execute("SELECT client_options FROM system.clients"))
+    except InvalidRequest:
+        rows = list(session.execute("SELECT client_options FROM system_views.clients"))
+    # Indexed rather than named: the query selects the one column, so this works
+    # whatever row factory the caller's session is using.
+    return [row[0] for row in rows if row[0]]
+
+
 def xfail_scylla_version_lt(reason, scylla_version, *args, **kwargs):
     """
     It is used to mark tests that are going to fail on certain scylla versions.

--- a/tests/integration/standard/test_application_info.py
+++ b/tests/integration/standard/test_application_info.py
@@ -15,7 +15,8 @@
 import unittest
 
 from cassandra.application_info import ApplicationInfo
-from tests.integration import TestCluster, use_single_node, remove_cluster, xfail_scylla_version_lt
+from tests.integration import (TestCluster, get_client_options, use_single_node, remove_cluster,
+                               xfail_scylla_version_lt)
 
 
 def setup_module():
@@ -77,22 +78,15 @@ class ApplicationInfoTest(unittest.TestCase):
                     found = False
                     session = cluster.connect()
 
-                    try:
-                        rows = list(session.execute("SELECT client_options FROM system.clients"))
-                    except Exception:
-                        rows = list(session.execute("SELECT client_options FROM system_views.clients"))
-
-                    for row in rows:
-                        if not row[0]:
-                            continue
+                    for client_options in get_client_options(session):
                         for attribute_key, startup_key in self.attribute_to_startup_key.items():
                             expected_value = application_info_args.get(attribute_key)
                             if expected_value:
-                                if row[0].get(startup_key) != expected_value:
+                                if client_options.get(startup_key) != expected_value:
                                     break
                             else:
                                 # Check that it is absent
-                                if row[0].get(startup_key, None) is not None:
+                                if client_options.get(startup_key, None) is not None:
                                     break
                         else:
                             found = True

--- a/tests/integration/standard/test_driver_config.py
+++ b/tests/integration/standard/test_driver_config.py
@@ -1,0 +1,223 @@
+# Copyright 2026 ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import time
+import unittest
+
+from cassandra.driver_config import (DRIVER_CONFIG_OPTION, DRIVER_CONFIG_SCHEMA_VERSION,
+                                     SESSION_ID_OPTION)
+from tests.integration import (TestCluster, get_client_options, use_single_node, remove_cluster,
+                               xfail_scylla_version_lt)
+
+
+def setup_module():
+    # A single node keeps the clients table, which lists only the connections
+    # made to the node serving the query, complete: every connection of the
+    # cluster under test is made to that one node.
+    use_single_node()
+
+
+def teardown_module():
+    remove_cluster()
+
+
+CONNECTION_WAIT_TIMEOUT = 30
+
+
+def _expected_connection_count(session):
+    """
+    Number of connections the driver believes it has open: the control
+    connection plus every live pool connection, one per shard on a shard aware
+    cluster. This is what "every connection of this cluster" has to be counted
+    against; asserting over whichever connections happen to be listed says
+    nothing about the ones that are not.
+    """
+    return 1 + sum(state['open_count'] for state in session.get_pool_state().values())
+
+
+def _settled_connection_count(session, timeout=CONNECTION_WAIT_TIMEOUT):
+    """
+    Same count, taken once the pools have stopped filling.
+
+    ``Cluster.connect(wait_for_all_pools=True)`` waits only for each pool's
+    first connection. On a shard aware cluster HostConnection opens that one,
+    learns the shard count from it, and then submits a connection per remaining
+    shard to the session executor, returning before any of them are up. Counting
+    straight after connect would therefore set the bar at one connection per
+    host and let the assertions pass without ever looking at the shard
+    connections.
+
+    A connection that fails to open for good would keep the count below the
+    shard count forever, so this waits for the count to stop moving rather than
+    for a particular value, and returns whatever the driver ended up with.
+    """
+    deadline = time.time() + timeout
+    # Two unchanged reads in a row, so that a gap between two shard connections
+    # coming up is not mistaken for the pools having settled.
+    settled_reads, previous = 0, None
+    while True:
+        count = _expected_connection_count(session)
+        settled_reads = settled_reads + 1 if count == previous else 0
+        previous = count
+        if settled_reads >= 2 or time.time() >= deadline:
+            return count
+        time.sleep(0.5)
+
+
+def _wait_for_connections(session, session_id, count, timeout=CONNECTION_WAIT_TIMEOUT):
+    """
+    Polls the clients table until at least ``count`` connections report
+    ``session_id``, and returns the client options of the ones that do.
+
+    ``Cluster.connect(wait_for_all_pools=True)`` waits for the pools to be
+    created, but a connection shows up here only once the server has registered
+    it, so the rows arrive later than the connections do.
+
+    Returns a short list if the timeout expires first rather than asserting, so
+    that the count stays the caller's claim to make: an "absent everywhere" or a
+    "reported exactly once" holds trivially over a list that is short only
+    because the rows had not appeared yet.
+    """
+    deadline = time.time() + timeout
+    while True:
+        options = [o for o in get_client_options(session) if o.get(SESSION_ID_OPTION) == session_id]
+        if len(options) >= count or time.time() >= deadline:
+            return options
+        time.sleep(0.5)
+
+
+def _assert_listed(options, count, session_id, timeout=CONNECTION_WAIT_TIMEOUT):
+    assert len(options) >= count, \
+        "only %d of %d connections with SESSION_ID %s were listed within %ss" % (
+            len(options), count, session_id, timeout)
+
+
+@xfail_scylla_version_lt(reason='scylladb/scylla-enterprise#5467 - system.client_options is not yet supported',
+                         scylla_version="2026.1.0")
+class DriverConfigReportingTest(unittest.TestCase):
+    def test_every_connection_reports_the_session_id(self):
+        """
+        The session id is what correlates a cluster's connections with each
+        other in the clients table, so all of them must report the one the
+        cluster exposes -- not merely some of them.
+        """
+        cluster = TestCluster()
+        try:
+            session = cluster.connect(wait_for_all_pools=True)
+            session_id = str(cluster.session_id)
+            expected = _settled_connection_count(session)
+
+            options = _wait_for_connections(session, session_id, count=expected)
+
+            # The rows were selected by session id, so the count is the claim:
+            # as many connections carry it as the cluster has open. More is
+            # fine, a connection that has already been closed lingers in the
+            # table; fewer means one of them went out without the id.
+            _assert_listed(options, expected, session_id)
+        finally:
+            cluster.shutdown()
+
+    def test_distinct_clusters_report_distinct_session_ids(self):
+        cluster = TestCluster()
+        other_cluster = TestCluster()
+        try:
+            session = cluster.connect(wait_for_all_pools=True)
+            other_cluster.connect(wait_for_all_pools=True)
+
+            session_id = str(cluster.session_id)
+            other_session_id = str(other_cluster.session_id)
+            assert session_id != other_session_id
+
+            # Both clusters reach the same node, so either session can read the
+            # rows of both. Each id is waited for rather than read straight out
+            # of one snapshot: connect() returns once the pools exist on the
+            # client, while the rows appear only once the server has registered
+            # the connections, so whichever cluster registered last would
+            # intermittently be missing.
+            #
+            # One row per cluster is the whole claim here -- that the two ids
+            # both reach the server and differ. Counting every connection of a
+            # cluster is what test_every_connection_reports_the_session_id is
+            # for.
+            for wanted in (session_id, other_session_id):
+                _assert_listed(_wait_for_connections(session, wanted, count=1), 1, wanted)
+        finally:
+            other_cluster.shutdown()
+            cluster.shutdown()
+
+    def test_only_the_control_connection_reports_the_driver_config(self):
+        """
+        The configuration is the same for every connection of a cluster, so it is
+        reported once, by the control connection, to keep the other STARTUP
+        frames small.
+        """
+        cluster = TestCluster()
+        try:
+            session = cluster.connect(wait_for_all_pools=True)
+            session_id = str(cluster.session_id)
+
+            # Every connection of the cluster, not merely two of them. Two rows
+            # can both be pool connections, and the control connection is the
+            # only one that ever reports, so its row missing from the snapshot
+            # would empty `reports` and fail this test with nothing broken.
+            expected = _settled_connection_count(session)
+            options = _wait_for_connections(session, session_id, count=expected)
+            _assert_listed(options, expected, session_id)
+
+            reports = [o[DRIVER_CONFIG_OPTION] for o in options if DRIVER_CONFIG_OPTION in o]
+
+            # Rows can outlive the connections they describe, so the table may
+            # list more than the cluster has open. Those extra rows are not
+            # harmless bystanders: a control connection re-established during
+            # this test leaves a closed row carrying this same session id and a
+            # DRIVER_CONFIG of its own, so a second report does not by itself
+            # mean a pool connection produced one.
+            #
+            # The exact count is kept regardless, because relaxing it would let
+            # through the regression this test exists for, and a reconnect
+            # against a healthy single node within the seconds it runs is not
+            # expected. The message says so, so that a failure here can be told
+            # apart from the regression.
+            assert len(reports) == 1, \
+                ("expected exactly one connection to report %s, got %d. If the control "
+                 "connection reconnected during this test, the closed one may still be "
+                 "listed with a report of its own." % (DRIVER_CONFIG_OPTION, len(reports)))
+            assert json.loads(reports[0]) == {'version': DRIVER_CONFIG_SCHEMA_VERSION}
+        finally:
+            cluster.shutdown()
+
+    def test_driver_config_is_not_reported_when_disabled(self):
+        """
+        With reporting disabled not even the control connection reports
+        DRIVER_CONFIG, while the session id, which the setting is documented not
+        to affect, is still reported by every connection.
+        """
+        cluster = TestCluster(driver_config_reporting_enabled=False)
+        try:
+            session = cluster.connect(wait_for_all_pools=True)
+            session_id = str(cluster.session_id)
+
+            # Every connection of the cluster, not merely two of them. Two rows
+            # can both be pool connections, which never report whatever this
+            # setting says, so the absence below would hold over them even with
+            # the control connection reporting away: the one case this test
+            # exists to catch.
+            expected = _settled_connection_count(session)
+            options = _wait_for_connections(session, session_id, count=expected)
+            _assert_listed(options, expected, session_id)
+
+            assert all(DRIVER_CONFIG_OPTION not in o for o in options)
+        finally:
+            cluster.shutdown()

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -26,6 +26,7 @@ from cassandra import ConsistencyLevel, DriverException, Timeout, Unavailable, R
 from cassandra.cluster import _Scheduler, Session, Cluster, ResultSet, SchemaAgreementScope, ControlConnectionQueryFallback, default_lbp_factory, \
     ExecutionProfile, _ConfigMode, EXEC_PROFILE_DEFAULT
 from cassandra.connection import ConnectionBusy, ConnectionException
+from cassandra.driver_config import DriverConfigReporter
 from cassandra.pool import Host
 from cassandra.policies import HostDistance, RetryPolicy, RoundRobinPolicy, DowngradingConsistencyRetryPolicy, SimpleConvictionPolicy
 from cassandra.query import SimpleStatement, named_tuple_factory, tuple_factory
@@ -286,6 +287,98 @@ class ClusterTest(unittest.TestCase):
                 assert factory.call_count == 1
                 assert factory.call_args.kwargs['compression'] == expected
                 assert cluster.compression == expected
+
+    def test_session_id_is_stable_and_unique_per_cluster(self):
+        cluster = Cluster()
+        other = Cluster()
+        self.addCleanup(cluster.shutdown)
+        self.addCleanup(other.shutdown)
+
+        assert isinstance(cluster.session_id, uuid.UUID)
+        assert cluster.session_id == cluster.session_id
+        assert cluster.session_id != other.session_id
+
+    def test_session_id_is_read_only(self):
+        """
+        Every connection reports it at STARTUP, so it cannot change once any of
+        them is open without breaking the correlation it exists for.
+        """
+        cluster = Cluster()
+        self.addCleanup(cluster.shutdown)
+
+        with pytest.raises(AttributeError):
+            cluster.session_id = uuid.uuid4()
+
+    def test_connection_factory_reports_the_session_id_and_the_configuration(self):
+        endpoint = Mock(address='127.0.0.1')
+        with patch.object(Cluster.connection_class, 'factory', autospec=True, return_value='connection') as factory:
+            cluster = Cluster()
+            self.addCleanup(cluster.shutdown)
+            cluster.connection_factory(endpoint)
+
+        assert factory.call_args.kwargs['session_id'] == cluster.session_id
+        assert isinstance(factory.call_args.kwargs['driver_config_reporter'], DriverConfigReporter)
+
+    def test_driver_config_reporting_can_be_toggled_after_construction(self):
+        """
+        The flag is a plain published attribute, so it is read when a connection
+        is opened rather than captured at construction: setting it either way
+        used to be silently inert, in both directions.
+        """
+        endpoint = Mock(address='127.0.0.1')
+
+        def reporter_for(cluster):
+            with patch.object(Cluster.connection_class, 'factory', autospec=True,
+                              return_value='connection') as factory:
+                cluster.connection_factory(endpoint)
+            return factory.call_args.kwargs['driver_config_reporter']
+
+        cluster = Cluster()
+        self.addCleanup(cluster.shutdown)
+        assert reporter_for(cluster) is not None
+        cluster.driver_config_reporting_enabled = False
+        assert reporter_for(cluster) is None
+
+        # And back on again: a cluster built with reporting off must not be
+        # permanently unable to report. Registered before the rebinding, since
+        # afterwards the first cluster is no longer reachable to shut down.
+        cluster = Cluster(driver_config_reporting_enabled=False)
+        self.addCleanup(cluster.shutdown)
+        assert reporter_for(cluster) is None
+        cluster.driver_config_reporting_enabled = True
+        assert isinstance(reporter_for(cluster), DriverConfigReporter)
+
+    def test_connection_factory_passes_no_reporter_when_reporting_is_disabled(self):
+        """
+        A reporter left as None is how the setting reaches the connections. The
+        session id is documented not to be affected by it.
+        """
+        endpoint = Mock(address='127.0.0.1')
+        with patch.object(Cluster.connection_class, 'factory', autospec=True, return_value='connection') as factory:
+            cluster = Cluster(driver_config_reporting_enabled=False)
+            self.addCleanup(cluster.shutdown)
+            cluster.connection_factory(endpoint)
+
+        assert cluster.driver_config_reporting_enabled is False
+        assert factory.call_args.kwargs['driver_config_reporter'] is None
+        assert factory.call_args.kwargs['session_id'] == cluster.session_id
+
+    def test_connection_factory_ignores_a_caller_supplied_session_id_and_reporter(self):
+        """
+        Both describe the Cluster to the server, so they are assigned rather than
+        defaulted from the caller's kwargs: nothing may substitute the id that
+        correlates this cluster's connections, nor a reporter the cluster's own
+        setting turned off.
+        """
+        endpoint = Mock(address='127.0.0.1')
+        with patch.object(Cluster.connection_class, 'factory', autospec=True, return_value='connection') as factory:
+            cluster = Cluster(driver_config_reporting_enabled=False)
+            self.addCleanup(cluster.shutdown)
+            cluster.connection_factory(endpoint, session_id=uuid.uuid4(),
+                                       driver_config_reporter=DriverConfigReporter())
+
+        assert factory.call_args.kwargs['session_id'] == cluster.session_id
+        assert factory.call_args.kwargs['driver_config_reporter'] is None
 
 
 class SchedulerTest(unittest.TestCase):

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -152,6 +152,7 @@ class ClusterTest(unittest.TestCase):
 
     def test_tuple_for_contact_points(self):
         cluster = Cluster(contact_points=[('localhost', 9045), ('127.0.0.2', 9046), '127.0.0.3'], port=9999)
+        self.addCleanup(cluster.shutdown)
         # Refactored for clarity
         addr_info = socket.getaddrinfo("localhost", 80)
         sockaddr_tuples = [info[4] for info in addr_info]  # info[4] is sockaddr
@@ -174,6 +175,7 @@ class ClusterTest(unittest.TestCase):
     def test_port_str(self):
         """Check port passed as string is converted and checked properly"""
         cluster = Cluster(contact_points=['127.0.0.1'], port='1111')
+        self.addCleanup(cluster.shutdown)
         for cp in cluster.endpoints_resolved:
             if cp.address in ('::1', '127.0.0.1'):
                 assert cp.port == 1111
@@ -188,24 +190,29 @@ class ClusterTest(unittest.TestCase):
                 cluster = Cluster(contact_points=['127.0.0.1'], port=invalid_port)
 
     def test_control_connection_query_fallback_modes(self):
-        assert Cluster().allow_control_connection_query_fallback is ControlConnectionQueryFallback.Disabled
+        default_cluster = Cluster()
+        self.addCleanup(default_cluster.shutdown)
+        assert default_cluster.allow_control_connection_query_fallback is ControlConnectionQueryFallback.Disabled
         with pytest.raises(TypeError):
             Cluster(allow_control_connection_query_fallback=False)
         with pytest.raises(TypeError):
             Cluster(allow_control_connection_query_fallback=True)
-        assert (
-            Cluster(allow_control_connection_query_fallback=ControlConnectionQueryFallback.Fallback)
-            .allow_control_connection_query_fallback
+        fallback_cluster = Cluster(
+            allow_control_connection_query_fallback=ControlConnectionQueryFallback.Fallback)
+        self.addCleanup(fallback_cluster.shutdown)
+        assert fallback_cluster.allow_control_connection_query_fallback \
             is ControlConnectionQueryFallback.Fallback
-        )
-        assert Cluster(
-            allow_control_connection_query_fallback=ControlConnectionQueryFallback.SkipPoolCreation
-        ).allow_control_connection_query_fallback is ControlConnectionQueryFallback.SkipPoolCreation
+        skip_pool_cluster = Cluster(
+            allow_control_connection_query_fallback=ControlConnectionQueryFallback.SkipPoolCreation)
+        self.addCleanup(skip_pool_cluster.shutdown)
+        assert skip_pool_cluster.allow_control_connection_query_fallback \
+            is ControlConnectionQueryFallback.SkipPoolCreation
 
     def test_control_connection_query_fallback_no_node_pool_mode_skips_pool_creation(self):
         cluster = Cluster(
             allow_control_connection_query_fallback=ControlConnectionQueryFallback.SkipPoolCreation,
         )
+        self.addCleanup(cluster.shutdown)
         host = Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())
 
         with patch.object(Session, "add_or_renew_pool") as mocked_add_or_renew_pool:
@@ -220,6 +227,7 @@ class ClusterTest(unittest.TestCase):
         cluster = Cluster(
             allow_control_connection_query_fallback=ControlConnectionQueryFallback.Fallback,
         )
+        self.addCleanup(cluster.shutdown)
         host = Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())
         future = Future()
         future.set_result(False)
@@ -235,6 +243,7 @@ class ClusterTest(unittest.TestCase):
         with patch.dict('cassandra.cluster.locally_supported_compressions', {}, clear=True):
             with patch('cassandra.cluster.log') as patched_logger:
                 cluster = Cluster(compression=True)
+                self.addCleanup(cluster.shutdown)
 
         patched_logger.error.assert_called_once()
         assert cluster.compression is False
@@ -247,6 +256,7 @@ class ClusterTest(unittest.TestCase):
         with patch.dict('cassandra.cluster.locally_supported_compressions', {'lz4': ('c', 'd')}, clear=True):
             with patch('cassandra.cluster.log') as patched_logger:
                 cluster = Cluster(compression='lz4')
+                self.addCleanup(cluster.shutdown)
 
         patched_logger.error.assert_not_called()
         assert cluster.compression == 'lz4'
@@ -269,6 +279,7 @@ class ClusterTest(unittest.TestCase):
             with patch.dict('cassandra.cluster.locally_supported_compressions', supported, clear=True):
                 with patch.object(Cluster.connection_class, 'factory', autospec=True, return_value='connection') as factory:
                     cluster = Cluster(compression=configured)
+                    self.addCleanup(cluster.shutdown)
                     conn = cluster.connection_factory(endpoint)
 
                 assert conn == 'connection'
@@ -388,6 +399,7 @@ class SessionTest(unittest.TestCase):
             distance_map[host] = distances[index]
 
         cluster = Cluster(protocol_version=4)
+        self.addCleanup(cluster.shutdown)
         for host in hosts:
             cluster.metadata.add_or_return_host(host)
 
@@ -421,6 +433,7 @@ class SessionTest(unittest.TestCase):
         PR #510
         """
         c = Cluster(protocol_version=4)
+        self.addCleanup(c.shutdown)
         s = Session(c, [Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())])
         c.connection_class.initialize_reactor()
 
@@ -450,6 +463,7 @@ class SessionTest(unittest.TestCase):
         PR #510
         """
         c = Cluster(protocol_version=4)
+        self.addCleanup(c.shutdown)
         s = Session(c, [Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())])
         c.connection_class.initialize_reactor()
         # default is None
@@ -480,6 +494,7 @@ class SessionTest(unittest.TestCase):
         Requested in review of PR #758.
         """
         c = Cluster(protocol_version=4)
+        self.addCleanup(c.shutdown)
         s = Session(c, [Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())])
         c.connection_class.initialize_reactor()
 
@@ -599,6 +614,7 @@ class SessionTest(unittest.TestCase):
     @mock_session_pools
     def test_set_keyspace_for_all_pools_reports_all_errors(self, *_):
         cluster = Cluster()
+        self.addCleanup(cluster.shutdown)
         session = Session(
             cluster,
             [Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())],
@@ -653,6 +669,7 @@ class ExecutionProfileTest(unittest.TestCase):
     @mock_session_pools
     def test_default_exec_parameters(self):
         cluster = Cluster()
+        self.addCleanup(cluster.shutdown)
         assert cluster._config_mode == _ConfigMode.UNCOMMITTED
         assert cluster.load_balancing_policy.__class__ == default_lbp_factory().__class__
         assert cluster.profile_manager.default.load_balancing_policy.__class__ == default_lbp_factory().__class__
@@ -671,6 +688,7 @@ class ExecutionProfileTest(unittest.TestCase):
     @mock_session_pools
     def test_default_legacy(self):
         cluster = Cluster(load_balancing_policy=RoundRobinPolicy(), default_retry_policy=DowngradingConsistencyRetryPolicy())
+        self.addCleanup(cluster.shutdown)
         assert cluster._config_mode == _ConfigMode.LEGACY
         session = Session(cluster, hosts=[Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())])
         session.default_timeout = 3.7
@@ -686,6 +704,7 @@ class ExecutionProfileTest(unittest.TestCase):
     def test_default_profile(self):
         non_default_profile = ExecutionProfile(RoundRobinPolicy(), *[object() for _ in range(2)])
         cluster = Cluster(execution_profiles={'non-default': non_default_profile})
+        self.addCleanup(cluster.shutdown)
         session = Session(cluster, hosts=[Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())])
 
         assert cluster._config_mode == _ConfigMode.PROFILES
@@ -718,6 +737,7 @@ class ExecutionProfileTest(unittest.TestCase):
     @mock_session_pools
     def test_statement_params_override_legacy(self):
         cluster = Cluster(load_balancing_policy=RoundRobinPolicy(), default_retry_policy=DowngradingConsistencyRetryPolicy())
+        self.addCleanup(cluster.shutdown)
         assert cluster._config_mode == _ConfigMode.LEGACY
         session = Session(cluster, hosts=[Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())])
 
@@ -740,6 +760,7 @@ class ExecutionProfileTest(unittest.TestCase):
     def test_statement_params_override_profile(self):
         non_default_profile = ExecutionProfile(RoundRobinPolicy(), *[object() for _ in range(2)])
         cluster = Cluster(execution_profiles={'non-default': non_default_profile})
+        self.addCleanup(cluster.shutdown)
         session = Session(cluster, hosts=[Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())])
 
         assert cluster._config_mode == _ConfigMode.PROFILES
@@ -773,11 +794,13 @@ class ExecutionProfileTest(unittest.TestCase):
 
         # can't add after
         cluster = Cluster(load_balancing_policy=RoundRobinPolicy())
+        self.addCleanup(cluster.shutdown)
         with pytest.raises(ValueError):
             cluster.add_execution_profile('name', ExecutionProfile())
 
         # session settings lock out profiles
         cluster = Cluster()
+        self.addCleanup(cluster.shutdown)
         session = Session(cluster, hosts=[Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())])
         for attr, value in (('default_timeout', 1),
                             ('default_consistency_level', ConsistencyLevel.ANY),
@@ -796,6 +819,8 @@ class ExecutionProfileTest(unittest.TestCase):
     def test_no_legacy_with_profile(self):
         cluster_init = Cluster(execution_profiles={'name': ExecutionProfile()})
         cluster_add = Cluster()
+        self.addCleanup(cluster_init.shutdown)
+        self.addCleanup(cluster_add.shutdown)
         cluster_add.add_execution_profile('name', ExecutionProfile())
         # for clusters with profiles added either way...
         for cluster in (cluster_init, cluster_init):
@@ -817,6 +842,7 @@ class ExecutionProfileTest(unittest.TestCase):
 
         internalized_profile = ExecutionProfile(RoundRobinPolicy(), *[object() for _ in range(2)])
         cluster = Cluster(execution_profiles={'by-name': internalized_profile})
+        self.addCleanup(cluster.shutdown)
         session = Session(cluster, hosts=[Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())])
         assert cluster._config_mode == _ConfigMode.PROFILES
 
@@ -831,6 +857,7 @@ class ExecutionProfileTest(unittest.TestCase):
     def test_exec_profile_clone(self):
 
         cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(), 'one': ExecutionProfile()})
+        self.addCleanup(cluster.shutdown)
         session = Session(cluster, hosts=[Host("127.0.0.1", SimpleConvictionPolicy, host_id=uuid.uuid4())])
 
         profile_attrs = {'request_timeout': 1,
@@ -862,6 +889,7 @@ class ExecutionProfileTest(unittest.TestCase):
     def test_no_profiles_same_name(self):
         # can override default in init
         cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(), 'one': ExecutionProfile()})
+        self.addCleanup(cluster.shutdown)
 
         # cannot update default
         with pytest.raises(ValueError):
@@ -913,7 +941,8 @@ class ExecutionProfileTest(unittest.TestCase):
     @mock_session_pools
     def _check_warning_on_no_lbp_with_contact_points(self, cluster_kwargs):
         with patch('cassandra.cluster.log') as patched_logger:
-            Cluster(**cluster_kwargs)
+            cluster = Cluster(**cluster_kwargs)
+        self.addCleanup(cluster.shutdown)
         patched_logger.warning.assert_called_once()
         warning_message = patched_logger.warning.call_args[0][0]
         assert 'please specify a load-balancing policy' in warning_message
@@ -968,7 +997,8 @@ class ExecutionProfileTest(unittest.TestCase):
         @test_category configuration
         """
         with patch('cassandra.cluster.log') as patched_logger:
-            Cluster(**cluster_kwargs)
+            cluster = Cluster(**cluster_kwargs)
+        self.addCleanup(cluster.shutdown)
         patched_logger.warning.assert_not_called()
 
     @mock_session_pools
@@ -977,6 +1007,7 @@ class ExecutionProfileTest(unittest.TestCase):
         cluster = Cluster(
             contact_points=['127.0.0.1'],
             execution_profiles={EXEC_PROFILE_DEFAULT: ep_with_lbp})
+        self.addCleanup(cluster.shutdown)
         with patch('cassandra.cluster.log') as patched_logger:
             cluster.add_execution_profile(
                 name='no_lbp',
@@ -995,6 +1026,7 @@ class ExecutionProfileTest(unittest.TestCase):
         cluster = Cluster(
             contact_points=['127.0.0.1'],
             execution_profiles={EXEC_PROFILE_DEFAULT: ep_with_lbp})
+        self.addCleanup(cluster.shutdown)
         with patch('cassandra.cluster.log') as patched_logger:
             cluster.add_execution_profile(
                 name='with_lbp',

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -13,22 +13,27 @@
 # limitations under the License.
 import itertools
 import unittest
+import uuid
 from io import BytesIO
 import time
 from threading import Lock
 from unittest.mock import Mock, ANY, call, patch
 
 from cassandra import OperationTimedOut
+from cassandra.application_info import ApplicationInfoBase
 from cassandra.cluster import Cluster
 from cassandra.connection import (Connection, HEADER_DIRECTION_TO_CLIENT, ProtocolError,
                                   locally_supported_compressions, ConnectionHeartbeat, HeartbeatFuture, _Frame, Timer, TimerManager,
                                   ConnectionException, ConnectionShutdown, DefaultEndPoint, ShardAwarePortGenerator,
-                                  DRIVER_NAME)
+                                  DRIVER_NAME, DRIVER_VERSION)
+from cassandra.driver_config import (DriverConfigReporter, DRIVER_CONFIG_OPTION,
+                                     DRIVER_CONFIG_SCHEMA_VERSION, SESSION_ID_OPTION)
 from cassandra.marshal import uint8_pack, uint32_pack, int32_pack
 from cassandra.protocol import (write_stringmultimap, write_int, write_string,
-                                SupportedMessage, ProtocolHandler, ResultMessage,
-                                RESULT_KIND_SET_KEYSPACE)
+                                read_stringmap, SupportedMessage, ProtocolHandler,
+                                ResultMessage, RESULT_KIND_SET_KEYSPACE)
 
+from tests.unit.utils import ThrowingReporter
 from tests.util import wait_until, assertRegex
 import pytest
 
@@ -407,6 +412,219 @@ class ConnectionTest(unittest.TestCase):
         error_message = str(exc_info.value)
         assert "already closed" in error_message
         assert "Bad file descriptor" in error_message
+
+
+class StartupOptionsTest(unittest.TestCase):
+    """
+    Covers the options the driver puts in the STARTUP frame, by driving a
+    connection through the SUPPORTED response that triggers it and reading the
+    frame it hands to send_msg.
+    """
+
+    SESSION_ID = uuid.UUID('91b0b1a2-0000-4000-8000-000000000001')
+
+    def startup_options(self, **kwargs):
+        c = Connection(DefaultEndPoint('1.2.3.4'), **kwargs)
+        c._socket = Mock()
+        c.send_msg = Mock()
+        c.defunct = Mock()
+
+        c._handle_options_response(
+            SupportedMessage(cql_versions=['3.0.3'], options={'COMPRESSION': []}))
+
+        c.defunct.assert_not_called()
+        c.send_msg.assert_called_once()
+        return c.send_msg.call_args[0][0].options
+
+    def test_session_id_is_reported(self):
+        options = self.startup_options(session_id=self.SESSION_ID)
+
+        assert options[SESSION_ID_OPTION] == str(self.SESSION_ID)
+
+    def test_session_id_is_absent_when_not_configured(self):
+        """
+        Connections built outside of a Cluster (lower-level integrations, tests)
+        have no cluster to be correlated with, so they report no SESSION_ID
+        rather than an empty one.
+        """
+        options = self.startup_options()
+
+        assert SESSION_ID_OPTION not in options
+
+    def test_application_info_cannot_override_the_session_id(self):
+        """
+        SESSION_ID is driver-owned: it is what correlates a cluster's connections
+        in the clients table, so an application-supplied value must not win.
+        """
+        class SpoofingApplicationInfo(ApplicationInfoBase):
+            def add_startup_options(self, options):
+                options[SESSION_ID_OPTION] = 'not-the-session-id'
+                options['APPLICATION_NAME'] = 'app'
+
+        options = self.startup_options(session_id=self.SESSION_ID,
+                                       application_info=SpoofingApplicationInfo())
+
+        assert options[SESSION_ID_OPTION] == str(self.SESSION_ID)
+        # Keys the driver does not own must still come through.
+        assert options['APPLICATION_NAME'] == 'app'
+
+    def test_application_info_cannot_override_the_driver_config(self):
+        """
+        DRIVER_CONFIG is driver-owned too: an operator reading it out of the
+        clients table must be reading the driver's description of itself, not an
+        application's. That has to hold on the connections and in the
+        configurations that report none of their own, which is where merely
+        writing it last would leave the application's value standing.
+        """
+        class SpoofingApplicationInfo(ApplicationInfoBase):
+            def add_startup_options(self, options):
+                options[DRIVER_CONFIG_OPTION] = '{"version":999,"spoofed":true}'
+                options['APPLICATION_NAME'] = 'app'
+
+        # Four independent guarantees, each in its own subtest: run sequentially
+        # the first regression would hide the other three, and which of them
+        # break is what says where the hole is.
+        ABSENT = object()
+        cases = [
+            ("a pool connection reports no configuration at all",
+             {'driver_config_reporter': DriverConfigReporter()},
+             ABSENT),
+            ("nor does a control connection with reporting disabled",
+             {'is_control_connection': True},
+             ABSENT),
+            ("a dropped report is not a hole for one either",
+             {'is_control_connection': True, 'driver_config_reporter': ThrowingReporter()},
+             ABSENT),
+            ("the driver's own report wins where there is one",
+             {'is_control_connection': True, 'driver_config_reporter': DriverConfigReporter()},
+             '{"version":%d}' % DRIVER_CONFIG_SCHEMA_VERSION),
+        ]
+
+        for description, kwargs, expected in cases:
+            with self.subTest(description):
+                options = self.startup_options(session_id=self.SESSION_ID,
+                                               application_info=SpoofingApplicationInfo(),
+                                               **kwargs)
+                if expected is ABSENT:
+                    assert DRIVER_CONFIG_OPTION not in options
+                else:
+                    assert options[DRIVER_CONFIG_OPTION] == expected
+                # Keys the driver does not own must still come through.
+                assert options['APPLICATION_NAME'] == 'app'
+
+    def test_application_info_cannot_override_the_driver_identity(self):
+        """
+        DRIVER_NAME and DRIVER_VERSION are driver-owned for the same reason as
+        the two options above: they land in the same clients-table row, read by
+        the same operator, and a spoofed value would misreport the driver for the
+        life of the connection.
+
+        They are the pair that made the ordering matter: _send_startup_message
+        merges the application's options *after* its own literals, so before they
+        were cleared here an application-supplied value won.
+        """
+        class SpoofingApplicationInfo(ApplicationInfoBase):
+            def add_startup_options(self, options):
+                options['DRIVER_NAME'] = 'not-the-driver'
+                options['DRIVER_VERSION'] = '0.0.0'
+                options['APPLICATION_NAME'] = 'app'
+
+        options = self.startup_options(application_info=SpoofingApplicationInfo())
+
+        assert options['DRIVER_NAME'] == DRIVER_NAME
+        assert options['DRIVER_VERSION'] == DRIVER_VERSION
+        # Keys the driver does not own must still come through.
+        assert options['APPLICATION_NAME'] == 'app'
+
+    def test_ignored_option_is_warned_about_once_per_cluster(self):
+        """
+        The offending key is on every connection of the cluster, since they share
+        one application info object, so warning on each would mean
+        hosts x shards + 1 lines per connect() and as many again on every pool
+        replacement. The control connection, established once and before the
+        pools, carries the warning; the rest stay at debug.
+        """
+        class SpoofingApplicationInfo(ApplicationInfoBase):
+            def add_startup_options(self, options):
+                options['DRIVER_NAME'] = 'not-the-driver'
+
+        with self.assertLogs('cassandra.connection', level='DEBUG') as captured:
+            self.startup_options(is_control_connection=True,
+                                 application_info=SpoofingApplicationInfo())
+        assert [r.getMessage() for r in captured.records if r.levelname == 'WARNING'] == [
+            "Ignoring the application-supplied DRIVER_NAME startup option on 1.2.3.4:9042: "
+            "the option is reserved for the driver"]
+
+        with self.assertLogs('cassandra.connection', level='DEBUG') as captured:
+            self.startup_options(application_info=SpoofingApplicationInfo())
+        assert [r.levelname for r in captured.records if 'DRIVER_NAME' in r.getMessage()] == ['DEBUG']
+
+    def test_application_info_cannot_override_the_cql_version(self):
+        """
+        CQL_VERSION is driver-owned as well, but needs no clearing: StartupMessage
+        writes it after the options map. Pinned here so that the reason the key is
+        absent from the cleared set stays true.
+        """
+        class SpoofingApplicationInfo(ApplicationInfoBase):
+            def add_startup_options(self, options):
+                options['CQL_VERSION'] = '9.9.9'
+
+        c = Connection(DefaultEndPoint('1.2.3.4'),
+                       application_info=SpoofingApplicationInfo())
+        c._socket = Mock()
+        c.send_msg = Mock()
+        c.defunct = Mock()
+        c._handle_options_response(
+            SupportedMessage(cql_versions=['3.0.3'], options={'COMPRESSION': []}))
+        c.defunct.assert_not_called()
+
+        buf = BytesIO()
+        c.send_msg.call_args[0][0].send_body(buf, c.protocol_version)
+        buf.seek(0)
+        assert read_stringmap(buf)['CQL_VERSION'] == '3.0.3'
+
+    def test_driver_config_is_reported_on_the_control_connection(self):
+        options = self.startup_options(is_control_connection=True,
+                                       driver_config_reporter=DriverConfigReporter())
+
+        assert options[DRIVER_CONFIG_OPTION] == '{"version":%d}' % DRIVER_CONFIG_SCHEMA_VERSION
+
+    def test_driver_config_is_not_reported_on_a_regular_connection(self):
+        """
+        The configuration is the same for every connection of a cluster, so only
+        the control connection reports it; the pool connections still report the
+        session id that ties them to it.
+        """
+        options = self.startup_options(session_id=self.SESSION_ID,
+                                       driver_config_reporter=DriverConfigReporter())
+
+        assert SESSION_ID_OPTION in options
+        assert DRIVER_CONFIG_OPTION not in options
+
+    def test_driver_config_is_not_reported_without_a_reporter(self):
+        """
+        A reporter left as None is how a Cluster with
+        driver_config_reporting_enabled=False reaches its connections. The
+        session id is documented not to be affected by that setting.
+        """
+        options = self.startup_options(is_control_connection=True,
+                                       session_id=self.SESSION_ID)
+
+        assert options[SESSION_ID_OPTION] == str(self.SESSION_ID)
+        assert DRIVER_CONFIG_OPTION not in options
+
+    def test_a_failing_reporter_does_not_break_the_handshake(self):
+        """
+        Reporting is a diagnostic aid: a reporter that cannot produce a report
+        must leave the STARTUP frame otherwise intact rather than fail the
+        connection.
+        """
+        options = self.startup_options(is_control_connection=True,
+                                       session_id=self.SESSION_ID,
+                                       driver_config_reporter=ThrowingReporter())
+
+        assert DRIVER_CONFIG_OPTION not in options
+        assert options[SESSION_ID_OPTION] == str(self.SESSION_ID)
 
 
 @patch('cassandra.connection.ConnectionHeartbeat._raise_if_stopped')

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -22,7 +22,8 @@ from cassandra import OperationTimedOut
 from cassandra.cluster import Cluster
 from cassandra.connection import (Connection, HEADER_DIRECTION_TO_CLIENT, ProtocolError,
                                   locally_supported_compressions, ConnectionHeartbeat, HeartbeatFuture, _Frame, Timer, TimerManager,
-                                  ConnectionException, ConnectionShutdown, DefaultEndPoint, ShardAwarePortGenerator)
+                                  ConnectionException, ConnectionShutdown, DefaultEndPoint, ShardAwarePortGenerator,
+                                  DRIVER_NAME)
 from cassandra.marshal import uint8_pack, uint32_pack, int32_pack
 from cassandra.protocol import (write_stringmultimap, write_int, write_string,
                                 SupportedMessage, ProtocolHandler, ResultMessage,
@@ -237,6 +238,30 @@ class ConnectionTest(unittest.TestCase):
         c.process_msg(message, len(message) - 8)
 
         assert c.decompressor == None
+
+    def test_startup_message_can_be_sent_without_extra_options(self):
+        """
+        _send_startup_message defaults extra_options to None but splats it, so
+        omitting it raised a TypeError that defunct_on_error turned into a silent
+        defunct: no STARTUP frame was ever sent.
+
+        The only caller inside the driver always passes a dict, so the default
+        went unexercised; the caller that does omit it is the mock the simulacron
+        heartbeat test installs over the options exchange, which has therefore
+        been defuncting every connection it touched.
+        """
+        c = self.make_connection()
+        c.send_msg = Mock()
+        c.defunct = Mock()
+        c.cql_version = '3.0.3'
+
+        c._send_startup_message(no_compact=True)
+
+        c.defunct.assert_not_called()
+        c.send_msg.assert_called_once()
+        options = c.send_msg.call_args[0][0].options
+        assert options['DRIVER_NAME'] == DRIVER_NAME
+        assert options['NO_COMPACT'] == 'true'
 
     def test_not_implemented(self):
         """

--- a/tests/unit/test_driver_config.py
+++ b/tests/unit/test_driver_config.py
@@ -1,0 +1,113 @@
+# Copyright 2026 ScyllaDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+
+from cassandra.driver_config import (DriverConfigReporter, DRIVER_CONFIG_OPTION,
+                                     DRIVER_CONFIG_SCHEMA_VERSION, MAX_DRIVER_CONFIG_LENGTH)
+from tests.unit.utils import ThrowingReporter
+
+
+class OversizedReporter(DriverConfigReporter):
+    """
+    Produces a report one byte past the limit. The schema-only report built by
+    :class:`.DriverConfigReporter` cannot reach the limit on its own, so the
+    guard is only reachable through a subclass.
+    """
+    def _build_report(self):
+        return 'a' * (MAX_DRIVER_CONFIG_LENGTH + 1)
+
+
+class MistypedReporter(DriverConfigReporter):
+    """
+    Returns something that is not a string, the mistake the ``_populate_report``
+    extension point invites once it describes more than the schema version.
+    """
+    def _build_report(self):
+        return None
+
+
+class DriverConfigReporterTest(unittest.TestCase):
+    def test_reports_the_schema_version(self):
+        options = {}
+
+        DriverConfigReporter().add_startup_options(options)
+
+        assert json.loads(options[DRIVER_CONFIG_OPTION]) == {'version': DRIVER_CONFIG_SCHEMA_VERSION}
+
+    def test_report_is_compact_json(self):
+        """
+        The report is a wire value bounded by MAX_DRIVER_CONFIG_LENGTH, not
+        something meant to be read as it is, so it carries no padding.
+        """
+        options = {}
+
+        DriverConfigReporter().add_startup_options(options)
+
+        assert options[DRIVER_CONFIG_OPTION] == '{"version":%d}' % DRIVER_CONFIG_SCHEMA_VERSION
+
+    def test_report_fits_within_the_length_limit(self):
+        """
+        Tripwire for when the actual configuration groups land: a report over the
+        limit is dropped by add_startup_options, so this would fail with a clear
+        message instead of the size assertion raising an unrelated KeyError.
+        """
+        options = {}
+
+        DriverConfigReporter().add_startup_options(options)
+
+        assert DRIVER_CONFIG_OPTION in options, \
+            "the report was dropped, it must have exceeded the length limit"
+        # The limit is enforced on the encoded length, so measure bytes as well.
+        assert len(options[DRIVER_CONFIG_OPTION].encode('utf8')) <= MAX_DRIVER_CONFIG_LENGTH
+
+    def test_oversized_report_is_not_reported(self):
+        options = {}
+
+        OversizedReporter().add_startup_options(options)
+
+        assert DRIVER_CONFIG_OPTION not in options
+
+    def test_failure_to_build_the_report_is_not_reported(self):
+        """
+        Building the report must never take a connection down with it: the
+        exception is swallowed and the option left out.
+        """
+        options = {}
+
+        ThrowingReporter().add_startup_options(options)
+
+        assert DRIVER_CONFIG_OPTION not in options
+
+    def test_a_report_that_is_not_a_string_is_not_reported(self):
+        """
+        The guard covers the whole method, not just building the report: a
+        subclass returning a non-string must be as harmless as one raising, since
+        an exception here would reach the connection and defunct it.
+        """
+        options = {}
+
+        MistypedReporter().add_startup_options(options)
+
+        assert DRIVER_CONFIG_OPTION not in options
+
+    def test_other_options_are_left_alone(self):
+        options = {'APPLICATION_NAME': 'app'}
+
+        OversizedReporter().add_startup_options(options)
+        MistypedReporter().add_startup_options(options)
+        DriverConfigReporter().add_startup_options(options)
+
+        assert options['APPLICATION_NAME'] == 'app'

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 from concurrent.futures import Future
 from cassandra.cluster import Session
+from cassandra.driver_config import DriverConfigReporter
 
 
 def mock_session_pools(f):
@@ -32,3 +33,16 @@ def mock_session_pools(f):
             mocked_add_or_renew_pool.return_value = future
             f(*args, **kwargs)
     return wrapper
+
+
+class ThrowingReporter(DriverConfigReporter):
+    """
+    A driver configuration reporter whose report cannot be built.
+
+    Shared because two suites need it: the reporter's own tests, for the guard
+    that drops a report it cannot build, and the connection tests, for the
+    guarantee that such a failure leaves the STARTUP frame otherwise intact
+    instead of failing the connection.
+    """
+    def _build_report(self):
+        raise ValueError("simulated failure while building the report")


### PR DESCRIPTION
## Motivation

An operator investigating an incident on the server side can see a client's
connections, but nothing about the client itself. Two questions come up every
time and neither can be answered today:

*Which connections belong to which client process?* Correlating by address and
port is unreliable in exactly the deployments where it matters — a shard-aware
pool opens one connection per shard, several `Cluster` objects can live in one
process, and NAT or a container network can make several hosts look alike.

*What was that client configured to do?* Answering it currently requires access
to the client host and its logs, which an operator investigating the cluster
usually does not have.

ScyllaDB already echoes the CQL `STARTUP` options into the `client_options`
column of its clients table, so both answers can travel with the connection that
raises the question. The two options added here follow the naming convention
shared with the other ScyllaDB drivers.

## Change

Five commits, one per layer:

| Commit | What |
|--------|------|
| `Add a driver configuration reporter` | New `cassandra/driver_config.py`: the `DRIVER_CONFIG`/`SESSION_ID` option names, the schema version, and `DriverConfigReporter`, which builds the JSON configuration report |
| `Report SESSION_ID and DRIVER_CONFIG in the STARTUP options` | `Connection` takes a session id and a reporter, and puts both in the `STARTUP` frame |
| `Give every Cluster a session id and a config reporter` | `Cluster` generates the id, owns the reporter, and passes both to every connection it opens; new `Cluster.session_id` and `Cluster(driver_config_reporting_enabled=...)` |
| `Add integration tests for the reported startup options` | End-to-end coverage through the clients table against a live ScyllaDB |
| `Document client identification and configuration reporting` | Scylla-specific guide section, API reference entries, CHANGELOG |

Three decisions worth calling out, all argued in the commit messages:

**The session id is scoped to the `Cluster`, not the `Session`.** The control
connection — the one that describes the configuration — belongs to the
`Cluster`, so a per-`Session` id would leave the configuration report
uncorrelated with the connections it describes. The option name follows the
convention shared with the other ScyllaDB drivers, where a "session" is what
this driver calls a `Cluster`; it is unrelated to the existing
`Session.session_id`, which identifies a `Session` to Insights and never goes on
the wire. Both docstrings now say so, because this is the easiest thing in the
change to misread.

**Every connection reports `SESSION_ID`; only the control connection reports
`DRIVER_CONFIG`.** Correlating a cluster's connections with each other is the
whole point of the id, so all of them carry it. The configuration is identical
across those connections, so reporting it once keeps the other `STARTUP` frames
small; the existing `is_control_connection` flag is what decides that.

**Both options are driver-owned.** They are cleared from the option map and then
written by the driver, so an application cannot set `SESSION_ID` and break the
correlation the option exists for, nor set `DRIVER_CONFIG` and have an operator
read its value as the driver's own description of itself. Clearing rather than
merely overwriting is what makes that hold on connections where the driver
reports nothing of its own — a pool connection sends no configuration, and
neither does a control connection whose report is turned off or was dropped.
Keys the driver does not own still come through unchanged, so the existing
`application_info` options (`APPLICATION_NAME`, `APPLICATION_VERSION`,
`CLIENT_ID`) are unaffected.

Reporting the configuration is best effort by construction: it runs while a
connection is being established, so a report that cannot be built, or that
exceeds the 32 KiB cap, is logged and left out rather than allowed to fail the
handshake. The cap matters because `STARTUP` values carry a 16-bit length prefix
and the configuration groups added later will describe user-supplied values that
can grow arbitrarily large — enforcing it here keeps "reporting never prevents a
connection from being established" a property of this module rather than of the
user's configuration.

This first stage reports only the schema version the document follows
(`{"version":1}`). The groups describing the configuration itself land on top of
it; adding keys to the report is backwards compatible and does not bump the
version.

Fixes: https://scylladb.atlassian.net/browse/DRIVER-950

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.rst for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.