### PR TITLE
Add support for Python 3.15

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [8]
-        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
         event_loop_manager: ["libev", "asyncio", "asyncore"]
         exclude:
           - python-version: "3.12"
@@ -53,6 +53,10 @@ jobs:
           - python-version: "3.14"
             event_loop_manager: "asyncore"
           - python-version: "3.14t"
+            event_loop_manager: "asyncore"
+          - python-version: "3.15"
+            event_loop_manager: "asyncore"
+          - python-version: "3.15t"
             event_loop_manager: "asyncore"
 
     steps:

--- a/.github/workflows/lib-build.yml
+++ b/.github/workflows/lib-build.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          uv tool install 'cibuildwheel==3.2.1'
+          uv tool install 'cibuildwheel==4.2.1'
 
       - name: Install Conan
         if: runner.os == 'Windows'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,6 +75,10 @@ Others
   ``protocol_features`` could silently omit fields a negotiated extension requires.
   This release emits no new bytes on the wire; the parameter is groundwork for
   upcoming protocol extensions (``SCYLLA_USE_METADATA_ID``, ``TABLETS_ROUTING_V2``).
+* Python 3.15 is now supported: wheels are published for it (cibuildwheel builds
+  ``cp315`` since 4.2.0, against a release candidate that is ABI compatible with the
+  final release) and the integration tests run on 3.15 and on free-threaded 3.15t.
+  As for 3.14, no free-threaded wheels are published; ``3.15t`` is tested only.
 
 3.29.11
 =======

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Scylla Enterprise (2018.1.x+) using exclusively Cassandra's binary protocol and 
 .. image:: https://github.com/scylladb/python-driver/actions/workflows/integration-tests.yml/badge.svg?branch=master
    :target: https://github.com/scylladb/python-driver/actions/workflows/integration-tests.yml?query=event%3Apush+branch%3Amaster
 
-The driver supports Python versions 3.10-3.14.
+The driver supports Python versions 3.10-3.15.
 
 .. **Note:** This driver does not support big-endian systems.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ A Python client driver for `Scylla <https://docs.scylladb.com>`_.
 This driver works exclusively with the Cassandra Query Language v3 (CQL3)
 and Cassandra's native protocol.
 
-The driver supports Python 3.10-3.14.
+The driver supports Python 3.10-3.15.
 
 This driver is open source under the
 `Apache v2 License <http://www.apache.org/licenses/LICENSE-2.0.html>`_.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Supported Platforms
 -------------------
-Python versions 3.10-3.14 are supported. Both CPython (the standard Python
+Python versions 3.10-3.15 are supported. Both CPython (the standard Python
 implementation) and `PyPy <http://pypy.org>`_ are supported and tested.
 
 Linux, OSX, and Windows are supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3.14',
+    'Programming Language :: Python :: 3.15',
     'Programming Language :: Python :: Free Threading :: 2 - Beta',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,12 +152,8 @@ directory = "htmlcov"
 build-frontend = "build[uv]"
 environment = { CASS_DRIVER_BUILD_CONCURRENCY = "2", CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST = "yes", CFLAGS = "-g0 -O3" }
 skip = [
-    "cp38*",
-    "pp38*",
     "cp39*",
-    "pp39*",
     "cp3*t-*",
-    "pp3*t-*",
     "*i686",
     "*win32",
     "*musllinux*",


### PR DESCRIPTION
Starts supporting Python 3.15: publish wheels for it and run the integration tests on it, following what #566 did for 3.14.

### Wheels

cibuildwheel is bumped `3.2.1` -> `4.2.1`. 4.2.0 is where `cp315` started being built by default, without the `cpython-prerelease` enable set — it pins a 3.15 release candidate, which upstream guarantees is ABI compatible with the final release. 3.2.1 knows nothing about 3.15, so no configuration alone could have produced those wheels.

The bump does need a `skip` cleanup. 4.x dropped everything below Python 3.9 and no longer builds PyPy unless `enable` asks for it, which leaves four dead entries that 4.2.1 warns about: `cp38*` and `pp38*` name versions it no longer knows, `pp39*` names a PyPy it does not enable, and `pp3*t-*` matches nothing, as there are no free-threaded PyPy builds. All four are removed. `cp39*` stays, since 3.9 is still a build target we opt out of, and so does `cp3*t-*`, which is what keeps the free-threaded CPython wheels out of the set.

Nothing else in `[tool.cibuildwheel]` changes: `build = ["cp3*"]` already selects `cp315`, PyPy is already covered by `enable = ["pypy"]`, and 32-bit Linux — which 4.0.0 stopped building by default — was never built here anyway.

### Tests

`3.15` and `3.15t` join the integration test matrix, with the same `asyncore` exclusions as the 3.14 rows (asyncore was removed from the standard library in 3.12, so only 3.11 still exercises it). The matrix goes from 11 to 15 jobs.

As for 3.14, no free-threaded wheels are published; `3.15t` is tested only.

### Verification

- Diffed `cibuildwheel --print-build-identifiers` between 3.2.1 and 4.2.1 against the real `pyproject.toml`, for linux, macos and windows. The only difference is the added `cp315-manylinux_x86_64` / `cp315-macosx_x86_64` / `cp315-win_amd64`: PyPy stays at `pp311`, and no new architecture or free-threaded identifier appears. The aarch64 invocation, which overrides `CIBW_BUILD`, was checked the same way. Neither emits warnings after the `skip` cleanup.
- Ran the unit suite on 3.15 and on 3.15t: 953 passed, 112 skipped on each. No driver code change was required.
- Checked that the Cython-generated extensions compile under 3.15.
- Confirmed `uv` resolves both `3.15` and `3.15t`, so the new matrix rows will actually provision.

`docs/pyproject.toml` is deliberately untouched — that is the docs build environment, which Renovate bumps on its own (#978).

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
